### PR TITLE
fix(controller): clear ring on begin_publish, fixes frozen buffer_fill_ms (v0.1.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     name: test + clippy
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
 
@@ -67,7 +67,7 @@ jobs:
   e2e:
     name: e2e (ffmpeg → proxy → sink)
     needs: test
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
     # Gate: skip on private repos (where CodeQL would 403 without GHAS).
     # Becomes a no-op until the repo is made public.
     if: ${{ github.event.repository.private == false }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   # This guards against the "tag a commit that was never on main" case
   # where ci.yml never ran. Same checks ci.yml does, in the same order.
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -33,7 +33,7 @@ jobs:
   # Gate 2: only runs if `test` succeeded. Builds, stages, publishes.
   build:
     needs: test
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ All notable changes will land here. Format loosely follows
 
 Nothing yet.
 
+## [0.1.2] - Stop-start session restart fix
+
+**The delay bar would freeze at 0% after Stop Streaming + Start
+Streaming in OBS.** Reported by a streamer testing v0.1.1 against
+their Enhanced Broadcasting setup ("stream no EB, stop, turn on EB,
+try to apply delay - bar doesn't fill"). Not actually EB-specific:
+any stop-start cycle reproduces it.
+
+Root cause: OBS's RTMP wire timestamps restart from ~0 on every
+fresh stream session. `begin_publish` correctly cleared the
+per-track seq-header caches and the cached onMetaData, but left
+the ring buffer's indexed tags from the prior session in place.
+The old tags sat at the front of the index with high ts_ms values
+(e.g. 600,000 ms into a 10-minute prior stream); the new session's
+tags landed at the back with low ts_ms values (e.g. 100 ms).
+`buffer_fill_ms = latest.saturating_sub(oldest)` saturated to 0
+forever, and `trim_older_than` could not rescue it - its cutoff
+also saturated to 0 against the new session's small current_ts.
+
+Fix: `Ring::clear()` wipes the index (and the IDR-only secondary
+index) on every fresh `begin_publish`. The seq counter and disk
+write cursor are deliberately preserved so consumer seqs held by
+destinations stay valid - new tags get seqs above the old high-water
+mark and reads naturally advance onto fresh data. The on-disk bytes
+get overwritten as new tags land. A regression test in
+`buffer_fill_recovers_after_publisher_session_restart` reproduces
+the exact streamer-reported symptom and fails fast (buffer_fill_ms
+returns 0) without the fix.
+
+**CI runners pinned to `windows-2022`.** GitHub is redirecting the
+`windows-latest` alias to `windows-2025-vs2026` on June 15, 2026,
+which would change the MSVC toolchain and runtime DLL set the
+shipped binary links against - a silent upgrade that could regress
+users on older Windows builds. Five lines across `release.yml`,
+`ci.yml`, and `codeql.yml`. Bumping to a newer runner is now an
+intentional choice rather than an upstream surprise.
+
 ## [0.1.1] - First-run dashboard polish
 
 Quality-of-life fixes spotted right after the v0.1.0 release went out.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "instantclone"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instantclone"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # Squeeze every byte out of the release binary. opt-level = "s" trades

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -452,6 +452,28 @@ impl DiskRing {
             }
         }
     }
+
+    /// Drop every indexed tag. Called from `begin_publish` so a fresh
+    /// OBS session, whose RTMP wire timestamps restart from ~0, does not
+    /// get measured against the prior session's tags still sitting at
+    /// the front of the index at much higher ts_ms values. Without this,
+    /// `oldest_ts()` returns the stale session's first tag and
+    /// `latest_ts() - oldest_ts()` saturates to 0, freezing
+    /// `buffer_fill_ms` at zero for the new session even as tags pour
+    /// in. `trim_older_than` cannot rescue it either, because
+    /// `cutoff = current_ts - max_age` also saturates to 0 when
+    /// `current_ts` is small.
+    ///
+    /// The seq counter and write cursor are deliberately preserved.
+    /// Consumer seqs held by destinations stay valid (the new tags get
+    /// seqs above the old high-water mark, so reads naturally advance
+    /// onto fresh data), and the disk bytes get overwritten as new tags
+    /// land.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.index.clear();
+        inner.idr_index.clear();
+    }
 }
 
 /// Open the buffer file with read+write+create, retrying briefly on

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -763,6 +763,16 @@ impl Controller {
         if let Ok(mut meta) = self.ring.metadata.lock() {
             *meta = None;
         }
+        // The ring's indexed tags also have to go. OBS's RTMP wire
+        // timestamps restart from ~0 on every fresh stream session
+        // (Start Streaming -> Stop -> Start), but the ring still holds
+        // the prior session's tags at much higher ts_ms values. Leaving
+        // them in place makes oldest_ts() return the stale front and
+        // latest_ts() the fresh back, so buffer_fill_ms saturates to 0
+        // forever in the new session - the delay bar never fills.
+        // trim_older_than cannot recover from this either: its cutoff
+        // also saturates to 0 against the new session's low current_ts.
+        self.ring.clear();
 
         // Bump token so any prior egress reader knows it's stale.
         let token = self.publisher_token.fetch_add(1, Ordering::SeqCst) + 1;
@@ -2340,6 +2350,83 @@ mod tests {
             "leak detected: begin_publish failed to clear stale onMetaData. \
              cached data: {:?}",
             post_metadata_cache
+        );
+    }
+
+    /// User-visible regression: after a Stop Streaming / Start Streaming
+    /// cycle in OBS (the proxy stays running), the delay bar froze at 0%
+    /// and never filled even though tags were flowing. OBS's RTMP wire
+    /// timestamps restart from ~0 on every fresh session, but the ring
+    /// still held the prior session's tags at much higher ts_ms values.
+    /// `oldest_ts()` returned the stale front and `latest_ts()` returned
+    /// the fresh back, so `buffer_fill_ms = latest.saturating_sub(oldest)`
+    /// saturated to 0 forever. `trim_older_than` could not rescue it
+    /// either - its cutoff also saturated to 0 against the new session's
+    /// low current_ts.
+    ///
+    /// Reported by the streamer on the v0.1.1 build: "stream no EB, stop,
+    /// turn on EB, try to apply delay - bar doesn't fill". Not actually
+    /// EB-specific: any stop-start cycle reproduces it.
+    #[tokio::test]
+    async fn buffer_fill_recovers_after_publisher_session_restart() {
+        let h = harness(0);
+
+        // Session 1: a few tags at "10 minutes into the stream" ts_ms,
+        // standing in for a real prior stream. Three tags is enough to
+        // populate the index front - the bug is purely about the ts
+        // values at the front vs back, not tag count.
+        h.ctrl.ingest_alive.store(true, Ordering::Relaxed);
+        for offset in 0u64..3 {
+            h.ctrl
+                .ring
+                .append(9, 600_000 + offset * 33, &[0xaa; 64], false, false)
+                .expect("session 1 append");
+        }
+        assert!(
+            h.ctrl.buffer_fill_ms() <= 100,
+            "session 1 sanity: three same-timestamp-region tags = tiny span"
+        );
+
+        // OBS stops streaming. Publisher disconnects. The ring is
+        // deliberately NOT cleared here so that a same-session blip
+        // (network flap, brief reconnect) keeps its buffered tags -
+        // only `begin_publish` of a fresh session wipes it.
+        h.ctrl.mark_ingest_dead();
+
+        // Fresh OBS Start Streaming. begin_publish must clear the
+        // ring so the new session's ts_ms (starting near 0) is
+        // measured against an empty index.
+        h.ctrl
+            .begin_publish("fresh-session-after-stop-start")
+            .await
+            .expect("begin_publish must succeed on fresh session");
+
+        // Session 2: simulate OBS sending tags with wire_ts starting
+        // from 0, the standard RTMP behaviour on a new stream session.
+        // After the fix, these tags populate an empty index and
+        // buffer_fill_ms reflects their span. Before the fix, the
+        // session 1 front sits at ts_ms=600_000 and latest_ts=66 makes
+        // buffer_fill_ms saturate to 0.
+        for offset in 0u64..3 {
+            h.ctrl
+                .ring
+                .append(9, offset * 33, &[0xbb; 64], false, false)
+                .expect("session 2 append");
+        }
+
+        let fill = h.ctrl.buffer_fill_ms();
+        assert!(
+            fill > 0,
+            "buffer_fill_ms must reflect new session tags after \
+             begin_publish, got {} (before the fix, the prior session's \
+             high-ts front made latest - oldest saturate to 0)",
+            fill,
+        );
+        assert!(
+            fill <= 200,
+            "session 2 fill must be the span of session 2 tags only \
+             (~66 ms), not a phantom span that includes session 1; got {}",
+            fill,
         );
     }
 }


### PR DESCRIPTION
## Summary

User-reported bug from a v0.1.1 streamer test:

> stream no EB. stop streaming (keep app on) and turn on EB and try to apply delay, delay bar doesn't fill.

Not EB-specific - any Stop Streaming -> Start Streaming cycle in OBS reproduces it. After the cycle, the delay bar freezes at 0% no matter how many tags flow in.

## Root cause

OBS's RTMP wire timestamps restart from ~0 on every fresh stream session. \`begin_publish\` correctly cleared the per-track seq-header caches and the cached onMetaData, but left the ring buffer's indexed tags from the prior session in place. The old tags sat at the front of the index with high \`ts_ms\` values (eg 600,000 ms after a 10-minute stream); the new session's tags landed at the back with low \`ts_ms\` values.

- \`oldest_ts()\` returns front of index = stale high ts
- \`latest_ts()\` returns back of index = fresh low ts
- \`buffer_fill_ms = latest.saturating_sub(oldest)\` saturates to **0 forever**
- \`trim_older_than\` cannot rescue it - its \`cutoff = current_ts.saturating_sub(target)\` also saturates to 0 against the new session's small \`current_ts\`, so stale tags stay locked at the front

## Fix

\`Ring::clear()\` wipes the index and the IDR-only secondary index on every fresh \`begin_publish\`. Seq counter and disk write cursor are deliberately preserved so consumer seqs held by destinations stay valid - new tags get seqs above the old high-water mark and reads naturally advance onto fresh data.

## Test

New regression test [\`buffer_fill_recovers_after_publisher_session_restart\`](https://github.com/Soulhackzlol/InstantClone/blob/fix/buffer-fill-publisher-restart/src/controller.rs) reproduces the exact streamer-reported symptom and **fails fast** (buffer_fill_ms = 0) without the fix - verified by toggling \`self.ring.clear()\` in and out during development.

133/133 unit tests pass. fmt + clippy clean.

## Bundled

- Pins CI runners from \`windows-latest\` -> \`windows-2022\` across \`release.yml\`, \`ci.yml\`, \`codeql.yml\` (the parked Jun 15, 2026 deprecation). Bumping is now an intentional choice rather than an upstream surprise.

Version 0.1.1 -> 0.1.2.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [x] \`cargo test --release\` 133/133 pass
- [x] New regression test fails without the fix (verified locally)
- [ ] CI: \`test + clippy\`, \`e2e\`, \`build\` green on \`windows-2022\` runner
- [ ] Manual: stream non-EB, stop, restart -> bar fills past 0%