### PR TITLE
fix(ui): OBS tab + tour reflect Register-as-service path (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes will land here. Format loosely follows
 
 Nothing yet.
 
+## [0.1.1] - First-run dashboard polish
+
+Quality-of-life fixes spotted right after the v0.1.0 release went out.
+
+**Tour bubble for "Wire OBS to InstantClone" now matches the actual
+OBS tab.** The step still described the manual Custom-RTMP path
+exclusively even though the tab itself leads with the one-click
+"Register with OBS" service-injection button. Rewrote the bubble
+copy: recommended path first (click Register, restart OBS, pick
+InstantClone from the Service dropdown), Custom RTMP framed as the
+fallback for older OBS / multi-RTMP plugins / non-OBS encoders.
+
+**OBS tab no longer shows a stale registration state.** If you
+registered through the first-run wizard and *then* opened the OBS
+tab, the tab still rendered "Not registered yet" with a primary
+"Register with OBS" button - because the tab's status only refreshed
+at page init and after its own button click, never on tab activation.
+`showTab()` now re-queries `/obs/register-status` whenever the OBS
+tab becomes active, so the button correctly flips to "Unregister
+from OBS" the moment you switch to the tab.
+
 ## [0.1.0] - Enhanced Broadcasting + VOD audio mode
 
 Headline: Enhanced Broadcasting works end-to-end through the proxy.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instantclone"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # Squeeze every byte out of the release binary. opt-level = "s" trades

--- a/web/index.html
+++ b/web/index.html
@@ -2946,14 +2946,9 @@ const TOUR = [
     target: '.tab[data-tab="obs"]', side: 'bottom', tab: 'obs',
     title: 'Wire OBS to InstantClone',
     body: `
-      <p>One-time setup. In OBS:</p>
-      <ol style="margin:6px 0 8px 18px;padding:0">
-        <li>Open <b>Settings → Stream</b></li>
-        <li>Service: pick <b>Custom…</b></li>
-        <li>Server: paste the URL shown in this tab (<code>rtmp://127.0.0.1:1935/live</code>)</li>
-        <li>Stream Key: anything works - we suggest <code>main</code></li>
-        <li>Apply, then hit <b>Start Streaming</b> like normal</li>
-      </ol>
+      <p>Two ways - pick whichever fits your setup.</p>
+      <p><b>Recommended - one click:</b> hit <b>Register with OBS</b> on this tab. InstantClone shows up next to Twitch / YouTube in OBS's <b>Settings → Stream → Service</b> dropdown. Restart OBS once, pick <b>InstantClone</b>, set Stream Key to anything (we suggest <code>main</code>), and hit <b>Start Streaming</b>. Multi-track Video "Auto" works out of the box.</p>
+      <p><b>Fallback - Custom RTMP:</b> if you're on older OBS, using a multi-RTMP plugin, or a non-OBS encoder, use the Server URL + key shown below this section instead - Service: <b>Custom…</b>.</p>
       <p style="font-size:12px;color:var(--fg-3);margin-top:8px">Until you press <b>Start Streaming</b> in OBS, the dashboard stays <b>OFFLINE</b> and the OBS pill at the top reads "not connected" - that's expected, not a setup mistake.</p>
       <div class="tour-tip"><strong>Why a fake key?</strong> OBS's key is just an internal label here. Your real Twitch / YouTube / Kick keys go in the <b>Destinations</b> tab - that's what actually reaches the platforms.</div>
     `,
@@ -3134,6 +3129,7 @@ function showTab(name){
   $$('.tab').forEach(t => t.classList.toggle('on', t.dataset.tab === name));
   $$('.tab-pane').forEach(p => p.hidden = p.dataset.pane !== name);
   moveTabInd();
+  if (name === 'obs') refreshObsRegisterStatus();
 }
 function moveTabInd(){
   const cur = document.querySelector('.tab.on'); if (!cur) return;


### PR DESCRIPTION
## Summary

Two quality-of-life fixes spotted right after v0.1.0 went out, bundled as a v0.1.1 patch.

1. **Tour bubble step 7/9 (\"Wire OBS to InstantClone\") rewritten.** It still described the manual Custom-RTMP path exclusively even though the OBS tab itself leads with the one-click \"Register with OBS\" service-injection button. New copy leads with the recommended path (click Register, restart OBS, pick InstantClone from the Service dropdown) and frames Custom RTMP as the fallback for older OBS / multi-RTMP plugins / non-OBS encoders.
2. **OBS tab no longer shows stale \"Not registered\" after wizard registration.** The tab's status query only ran at page init and after its own button click - never on tab activation. \`showTab()\` now re-queries \`/obs/register-status\` whenever the OBS tab becomes active, so the button correctly reflects whatever state the wizard (or another instance) left things in.

Version bumped to 0.1.1, CHANGELOG entry added.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo build --release\` succeeds (HTML minify+gzip step picks up new index.html)
- [ ] CI: \`test + clippy\`, \`e2e\`, \`build\` all green
- [ ] Manual: register via wizard, switch to OBS tab -> button reads \"Unregister from OBS\", status reads \"✓ Registered\"
- [ ] Manual: open tour from \`?\` button, step through to \"Wire OBS\" - new copy is shown