### PR TITLE
fix: VOD audio works on OBS 32 + EB Launch button + audio wire format (v0.1.3, closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,193 @@ All notable changes will land here. Format loosely follows
 
 Nothing yet.
 
+## [0.1.3] - VOD audio flag actually works (issue #9)
+
+**VOD audio toggle did nothing on OBS 32.** Reported as issue #9
+on v0.1.2: the streamer toggled VOD audio in InstantClone, restarted
+OBS, and the "Twitch VOD audio track" option stayed locked - both
+with the InstantClone-registered service AND with Custom RTMP.
+
+Root cause: OBS 32 split the legacy `global.ini` into two files -
+`global.ini` (app-level) and `user.ini` (user-level) - and the
+VOD-track frontend gate reads `App()->GetUserConfig()` which now
+maps to `user.ini`:
+
+    bool enableForCustomServer = config_get_bool(
+        App()->GetUserConfig(), "General", "EnableCustomServerVodTrack");
+    bool enableVodTrack = ui->service->currentText() == "Twitch";
+    if (enableForCustomServer && IsCustomService())
+        enableVodTrack = true;
+
+We were writing the flag to `global.ini`, which OBS 32 simply
+ignored. v0.1.0..0.1.2 shipped the toggle as a no-op without anyone
+catching it because we never tested against a fresh OBS 32 install
+with a real Custom RTMP service.
+
+Fix: a new `obs_user_config_path()` prefers `user.ini` when present
+(OBS 32+) and falls back to `global.ini` for older installs that
+haven't been split yet. The active-profile detection now resolves
+through the same helper, so both the VOD flag and the `[Basic]
+Profile=` lookup follow the same source of truth. Every write to
+`set_vod_audio_flag` also flips the same key to `false` in the
+now-orphan `global.ini`, so users upgrading from v0.1.0..0.1.2 end
+up with no live flag anywhere. Pure path-resolution helpers
+`resolve_user_config_in` and `legacy_global_ini_in` are unit-tested
+against a temp directory so the prefer-user.ini behaviour can't
+silently regress.
+
+**Toggle-OFF now flips the value in place instead of deleting the
+line.** On the v0.1.3 test build, OBS 32 was observed rewriting
+`user.ini` on shutdown and consolidating its own duplicate
+`[General]` sections - which would have left a "deleted by us" path
+fragile against where exactly OBS chose to keep the key after the
+rewrite. New semantics: `set_vod_audio_flag(true)` writes
+`EnableCustomServerVodTrack=true`, `set_vod_audio_flag(false)` writes
+`EnableCustomServerVodTrack=false`, and we never try to find-and-
+delete. OBS's `config_get_bool` reads `=false` and "key absent"
+identically, so the runtime behaviour is the same; the robustness
+gain is that wherever OBS shuffles the key to between sessions, the
+next toggle just flips the value in place. Insertion is still gated
+to the enable path, so a never-toggled `user.ini` stays clean.
+Tests `ini_set_writes_false_in_place_when_disabling`,
+`ini_set_does_not_create_false_line_when_disabling_a_virgin_file`,
+and `ini_set_flips_value_to_false_in_trailing_duplicate_general_section`
+lock in this behaviour against the exact file shape OBS 32 produces.
+
+**Stopped swallowing reconcile errors.** `reconcile_obs_vod_files`
+previously used `let _ = ...` on every write call. When OBS was open
+and held its files locked, `write_or_friendly` returned
+`PermissionDenied`, the toggle silently failed, and the user got no
+feedback. The function now takes the controller and logs failures
+to the dashboard event log with the message
+`vod-audio: couldn't write OBS user config (...). Close OBS, then
+toggle the destination off and back on to retry.` so the path
+forward is obvious from the Logs tab.
+
+**Enhanced-RTMP audio wire format read correctly for the first time.**
+The fundamental bug behind issue #9's "both tracks silent" symptom
+on manual test: v0.1.0..0.1.3 mis-located the `AudioPacketType` and
+`TrackId` fields in Enhanced-RTMP audio tags. The classifier read
+`PacketType` from `payload[1] & 0x0F` and `TrackId` from `payload[7]`;
+the correct positions per OBS's
+`plugins/obs-outputs/flv-mux.c::flv_packet_audio_ex` are
+`payload[0] & 0x0F` (high nibble of byte 0 is `SoundFormat=9`, low
+nibble is the packet type) and `payload[6]` (after the multitrack
+header byte and the 4-byte FourCC).
+
+The user-visible failure: when OBS sends the Live track as
+Enhanced-RTMP single-track (which it does whenever VOD audio is
+enabled, since the encoder switches to the EX header path for
+idx=0 even without multitrack wrapping), our classifier saw
+`PacketType = 'm' & 0x0F = 0x0D` and never matched
+`SequenceStart=0`. The `AudioSpecificConfig` tag flowed into the
+ring buffer like a regular audio frame, got evicted by `trim_older_than`
+once newer tags accumulated past the delay window, and the
+destination consumer connected to Twitch with no decoder config
+ever sent. Twitch's `Inspector` still listed both tracks because
+OBS's `onMetaData` declared them, but the actual frames were
+undecodable - both tracks silent.
+
+Fix: corrected `classify_audio_tag`, `select_audio_bytes`, and
+`audio_seq_header_track_id` to read the real byte positions. Test
+data builders (`enhanced_audio_onetrack`, new
+`enhanced_audio_single_track`) now emit byte sequences identical
+to what OBS actually puts on the wire, verified against
+`flv_packet_audio_ex`. Two existing tests that asserted the broken
+interpretation (`enhanced_rtmp_opus_audio_recognised`,
+`enhanced_aac_seq_header_via_packet_type_0`) were rewritten to
+match the spec layout. New test
+`enhanced_single_track_seq_header_is_detected` locks in the exact
+bytes that triggered the regression so a future refactor can't
+silently re-introduce the off-by-one.
+
+**Audio multi-track passthrough decoupled from Enhanced Broadcasting.**
+Reported during manual test of the v0.1.3 build: OBS was sending
+VOD audio (mixer track 2, wire TrackId 1) but Twitch was receiving
+both Live and VOD tracks silent. Root cause was a flag-scope bug
+in v0.1.0..0.1.2: `pass_through_multitrack_video` gated both audio
+AND video selection, and was only set true when an EB session was
+allocated. For a Twitch destination without EB but with VOD audio:
+TrackId 0 (live) was forwarded wrapped in Enhanced-RTMP multi-track
+framing that Twitch's regular ingest can't decode, and TrackId 1
+(VOD) was dropped entirely. New `pass_through_multitrack_audio`
+flag is decoupled and set to true for every enabled Twitch
+destination - VOD audio has worked on Twitch's regular ingest for
+years, predating EB. Non-Twitch destinations still drop TrackId
+!= 0 so a simulcast YouTube / Kick doesn't choke on a track its
+decoder can't map. `send_sequence_headers` also gates the audio
+seq-header replay on the same audio flag now, so a VOD track's
+AudioSpecificConfig gets re-emitted on egress restart for any
+Twitch destination, not only EB ones.
+
+**Phase C (experimental "EB on Custom RTMP") replaced with a "Launch
+OBS for EB + VOD" button.** After confirming the file-injection path
+was architecturally dead (OBS's `rtmp_custom` plugin only declares
+five known settings keys in `rtmp_custom_update` and discards every
+other field at LOAD time, never at SAVE - so our injected
+`multitrack_video_configuration_url` was never read at all),
+re-implemented Phase C using the only path OBS's frontend actually
+honours for Custom RTMP: the `--config-url` command-line argument
+(`frontend/utility/GoLiveAPI_Network.cpp::MultitrackVideoAutoConfigURL`
+checks the CLI flag before consulting the service settings object).
+The dashboard's destination editor now shows a "Launch OBS for EB +
+VOD" button under the VOD audio toggle when the user enables VOD
+audio on a Twitch destination. The button hits a new
+`POST /obs/launch-with-eb` endpoint that spawns
+`C:\Program Files\obs-studio\bin\64bit\obs64.exe --config-url <our
+endpoint>` (detached process group so closing InstantClone afterwards
+doesn't take OBS down). The flag is per-launch, so the UI copy makes
+it clear the user has to use this button every time they want EB on
+top of VOD audio. The old `inject_vod_eb` file-edit path and its UI
+sub-toggle are gone; the legacy strip is preserved and runs on every
+reconcile so users upgrading from v0.1.0..0.1.2 end up with a clean
+service.json. Recommended paths for the simpler cases stay the same:
+- EB alone -> register InstantClone as an OBS service
+- VOD audio alone -> Custom RTMP + the per-destination VOD toggle
+- Both together -> the new Launch button (experimental)
+
+**EB cuts no longer pixel-glitch on the legacy primary track.**
+Confirmed via trace log inspection during the v0.1.3 EB+VOD manual
+test: `compute_delay_cut` was landing on whichever ladder rung's IDR
+happened to win the partition_point in the IDR-only secondary index,
+including TrackId-1..4. The destination's decoder for the LEGACY
+primary track (the one Twitch's transcoder anchors on) then received
+a P-frame with no reference, producing visible pixel artefacts until
+the next track-0 IDR ~2 s later. Fix: new `is_primary_video_idr`
+classifier in `h264.rs` and a gate in `Ring::append` that only adds
+the PRIMARY track's keyframes to `idr_index`. Multi-track ladder
+IDRs still live in the main `index` (forwarded bit-faithfully to
+Twitch IVS) - they just stop being cut candidates. Since OBS aligns
+every ladder rung's IDR to the same encoder PTS, no cut points are
+lost; we just stop landing on a rung where the legacy decoder has
+no anchor. Six unit tests in `h264::tests` lock in the classifier
+(legacy AVC keyframe accepted, legacy inter rejected, OneTrack
+TrackId=0 accepted, OneTrack TrackId 1..4 rejected, Enhanced-RTMP
+single-track P-frame rejected, truncated multi-track handled
+gracefully). Three pre-existing buffer/controller tests were updated
+to seed proper primary-IDR payloads via a new `primary_idr_payload`
+helper - they previously used `[0u8; N]` which incidentally passed
+through the old "any-track" index but is correctly rejected now.
+
+**Dashboard title contrast.** `.ic-brand-mark` is now a solid warm
+cream (`#f5efe1`) instead of the previous white -> 30%-accent
+gradient. The bottom half of the letters was muddied to ~30%
+lightness on most themes, which read as low-contrast against the
+dark header.
+
+**Passive update check.** New `src/update_check.rs` calls GitHub's
+Releases API once per process lifetime (with a 10-minute cache to
+avoid hammering on dashboard refreshes), parses `tag_name`, and
+compares against the compiled-in `CARGO_PKG_VERSION`. A small "v0.1.4
+available" pill appears in the dashboard header on load when a newer
+release is published. Failures are silent - offline users and
+GitHub rate-limit hits don't get an error toast, just no pill. The
+SemVer-ish comparison correctly handles prerelease suffixes
+(`0.1.3` beats `0.1.3-beta.7`) so users on a beta tag don't get an
+"update available" prompt that points back at their current build.
+Six unit tests in `update_check::tests` lock in the tag-name parser
+and the version comparator.
+
 ## [0.1.2] - Stop-start session restart fix
 
 **The delay bar would freeze at 0% after Stop Streaming + Start

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "instantclone"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instantclone"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # Squeeze every byte out of the release binary. opt-level = "s" trades

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -239,7 +239,13 @@ impl DiskRing {
             is_idr,
         };
         inner.index.push_back(meta);
-        if is_idr {
+        if is_idr && crate::h264::is_primary_video_idr(payload) {
+            // Only the PRIMARY track's IDRs become cut candidates. Each
+            // EB ladder rung has its own IDR cadence; OBS aligns them
+            // all to the same encoder PTS, so we don't lose cut points,
+            // we just stop landing on a non-primary rung's IDR where
+            // the legacy decoder has no reference. See
+            // `h264::is_primary_video_idr` for the full classification.
             inner.idr_index.push_back(meta);
         }
         drop(inner);
@@ -557,6 +563,18 @@ mod tests {
 
     static UNIQ: AtomicU32 = AtomicU32::new(0);
 
+    /// Build a video payload whose leading byte (`0x17`) matches the
+    /// legacy-AVC keyframe shape that the v0.1.3 primary-IDR gate
+    /// expects. Used everywhere a test wants to seed the IDR-only
+    /// index - before v0.1.3 a generic `[0u8; N]` slice also landed
+    /// in idr_index because the gate didn't exist.
+    fn primary_idr_payload(len: usize) -> Vec<u8> {
+        let mut v = Vec::with_capacity(len);
+        v.push(0x17);
+        v.resize(len, 0);
+        v
+    }
+
     /// Test-scoped DiskRing in a fresh temp file. Deletes the file on drop
     /// so a run can re-create cleanly. Capacity must be > 2× any test tag.
     struct Tmp(DiskRing, std::path::PathBuf);
@@ -626,17 +644,18 @@ mod tests {
 
     #[test]
     fn multitrack_audio_seq_headers_cache_per_track_id() {
-        // Same shape as the video test: the VOD-audio session sends
-        // one OneTrack seq-header per audio track. Without per-track
-        // keying the second arrival would stomp the first, and the
-        // destination's decoder for the missing track would lose its
-        // AudioSpecificConfig after the next pump restart.
+        // OneTrack Enhanced-RTMP audio per OBS's flv_packet_audio_ex:
+        //   byte 0: 0x95 (SoundFormat=9 | PacketType=Multitrack)
+        //   byte 1: MultiTrackType=0 | NestedPacketType=0 (Seq)
+        //   bytes 2..6: FourCC = "mp4a"
+        //   byte 6:    TrackId
+        //   bytes 7..: AudioSpecificConfig
         let t = tmp(4096);
         let live = vec![
-            0x90, 0x05, 0x00, b'm', b'p', b'4', b'a', 0x00, 0x12, 0x10, 0x56, 0xe5,
+            0x95, 0x00, b'm', b'p', b'4', b'a', 0x00, 0x12, 0x10, 0x56, 0xe5,
         ];
         let vod = vec![
-            0x90, 0x05, 0x00, b'm', b'p', b'4', b'a', 0x01, 0x12, 0x08, 0x44, 0x00,
+            0x95, 0x00, b'm', b'p', b'4', b'a', 0x01, 0x12, 0x08, 0x44, 0x00,
         ];
         t.0.append(8, 0, &live, false, true).unwrap();
         t.0.append(8, 0, &vod, false, true).unwrap();
@@ -704,9 +723,13 @@ mod tests {
     #[test]
     fn find_idr_near_picks_closest() {
         let t = tmp(8192);
-        // Three IDRs at ts 1000, 2000, 3000
+        // Three IDRs at ts 1000, 2000, 3000. v0.1.3 added a primary-
+        // track gate on idr_index pushes - use the helper that emits
+        // a payload classifying as primary so the cut-candidate index
+        // actually fills up.
+        let payload = primary_idr_payload(50);
         for ts in [1000u64, 2000, 3000] {
-            t.0.append(9, ts, &[0u8; 50], true, false).unwrap();
+            t.0.append(9, ts, &payload, true, false).unwrap();
         }
         // Target 1900 with tolerance 500 → closest is 2000
         let m = t.0.find_idr_near(1900, 500).expect("found IDR");
@@ -773,9 +796,10 @@ mod tests {
     #[test]
     fn newest_idr_returns_the_last_one() {
         let t = tmp(4096);
-        t.0.append(9, 100, &[0u8; 30], true, false).unwrap();
+        let idr = primary_idr_payload(30);
+        t.0.append(9, 100, &idr, true, false).unwrap();
         t.0.append(9, 200, &[0u8; 30], false, false).unwrap();
-        t.0.append(9, 300, &[0u8; 30], true, false).unwrap();
+        t.0.append(9, 300, &idr, true, false).unwrap();
         t.0.append(9, 400, &[0u8; 30], false, false).unwrap();
         let m = t.0.newest_idr().expect("has IDR");
         assert_eq!(m.ts_ms, 300);
@@ -850,7 +874,8 @@ mod tests {
     #[test]
     fn find_idr_near_with_zero_tolerance_demands_exact_match() {
         let t = tmp(4096);
-        t.0.append(9, 1000, &[0u8; 40], true, false).unwrap();
+        t.0.append(9, 1000, &primary_idr_payload(40), true, false)
+            .unwrap();
         // ts 999 with tolerance 0 → no match
         assert!(t.0.find_idr_near(999, 0).is_none());
         // ts 1000 with tolerance 0 → exact hit
@@ -862,14 +887,9 @@ mod tests {
         // Models the publisher-reconnect case: there are old IDRs in the
         // ring from before the reconnect; we want only the new session's.
         let t = tmp(4096);
-        let old_seq =
-            t.0.append(9, 100, &[0u8; 30], true, false)
-                .unwrap()
-                .unwrap();
-        let new_seq =
-            t.0.append(9, 200, &[0u8; 30], true, false)
-                .unwrap()
-                .unwrap();
+        let idr = primary_idr_payload(30);
+        let old_seq = t.0.append(9, 100, &idr, true, false).unwrap().unwrap();
+        let new_seq = t.0.append(9, 200, &idr, true, false).unwrap().unwrap();
         let m = t.0.newest_idr_after(old_seq).expect("found");
         assert_eq!(m.seq, new_seq);
         assert!(t.0.newest_idr_after(new_seq + 100).is_none());

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -142,6 +142,20 @@ pub struct DestinationState {
     /// byte-identical to what beta.6 emitted from the ingest-side
     /// flatten - so existing destinations see no behaviour change.
     pub pass_through_multitrack_video: AtomicBool,
+    /// Twitch only: when true, multi-track AUDIO tags (live track 0 +
+    /// VOD audio track 1, OBS's "Pista VOD de Twitch") pass through to
+    /// the destination bit-faithfully. Twitch's regular ingest has
+    /// supported the VOD audio track for years, predating Enhanced
+    /// Broadcasting - so this is `true` for any enabled Twitch
+    /// destination, not gated on an EB session like the video flag
+    /// above. Non-Twitch destinations still drop TrackId != 0 audio so
+    /// a simulcast YouTube / Kick doesn't get a second track it can't
+    /// decode. Before v0.1.3 we reused `pass_through_multitrack_video`
+    /// for both, which meant a Twitch destination without EB silently
+    /// dropped the VOD audio track and left the live track wrapped in
+    /// Enhanced-RTMP multi-track framing - Twitch's regular ingest
+    /// reads the metadata but the audio renders silent.
+    pub pass_through_multitrack_audio: AtomicBool,
     /// Twitch only: when our /obs/multitrack-config proxy successfully
     /// allocates an Enhanced Broadcasting session, Twitch's API returns
     /// a specific IVS ingest URL like
@@ -188,6 +202,7 @@ impl DestinationState {
             // a DestinationState without going through the supervisor
             // (the destination_state lazy-init in particular).
             pass_through_multitrack_video: AtomicBool::new(false),
+            pass_through_multitrack_audio: AtomicBool::new(false),
         }
     }
 
@@ -1441,7 +1456,7 @@ async fn pace_and_send(
             // borrows through unchanged in both modes.
             let Some(selected) = crate::h264::select_audio_bytes(
                 io_buf,
-                dest.pass_through_multitrack_video.load(Ordering::Relaxed),
+                dest.pass_through_multitrack_audio.load(Ordering::Relaxed),
             ) else {
                 state.consumer_seq = meta.seq + 1;
                 dest.consumer_seq
@@ -1774,12 +1789,18 @@ async fn send_sequence_headers(
             sink.send_video(ts, bytes_out).await?;
         }
     }
-    // Audio seq-headers, same per-track shape as video. Twitch
-    // destinations (passthrough) receive every cached track's
-    // AudioSpecificConfig bit-faithfully so a VOD audio track's
-    // decoder stays configured across egress restarts. Non-Twitch
-    // destinations only get the primary track's config - the
-    // simulcast-second-audio-track simply doesn't exist for them.
+    // Audio seq-headers, same per-track shape as video, but gated on
+    // the AUDIO passthrough flag - which is true for every Twitch
+    // destination regardless of EB session, because Twitch's regular
+    // ingest accepts multi-track audio (VOD audio track 1) without an
+    // EB allocation. v0.1.0..0.1.2 reused the video flag here, which
+    // meant a non-EB Twitch destination only got TrackId 0's
+    // AudioSpecificConfig replayed on egress restart - leaving the
+    // VOD track's decoder unconfigured and the live track wrapped in
+    // multi-track framing the regular ingest didn't decode. Non-Twitch
+    // destinations still only get the primary track's config (the
+    // simulcast-second-audio-track simply doesn't exist for them).
+    let a_passthrough = dest.pass_through_multitrack_audio.load(Ordering::Relaxed);
     let a_headers: Vec<(u8, Vec<u8>)> = ctrl
         .ring
         .audio_seq_headers
@@ -1788,7 +1809,7 @@ async fn send_sequence_headers(
         .iter()
         .map(|(k, v)| (*k, v.clone()))
         .collect();
-    if passthrough {
+    if a_passthrough {
         for (track_id, h) in &a_headers {
             crate::trace::log(
                 "AUDIO_SEQ_HDR_SENT",
@@ -1955,12 +1976,26 @@ mod tests {
     /// the armed threshold so we can exercise phase transitions.
     fn feed_seconds(ctrl: &Controller, start_ms: u32, secs: u32, fps: u32) {
         let frame_ms = 1000 / fps;
+        // Leading byte 0x17 (legacy AVC keyframe) lets the IDR survive
+        // v0.1.3's primary-track gate in `Ring::append`; 0x27 marks the
+        // inter-frames so they get classified the same way the real
+        // wire pattern does. Bytes after the header are filler.
+        let idr_payload: [u8; 50] = {
+            let mut b = [0u8; 50];
+            b[0] = 0x17;
+            b
+        };
+        let p_payload: [u8; 50] = {
+            let mut b = [0u8; 50];
+            b[0] = 0x27;
+            b
+        };
         for s in 0..secs {
             for f in 0..fps {
                 let ts = start_ms + s * 1000 + f * frame_ms;
                 let is_idr = f == 0;
-                // kind 9 = video, ~50 B payload (size doesn't matter for state machine)
-                ctrl.on_tag(9, ts, &[0u8; 50], is_idr, false);
+                let payload = if is_idr { &idr_payload } else { &p_payload };
+                ctrl.on_tag(9, ts, payload, is_idr, false);
             }
         }
     }
@@ -2273,10 +2308,14 @@ mod tests {
         // 2. Populate the audio sequence header cache simulating an active
         //    Twitch VOD-audio session (Tracks 0 and 1).
         for track_id in 0u8..=1 {
-            // OneTrack multi-track audio seq-header: SoundFormat=9,
-            // PacketType=Multitrack(5), MultiTrackType=0, NestedPT=0,
-            // FourCC=mp4a, TrackId at byte 7.
-            let mut tag = vec![0x90, 0x05, 0x00, 0x6d, 0x70, 0x34, 0x61, track_id];
+            // OneTrack multi-track audio seq-header per OBS's
+            // flv_packet_audio_ex wire format:
+            //   byte 0: 0x95 (SoundFormat=9 | PacketType=Multitrack)
+            //   byte 1: MultiTrackType=0 | NestedPacketType=0 (Seq)
+            //   bytes 2..6: FourCC = "mp4a"
+            //   byte 6:    TrackId
+            //   bytes 7..: AudioSpecificConfig
+            let mut tag = vec![0x95, 0x00, 0x6d, 0x70, 0x34, 0x61, track_id];
             tag.extend_from_slice(&[0x12, 0x10, track_id, 0x00]);
             h.ctrl
                 .ring

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -327,6 +327,66 @@ pub fn seq_header_track_id(payload: &[u8]) -> u8 {
     payload[6]
 }
 
+/// True iff this video tag is a keyframe carrying the PRIMARY track's
+/// IDR. Used to gate which tags enter the buffer's IDR-only secondary
+/// index (the cut-point selector). For multi-track Enhanced Broadcasting
+/// streams every ladder rung has its own IDR cadence; if we index all
+/// of them as cut candidates, `compute_delay_cut` lands on whichever
+/// rung's IDR happens to be at the closest seq, and the destination
+/// decoder for the OTHER rungs receives a P-frame with no reference -
+/// the pixel-glitch artefact users see on EB cuts. Restricting the
+/// IDR index to primary-track keyframes only guarantees the cut lands
+/// at a temporal moment where the legacy decoder has its anchor, and
+/// since OBS aligns every ladder track's IDR to the same encoder PTS
+/// the other rungs naturally have IDRs at the same input ts too.
+///
+/// Returns true for:
+///   * legacy AVC keyframes (byte 0 == 0x17) - single-track, IS primary
+///   * Enhanced-RTMP single-track keyframes (Ex bit + FrameType=1 +
+///     PacketType != Multitrack)
+///   * Enhanced-RTMP OneTrack multi-track keyframes with TrackId == 0
+///
+/// Returns false for non-key frames, non-primary multi-track tags, and
+/// payloads too short to classify.
+pub fn is_primary_video_idr(payload: &[u8]) -> bool {
+    if payload.is_empty() {
+        return false;
+    }
+    let b0 = payload[0];
+    if (b0 & 0x80) == 0 {
+        // Legacy: FrameType=1 (key, high nibble) + CodecID=7 (AVC, low
+        // nibble) packs into 0x17. AVC has only one track per stream,
+        // so any AVC keyframe IS the primary IDR.
+        return b0 == 0x17;
+    }
+    // Enhanced-RTMP. bits6:4 = FrameType, bits3:0 = PacketType.
+    let frame_type = (b0 >> 4) & 0x07;
+    if frame_type != 1 {
+        return false;
+    }
+    let packet_type = b0 & 0x0F;
+    if packet_type != 6 {
+        // Single-track Enhanced-RTMP keyframe - one track per stream,
+        // so the keyframe IS the primary.
+        return true;
+    }
+    // Multitrack tag. mt_type in byte 1 high nibble; only OneTrack (=0)
+    // has a per-tag TrackId at byte 6. ManyTracks layouts pack every
+    // track into one tag and we treat them as primary too (the cut is
+    // semantically aligned for the whole bundle).
+    if payload.len() < 2 {
+        return false;
+    }
+    let mt_type = (payload[1] >> 4) & 0x0F;
+    if mt_type != 0 {
+        return true;
+    }
+    if payload.len() < 7 {
+        return false;
+    }
+    payload[6] == 0
+}
+
 pub fn select_video_bytes<'a>(
     payload: &'a [u8],
     pass_through_multitrack: bool,
@@ -385,25 +445,32 @@ pub fn select_audio_bytes<'a>(
     if pass_through_multitrack {
         return Some(Cow::Borrowed(payload));
     }
-    // Pre-checks that mirror audio_seq_header_track_id. Anything that
-    // isn't an Enhanced-RTMP OneTrack multi-track audio tag passes
-    // through unchanged - single-track audio, legacy AAC / MP3,
+    // Pre-checks mirror audio_seq_header_track_id. Anything that isn't
+    // an Enhanced-RTMP OneTrack multi-track audio tag passes through
+    // unchanged - single-track audio (Enhanced or legacy), MP3, or
     // ManyTracks / ManyTracksManyCodecs layouts.
-    if payload.len() < 8 {
+    if payload.is_empty() {
         return Some(Cow::Borrowed(payload));
     }
     if (payload[0] >> 4) & 0x0F != 9 {
         return Some(Cow::Borrowed(payload));
     }
-    if payload[1] & 0x0F != 5 {
+    // PacketType in byte 0's low nibble; 5 = Multitrack.
+    if payload[0] & 0x0F != 5 {
         return Some(Cow::Borrowed(payload));
     }
-    // OneTrack only - the layouts that pack every track into one tag
-    // have nothing to drop.
-    if (payload[2] >> 4) & 0x0F != 0 {
+    if payload.len() < 2 {
         return Some(Cow::Borrowed(payload));
     }
-    let track_id = payload[7];
+    // OneTrack only (mt_type=0). ManyTracks layouts pack every track
+    // into one tag so there is nothing to drop.
+    if (payload[1] >> 4) & 0x0F != 0 {
+        return Some(Cow::Borrowed(payload));
+    }
+    if payload.len() < 7 {
+        return Some(Cow::Borrowed(payload));
+    }
+    let track_id = payload[6];
     if track_id != 0 {
         return None;
     }
@@ -474,44 +541,52 @@ pub fn classify_audio_tag(payload: &[u8]) -> AudioTagInfo {
             ..unknown
         };
     }
-    // Enhanced RTMP audio uses sound_format=9 as the sentinel for
-    // ExAudioTagHeader. We pass these tags through bit-faithfully so
-    // Twitch's VOD audio track (OBS "Audio Track 2") keeps working.
+    // Enhanced RTMP audio (ExAudioTagHeader) uses sound_format=9 as the
+    // sentinel. The PacketType lives in the SAME byte's low nibble -
+    // NOT byte 1 as our v0.1.0..0.1.3 wrote it. See OBS's
+    // flv_packet_audio_ex in plugins/obs-outputs/flv-mux.c:
+    //
+    //   s_w8(&s, AUDIO_HEADER_EX | (is_multitrack
+    //              ? AUDIO_PACKETTYPE_MULTITRACK
+    //              : type));
+    //   if (is_multitrack) {
+    //       s_w8(&s, MULTITRACKTYPE_ONE_TRACK | type);
+    //       s_wa4cc(&s, codec_id);
+    //       s_w8(&s, (uint8_t)idx);
+    //   } else {
+    //       s_wa4cc(&s, codec_id);
+    //   }
+    //
+    // Single-track layout: byte0 = 0x9X (X = packet type),
+    //                      bytes 1..5 = FourCC, payload from byte 5.
+    // Multi-track  layout: byte0 = 0x95 (Multitrack packet type),
+    //                      byte1 = MultiTrackType | nested packet type,
+    //                      bytes 2..6 = FourCC,
+    //                      byte 6 = TrackId, payload from byte 7.
     if sound_format == 9 {
-        if payload.len() < 2 {
-            return unknown;
-        }
-        // byte 1: AudioPacketModEx(4) | AudioPacketType(4)
-        //   PacketType 0=SequenceStart, 1=CodedFrames, 5=Multitrack.
-        let packet_type = payload[1] & 0x0F;
+        let packet_type = payload[0] & 0x0F;
         let is_multitrack = packet_type == 5;
-        // For multi-track audio the SeqStart marker isn't on byte 1 -
-        // it's nested in the multitrack header at byte 2's low nibble
-        // (mirror of how Enhanced-RTMP video multi-track tags nest the
-        // real PacketType behind the multitrack envelope). Without this
-        // detection the per-track AudioSpecificConfig that OBS sends at
-        // session start would flow into the ring like a normal tag and
-        // get evicted by the trim, leaving the destination's decoder
-        // permanently unconfigured for that track after a buffer cut.
+        // For multi-track the SeqStart marker is the *nested* packet
+        // type in byte 1's low nibble - the outer packet type is 5
+        // (Multitrack) regardless of whether this is a config or a
+        // coded frame.
         let is_seq_header = if is_multitrack {
-            payload.len() >= 3 && (payload[2] & 0x0F) == 0
+            payload.len() >= 2 && (payload[1] & 0x0F) == 0
         } else {
             packet_type == 0
         };
-        // Codec FourCC sits at bytes 2..6 for single-track Enhanced-RTMP
-        // audio, and at bytes 3..7 for multi-track OneTrack / ManyTracks
+        // FourCC sits at bytes 1..5 for single-track Enhanced-RTMP,
+        // and at bytes 2..6 for multi-track OneTrack / ManyTracks
         // layouts (one extra byte for the multitrack header itself).
         // ManyTracksManyCodecs packs FourCC per-track inside the body,
         // so we report Unknown at the outer level - good enough for
         // dashboard chip display.
-        let codec = if !is_multitrack && payload.len() >= 6 {
-            fourcc_to_codec([payload[2], payload[3], payload[4], payload[5]])
-        } else if is_multitrack && payload.len() >= 7 {
-            // OneTrack(0) and ManyTracks(1) layouts carry the FourCC
-            // right after the multitrack header byte.
-            let mt_type = (payload[2] >> 4) & 0x0F;
+        let codec = if !is_multitrack && payload.len() >= 5 {
+            fourcc_to_codec([payload[1], payload[2], payload[3], payload[4]])
+        } else if is_multitrack && payload.len() >= 6 {
+            let mt_type = (payload[1] >> 4) & 0x0F;
             if mt_type <= 1 {
-                fourcc_to_codec([payload[3], payload[4], payload[5], payload[6]])
+                fourcc_to_codec([payload[2], payload[3], payload[4], payload[5]])
             } else {
                 AudioCodec::Unknown
             }
@@ -550,27 +625,38 @@ fn fourcc_to_codec(fourcc: [u8; 4]) -> AudioCodec {
 ///     track's data, so the single-slot key 0 captures the whole config)
 ///   * Truncated payloads we can't parse safely
 pub fn audio_seq_header_track_id(payload: &[u8]) -> u8 {
-    if payload.len() < 3 {
+    if payload.is_empty() {
         return 0;
     }
     // sound_format=9 sentinel
     if (payload[0] >> 4) & 0x0F != 9 {
         return 0;
     }
-    // PacketType=Multitrack
-    if payload[1] & 0x0F != 5 {
+    // PacketType=Multitrack lives in byte 0's low nibble (NOT byte 1's
+    // low nibble - that was the v0.1.0..0.1.3 wire-format mis-read).
+    if payload[0] & 0x0F != 5 {
         return 0;
     }
-    // MultiTrackType high nibble. Only OneTrack (=0) has a per-tag id.
-    let mt_type = (payload[2] >> 4) & 0x0F;
+    if payload.len() < 2 {
+        return 0;
+    }
+    // MultiTrackType is byte 1's high nibble. Only OneTrack (=0) has a
+    // per-tag id; ManyTracks/ManyTracksManyCodecs layouts pack every
+    // track into one tag.
+    let mt_type = (payload[1] >> 4) & 0x0F;
     if mt_type != 0 {
         return 0;
     }
-    // OneTrack layout: [byte2 mt-header][bytes 3..7 FourCC][byte 7 TrackId][payload..]
-    if payload.len() < 8 {
+    // OneTrack layout (verified against OBS's flv-mux.c):
+    //   byte 0: 0x95 (SoundFormat=9 | PacketType=Multitrack)
+    //   byte 1: MultiTrackType=0 | NestedPacketType
+    //   bytes 2..6: FourCC
+    //   byte 6: TrackId   <- here, NOT byte 7
+    //   bytes 7..: payload
+    if payload.len() < 7 {
         return 0;
     }
-    payload[7]
+    payload[6]
 }
 
 /// Back-compat shim - sink.rs and a few other callers used this name
@@ -689,8 +775,9 @@ mod tests {
 
     #[test]
     fn enhanced_rtmp_opus_audio_recognised() {
-        // sound_format 9 (ExAudio), packet_type 1 (CodedFrames), FourCC "Opus"
-        let mut payload = vec![0x90, 0x01];
+        // Enhanced-RTMP single-track: byte 0 = SoundFormat<<4 | PacketType.
+        // Here: 9 << 4 | 1 (CodedFrames) = 0x91, followed by FourCC.
+        let mut payload = vec![0x91];
         payload.extend_from_slice(b"Opus");
         let info = classify_audio_tag(&payload);
         assert_eq!(info.codec, AudioCodec::Opus);
@@ -759,8 +846,12 @@ mod tests {
 
     #[test]
     fn enhanced_aac_seq_header_via_packet_type_0() {
-        // sound_format 9 (ExAudio), packet_type 0 (SequenceStart), FourCC "mp4a"
-        let mut payload = vec![0x90, 0x00];
+        // Enhanced-RTMP single-track AAC seq header: byte 0 = 0x90
+        // (SoundFormat=9, AudioPacketType=0=SequenceStart), followed
+        // by FourCC. This is the exact tag OBS emits for the live
+        // track when VOD audio is enabled (live = idx=0, single-track
+        // because not multitrack).
+        let mut payload = vec![0x90];
         payload.extend_from_slice(b"mp4a");
         let info = classify_audio_tag(&payload);
         assert!(info.is_seq_header);
@@ -861,6 +952,68 @@ mod tests {
         }
     }
 
+    // ── is_primary_video_idr: cut-target gate for EB ladder cuts ──
+    //
+    // Regression test set for the v0.1.3 EB pixel-glitch fix. Before
+    // this gate, the ring's IDR-only secondary index recorded every
+    // track's keyframes equally, so `compute_delay_cut` could land on
+    // a TrackId-1 IDR while the legacy primary (track 0) was mid-GOP.
+    // After: only primary-track IDRs are candidates, the legacy
+    // decoder always has its anchor at the cut boundary.
+
+    #[test]
+    fn is_primary_video_idr_accepts_legacy_avc_keyframe() {
+        let tag = avc_single_track_keyframe_bytes();
+        assert!(is_primary_video_idr(&tag));
+    }
+
+    #[test]
+    fn is_primary_video_idr_rejects_legacy_avc_inter_frame() {
+        // FrameType=2 (inter) + CodecID=7 (AVC) = 0x27. Same shape as
+        // the keyframe builder above, just with the leading byte flipped.
+        let mut tag = avc_single_track_keyframe_bytes();
+        tag[0] = 0x27;
+        assert!(!is_primary_video_idr(&tag));
+    }
+
+    #[test]
+    fn is_primary_video_idr_accepts_onetrack_multitrack_track_0() {
+        // EB ladder primary rung at TrackId=0 - the cut anchor we want.
+        let tag = enhanced_rtmp_onetrack_video_bytes_track(0);
+        assert!(is_primary_video_idr(&tag));
+    }
+
+    #[test]
+    fn is_primary_video_idr_rejects_onetrack_multitrack_nonzero_tracks() {
+        // EB ladder rungs 1..=4 each carry their own IDR cadence but
+        // must NOT be picked as a cut anchor - if the cut lands here
+        // the legacy decoder on the destination has no reference.
+        for track in 1u8..=4 {
+            let tag = enhanced_rtmp_onetrack_video_bytes_track(track);
+            assert!(
+                !is_primary_video_idr(&tag),
+                "TrackId {track} must not be a cut candidate"
+            );
+        }
+    }
+
+    #[test]
+    fn is_primary_video_idr_rejects_enhanced_p_frame() {
+        // Enhanced-RTMP single-track inter-frame: IsEx | FrameType=2 |
+        // PacketType=CodedFrames(1) -> bits assembled as 0xA1.
+        let tag = vec![0x80 | (2u8 << 4) | 1, b'a', b'v', b'c', b'1', 0xAA, 0xBB];
+        assert!(!is_primary_video_idr(&tag));
+    }
+
+    #[test]
+    fn is_primary_video_idr_handles_truncated_multitrack_gracefully() {
+        // Multitrack header declared but payload too short to read the
+        // TrackId byte - safer to refuse cut-candidacy than to land on
+        // an unknown track.
+        let truncated = vec![0x80 | (1u8 << 4) | 6, 0x01, b'a', b'v', b'c', b'1'];
+        assert!(!is_primary_video_idr(&truncated));
+    }
+
     #[test]
     fn select_video_bytes_falls_back_to_raw_when_flatten_cannot_parse() {
         // Pathological multi-track tag (declares multi-track but the
@@ -886,26 +1039,89 @@ mod tests {
         assert!(!info.is_idr);
     }
 
-    // ── Multi-track audio (VOD audio path) ─────────────────────────
+    // ── Enhanced-RTMP audio (VOD audio path) ───────────────────────
     //
-    // OBS's VOD-audio feature emits Enhanced-RTMP audio packets with
-    // PacketType=Multitrack(5). The seq-header is nested: outer
-    // PacketType=5 with a nested PacketType=0 in byte 2. The TrackId
-    // for OneTrack-layout audio sits at byte 7 (one byte deeper than
-    // the video equivalent because audio has an extra header byte).
+    // OBS's VOD-audio feature emits Enhanced-RTMP audio packets via
+    // flv_packet_audio_ex in plugins/obs-outputs/flv-mux.c. The Live
+    // track (idx=0) is sent as Enhanced-RTMP SINGLE-TRACK and the VOD
+    // track (idx>0) as Enhanced-RTMP OneTrack multi-track. Layouts:
+    //
+    //   single-track: [byte0 0x9X][bytes 1..5 FourCC][payload]
+    //                     X = AudioPacketType (0=Seq, 1=Frames)
+    //
+    //   multi-track:  [byte0 0x95][byte1 mt_type|nested_pt][bytes 2..6 FourCC]
+    //                 [byte6 TrackId][payload]
+    //                     byte0 low nibble = 5 (Multitrack)
+    //                     byte1 high nibble = 0 (OneTrack)
+    //                     byte1 low nibble  = nested packet type
+    //
+    // v0.1.0..0.1.3 mis-read this format - PacketType from byte 1
+    // instead of byte 0, TrackId from byte 7 instead of byte 6. With
+    // VOD audio enabled the live track's seq-header was not detected
+    // (the classifier saw PacketType = 'm' & 0x0F = 0x0D), so it went
+    // into the ring like a regular tag and got evicted by trim before
+    // the destination consumer read it - Twitch never received an
+    // AudioSpecificConfig and both audio tracks rendered silent.
+
+    /// Helper: build an Enhanced-RTMP single-track AAC audio tag.
+    /// packet_type: 0=SequenceStart, 1=CodedFrames.
+    fn enhanced_audio_single_track(packet_type: u8) -> Vec<u8> {
+        let mut payload = vec![
+            0x90 | (packet_type & 0x0F), // SoundFormat=9 | AudioPacketType
+            b'm',
+            b'p',
+            b'4',
+            b'a', // FourCC=mp4a
+        ];
+        // AudioSpecificConfig stub (or AAC frame data; bytes don't
+        // matter for classification, only their position relative to
+        // the header).
+        payload.extend_from_slice(&[0x12, 0x10, 0x56, 0xe5]);
+        payload
+    }
 
     /// Helper: build an Enhanced-RTMP OneTrack multi-track audio tag.
     /// nested_pt: 0=SequenceStart, 1=CodedFrames.
     fn enhanced_audio_onetrack(track_id: u8, nested_pt: u8) -> Vec<u8> {
         let mut payload = vec![
-            0x90,      // SoundFormat=9
-            0x05,      // PacketType=Multitrack
-            nested_pt, // MultiTrackType=0, NestedPT=nested_pt
-            b'm', b'p', b'4', b'a',     // FourCC=mp4a
-            track_id, // TrackId
+            0x95,             // SoundFormat=9 | PacketType=Multitrack
+            nested_pt & 0x0F, // MultiTrackType=0 (high nibble) | NestedPT (low)
+            b'm',
+            b'p',
+            b'4',
+            b'a',     // FourCC=mp4a
+            track_id, // TrackId at byte 6
         ];
-        payload.extend_from_slice(&[0x12, 0x10, 0x56, 0xe5]); // AudioSpecificConfig stub
+        payload.extend_from_slice(&[0x12, 0x10, 0x56, 0xe5]);
         payload
+    }
+
+    #[test]
+    fn enhanced_single_track_seq_header_is_detected() {
+        // The user-visible regression for issue #9 (post-v0.1.3 manual
+        // test): with VOD audio enabled, OBS sends the live track as
+        // Enhanced-RTMP single-track. v0.1.0..0.1.3 read PacketType
+        // from byte 1 (which is 'm' = 0x6D, low nibble 0x0D) and never
+        // matched the SequenceStart value - so the AudioSpecificConfig
+        // tag flowed into the ring like a normal frame and got
+        // evicted, leaving Twitch's decoder unconfigured.
+        let tag = enhanced_audio_single_track(0);
+        let info = classify_audio_tag(&tag);
+        assert!(
+            info.is_seq_header,
+            "Enhanced-RTMP single-track byte 0 = 0x90 must classify as seq header"
+        );
+        assert!(!info.is_multitrack);
+        assert_eq!(info.codec, AudioCodec::Aac);
+    }
+
+    #[test]
+    fn enhanced_single_track_coded_frame_is_not_seq_header() {
+        let tag = enhanced_audio_single_track(1);
+        let info = classify_audio_tag(&tag);
+        assert!(!info.is_seq_header);
+        assert!(!info.is_multitrack);
+        assert_eq!(info.codec, AudioCodec::Aac);
     }
 
     #[test]
@@ -934,9 +1150,10 @@ mod tests {
     }
 
     #[test]
-    fn audio_seq_header_track_id_reads_onetrack_byte_7() {
-        // Each VOD-audio session sends one seq-header per track with
-        // TrackId at byte 7. Our cache keys on this so a publisher
+    fn audio_seq_header_track_id_reads_onetrack_byte_6() {
+        // OBS writes TrackId at byte 6 of the audio tag payload
+        // (byte 0 = 0x95, byte 1 = mt|nested, bytes 2..6 = FourCC,
+        // byte 6 = TrackId). Our cache keys on this so a publisher
         // reconnect can replay every track's config.
         for track in 0u8..=3 {
             let tag = enhanced_audio_onetrack(track, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod sysstat;
 mod trace;
 #[cfg(windows)]
 mod tray;
+mod update_check;
 mod web;
 
 use crate::config::Settings;
@@ -440,6 +441,22 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
                 state
                     .pass_through_multitrack_video
                     .store(has_eb_session, std::sync::atomic::Ordering::Relaxed);
+                // Audio multi-track passthrough is decoupled from EB.
+                // Twitch's regular ingest (live.twitch.tv) has supported
+                // VOD audio (OBS "Pista VOD de Twitch", wire TrackId 1)
+                // for years and accepts Enhanced-RTMP multi-track audio
+                // bit-faithfully. So pass through for any Twitch
+                // destination, with or without an EB session. Non-Twitch
+                // destinations still drop TrackId != 0 so a simulcast
+                // YouTube / Kick doesn't get a track its decoder can't
+                // map. Before v0.1.3 we reused the video flag here,
+                // which silently dropped VOD audio on every non-EB
+                // Twitch destination and wrapped the live audio in
+                // multi-track framing the regular ingest renders silent.
+                let is_twitch = dest.platform == "twitch";
+                state
+                    .pass_through_multitrack_audio
+                    .store(is_twitch, std::sync::atomic::Ordering::Relaxed);
                 let label = dest.name.clone();
                 let url_clone = url.clone();
                 let handle = tokio::spawn(controller::run_egress(

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -28,7 +28,7 @@
 
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Locate the user's `services.json`. Returns `None` if neither
 /// candidate path exists - typical when OBS isn't installed at all.
@@ -299,31 +299,95 @@ fn remove_entry(file: &str) -> Option<String> {
     Some(format!("{}{}", &file[..left], &file[right..]))
 }
 
-// ── VOD-audio integration: OBS global.ini flag ──────────────────────
+// ── VOD-audio integration: OBS user.ini flag ────────────────────────
 //
 // OBS gates the VOD Track checkbox behind `EnableCustomServerVodTrack`
-// in `[General]` of global.ini when the active service id is
-// `rtmp_custom`. We write/remove this flag in lockstep with the
-// per-destination `vod_audio` toggle so the streamer doesn't have to
-// hand-edit an INI file. The flag is global to the user's OBS - it
-// affects every Custom RTMP setup they have, not just InstantClone.
-// That's deliberate on OBS's side: they only want power users who
-// understand the implication enabling this, which is exactly what
-// our dashboard toggle's copy spells out.
+// in `[General]` of the user config. The frontend reads it as:
+//
+//   bool enableForCustomServer = config_get_bool(
+//       App()->GetUserConfig(), "General", "EnableCustomServerVodTrack");
+//   bool enableVodTrack = ui->service->currentText() == "Twitch";
+//   if (enableForCustomServer && IsCustomService())
+//       enableVodTrack = true;
+//
+// (frontend/settings/OBSBasicSettings_Stream.cpp on master)
+//
+// IMPORTANT: OBS 32 split the legacy global.ini into two files -
+// `global.ini` (app-level) and `user.ini` (user-level) - and
+// `GetUserConfig()` now returns user.ini. v0.1.0..0.1.2 wrote the
+// flag to global.ini, which OBS 32 simply ignored. Issue #9 was the
+// streamer report ("the bypass didn't work") that surfaced this.
+//
+// Strategy: prefer user.ini when it exists (OBS 32+), fall back to
+// global.ini for older installs. On every write we also strip the
+// legacy key from global.ini if it's there, so upgraders don't carry
+// dead state across files.
+//
+// We write/remove this flag in lockstep with the per-destination
+// `vod_audio` toggle so the streamer doesn't have to hand-edit an INI
+// file. The flag is global to the user's OBS - it affects every
+// Custom RTMP setup they have, not just InstantClone. That's
+// deliberate on OBS's side: they only want power users who understand
+// the implication enabling this, which is exactly what our dashboard
+// toggle's copy spells out.
 
-fn global_ini_path() -> Option<PathBuf> {
-    std::env::var("APPDATA")
-        .ok()
-        .map(|p| PathBuf::from(p).join("obs-studio/global.ini"))
-        .filter(|p| p.exists())
+/// Pure path-resolution helper: given an OBS install directory
+/// (typically `%APPDATA%\obs-studio`), pick the authoritative user
+/// config file - user.ini on OBS 32+, falling back to global.ini on
+/// older installs that haven't been split. Separated from
+/// `obs_user_config_path` so tests can exercise the prefer-user.ini
+/// logic with a temp directory instead of mutating real %APPDATA%.
+fn resolve_user_config_in(obs_dir: &Path) -> Option<PathBuf> {
+    let user = obs_dir.join("user.ini");
+    if user.exists() {
+        return Some(user);
+    }
+    let global = obs_dir.join("global.ini");
+    global.exists().then_some(global)
 }
 
-/// Read `[General] EnableCustomServerVodTrack` from OBS's global.ini.
+/// Pure helper for the cleanup-only path that resolves the legacy
+/// global.ini under an OBS install directory, but ONLY when user.ini
+/// is present alongside (i.e. OBS 32+, where global.ini's
+/// `EnableCustomServerVodTrack` is dead state to strip). Returns None
+/// on older installs where global.ini is still the live config.
+fn legacy_global_ini_in(obs_dir: &Path) -> Option<PathBuf> {
+    let user = obs_dir.join("user.ini");
+    if !user.exists() {
+        return None;
+    }
+    let global = obs_dir.join("global.ini");
+    global.exists().then_some(global)
+}
+
+/// Authoritative user-config path: user.ini in OBS 32+, falling back
+/// to global.ini for pre-32 installs that haven't been split yet.
+/// `[Basic] Profile=` lives in this file too, so the active-profile
+/// detection below shares the same lookup.
+fn obs_user_config_path() -> Option<PathBuf> {
+    let obs_dir = std::env::var("APPDATA")
+        .ok()
+        .map(|p| PathBuf::from(p).join("obs-studio"))?;
+    resolve_user_config_in(&obs_dir)
+}
+
+/// Legacy global.ini path - only consulted for the post-upgrade
+/// cleanup pass that strips dead `EnableCustomServerVodTrack` entries
+/// left behind by v0.1.0..0.1.2. None on pre-32 installs where
+/// `obs_user_config_path` already points at global.ini.
+fn legacy_global_ini_path_for_cleanup() -> Option<PathBuf> {
+    let obs_dir = std::env::var("APPDATA")
+        .ok()
+        .map(|p| PathBuf::from(p).join("obs-studio"))?;
+    legacy_global_ini_in(&obs_dir)
+}
+
+/// Read `[General] EnableCustomServerVodTrack` from OBS's user config.
 /// Returns `false` when OBS isn't installed, the file is missing, or
 /// the key isn't set. We treat any value other than literal `true` /
 /// `1` as off, matching OBS's `config_get_bool` parser.
 pub fn vod_audio_flag_set() -> bool {
-    let Some(p) = global_ini_path() else {
+    let Some(p) = obs_user_config_path() else {
         return false;
     };
     let Ok(s) = fs::read_to_string(&p) else {
@@ -334,22 +398,53 @@ pub fn vod_audio_flag_set() -> bool {
         .unwrap_or(false)
 }
 
-/// Set or clear `[General] EnableCustomServerVodTrack=true` in OBS's
-/// global.ini. Idempotent. Returns `Ok(false)` if OBS isn't installed
+/// Set `[General] EnableCustomServerVodTrack=<true|false>` in OBS's
+/// user config. Idempotent. Returns `Ok(false)` if OBS isn't installed
 /// (the file path doesn't exist) so callers can degrade gracefully
 /// instead of treating "no OBS" as a hard error.
+///
+/// Disabling rewrites the existing line to `=false` rather than
+/// deleting it. OBS's `config_get_bool` reads `=false` and "key
+/// absent" identically, but the in-place rewrite is robust against
+/// OBS rewriting user.ini on shutdown and moving the key between
+/// duplicate [General] blocks - wherever it lands, the next toggle
+/// just flips the value. The downside (one extra line on a never-
+/// enabled install) is gated away: insertion only happens on enable.
+///
+/// On OBS 32+ we also flip the same key to false in the now-orphan
+/// global.ini, so users upgrading from v0.1.0..0.1.2 (which mistakenly
+/// wrote there) end up with no live flag anywhere.
 pub fn set_vod_audio_flag(enable: bool) -> io::Result<bool> {
-    let Some(p) = global_ini_path() else {
+    let Some(p) = obs_user_config_path() else {
         return Ok(false);
     };
     let original = fs::read_to_string(&p)?;
     let updated = ini_set(&original, "General", "EnableCustomServerVodTrack", enable);
-    if updated == original {
-        return Ok(true); // already in desired state
+    if updated != original {
+        let bak = p.with_extension("ini.instantclone.bak");
+        write_or_friendly(&bak, &original)?;
+        write_or_friendly(&p, &updated)?;
     }
-    let bak = p.with_extension("ini.instantclone.bak");
-    write_or_friendly(&bak, &original)?;
-    write_or_friendly(&p, &updated)?;
+    // Best-effort legacy cleanup: silently strip the key from
+    // global.ini if v0.1.0..0.1.2 ever wrote it there. Failures are
+    // non-fatal - the user.ini write above is the load-bearing one,
+    // global.ini being unwritable just means the dead key lingers as
+    // harmless noise until the user closes OBS.
+    if let Some(legacy) = legacy_global_ini_path_for_cleanup() {
+        if let Ok(legacy_original) = fs::read_to_string(&legacy) {
+            let cleaned = ini_set(
+                &legacy_original,
+                "General",
+                "EnableCustomServerVodTrack",
+                false,
+            );
+            if cleaned != legacy_original {
+                let bak = legacy.with_extension("ini.instantclone.bak");
+                let _ = write_or_friendly(&bak, &legacy_original);
+                let _ = write_or_friendly(&legacy, &cleaned);
+            }
+        }
+    }
     Ok(true)
 }
 
@@ -377,8 +472,15 @@ fn ini_get<'a>(file: &'a str, section: &str, key: &str) -> Option<&'a str> {
 }
 
 fn ini_set(file: &str, section: &str, key: &str, enable: bool) -> String {
-    // Strategy: walk lines, copy through, replace the key inside its
-    // section, or insert at end of section / end of file if missing.
+    // Strategy: walk lines, copy through, ALWAYS rewrite the key's
+    // value when we encounter it (true OR false - never drop), or
+    // insert at end of section / end of file if missing AND we're
+    // enabling. Robust against OBS rewriting user.ini and moving the
+    // key around between duplicate [General] blocks - we don't depend
+    // on "where" the key lives, just that it lives in the target
+    // section *somewhere*. Disabling is just `=false`, which OBS's
+    // `config_get_bool` reads identically to "key absent" - so we
+    // never need to delete a line we can't reliably find.
     let want_value = if enable { "true" } else { "false" };
     let mut out = String::with_capacity(file.len() + 64);
     let mut cur: Option<String> = None;
@@ -406,13 +508,10 @@ fn ini_set(file: &str, section: &str, key: &str, enable: bool) -> String {
         if in_target_section && !wrote_key {
             if let Some((k, _)) = trimmed.split_once('=') {
                 if k.trim() == key {
-                    if enable {
-                        out.push_str(key);
-                        out.push('=');
-                        out.push_str(want_value);
-                        out.push('\n');
-                    }
-                    // If disabling, drop the line entirely.
+                    out.push_str(key);
+                    out.push('=');
+                    out.push_str(want_value);
+                    out.push('\n');
                     wrote_key = true;
                     continue;
                 }
@@ -458,9 +557,15 @@ fn ini_set(file: &str, section: &str, key: &str, enable: bool) -> String {
 // `"multitrack_video_configuration_url": "<our endpoint>"` into the
 // active OBS profile's service.json under `settings`. OBS's
 // rtmp-custom plugin only writes `server` / `key` / `use_auth` /
-// `username` / `password` to settings, but obs_data_t preserves
-// arbitrary keys round-trip. So the injected URL persists until we
-// remove it, and OBS auto-fetches our multitrack config from there.
+// `username` / `password` to settings, and discards every other key
+// in its `rtmp_custom_update` function. That means the injected URL
+// is dropped on LOAD (never reaches OBS's MultitrackVideoAutoConfigURL
+// lookup), not only on SAVE - so the injection mechanism is dead.
+// We keep `inject_vod_eb` / `revert_vod_eb` only for cleanup of stale
+// state left behind by v0.1.0..0.1.2. New Phase C is the
+// `launch_obs_with_eb_config` helper below: spawn obs64.exe with the
+// `--config-url` CLI flag, which is the only path OBS's frontend
+// actually honours for Custom RTMP services.
 //
 // We touch only the ACTIVE profile (not every profile we find). This
 // is the user-chosen scope from the dashboard: minimal footprint, the
@@ -468,11 +573,11 @@ fn ini_set(file: &str, section: &str, key: &str, enable: bool) -> String {
 
 const PROFILES_DIR_REL: &str = "obs-studio/basic/profiles";
 
-/// Active OBS profile name, read from `%APPDATA%\obs-studio\global.ini`
-/// (`[Basic] Profile=<name>`). None when OBS isn't installed or the
-/// key isn't present.
+/// Active OBS profile name, read from `[Basic] Profile=<name>` in
+/// OBS's user config (user.ini on 32+, global.ini on older installs).
+/// None when OBS isn't installed or the key isn't present.
 pub fn active_profile() -> Option<String> {
-    let p = global_ini_path()?;
+    let p = obs_user_config_path()?;
     let s = fs::read_to_string(&p).ok()?;
     ini_get(&s, "Basic", "Profile").map(|v| v.to_string())
 }
@@ -510,43 +615,6 @@ pub fn vod_eb_injection_present(web_port: u16) -> bool {
     s.contains(&needle) || s.contains(&needle_spaced)
 }
 
-/// Inject the multitrack-video config URL into the active OBS profile's
-/// rtmp_custom service.json. Idempotent. Returns Ok(true) when the
-/// active profile exists AND uses rtmp_custom AND the write landed
-/// (or was already present); Ok(false) when there's no active profile
-/// or the profile uses a different service type (rtmp_common is one
-/// where the URL would have no effect, since OBS gets it from
-/// services.json).
-pub fn inject_vod_eb(web_port: u16) -> io::Result<bool> {
-    let Some(p) = active_profile_service_json_path() else {
-        return Ok(false);
-    };
-    let original = fs::read_to_string(&p)?;
-    // Only inject into rtmp_custom - for rtmp_common services the
-    // multitrack-video URL is read from services.json (not from
-    // service.json), and injecting would be a no-op at best, foot-gun
-    // at worst.
-    if !original.contains("\"type\": \"rtmp_custom\"")
-        && !original.contains("\"type\":\"rtmp_custom\"")
-    {
-        return Ok(false);
-    }
-    let needle = format!("http://127.0.0.1:{}/obs/multitrack-config", web_port);
-    if original.contains(&needle) {
-        return Ok(true); // already injected
-    }
-    let patched = inject_service_json_key(&original, web_port).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            "couldn't find `settings` object in service.json - file shape unexpected",
-        )
-    })?;
-    let bak = p.with_extension("json.instantclone.bak");
-    write_or_friendly(&bak, &original)?;
-    write_or_friendly(&p, &patched)?;
-    Ok(true)
-}
-
 /// Remove the injected URL from the active OBS profile's service.json.
 /// Idempotent. Returns Ok(true) when the active profile exists and we
 /// removed (or there was nothing to remove); Ok(false) when there's no
@@ -567,21 +635,70 @@ pub fn revert_vod_eb(web_port: u16) -> io::Result<bool> {
     Ok(true)
 }
 
-/// Splice `"multitrack_video_configuration_url": "<url>"` into the
-/// JSON object's `settings` block. We locate `"settings": {` then
-/// insert the key as the first child, comma-separated from whatever
-/// comes next. Returns None if the marker isn't found - safer than
-/// blindly editing a file we don't recognise.
-fn inject_service_json_key(file: &str, web_port: u16) -> Option<String> {
-    let key_pos = file.find("\"settings\"")?;
-    let brace_offset = file[key_pos..].find('{')?;
-    let absolute_brace = key_pos + brace_offset;
-    let (head, tail) = file.split_at(absolute_brace + 1);
-    let entry = format!(
-        "\n        \"multitrack_video_configuration_url\": \"http://127.0.0.1:{}/obs/multitrack-config\",",
-        web_port
-    );
-    Some(format!("{head}{entry}{tail}"))
+// ── Phase C v2: launch OBS with --config-url ────────────────────────
+//
+// OBS's frontend looks for the multi-track config URL in this order
+// (frontend/utility/GoLiveAPI_Network.cpp::MultitrackVideoAutoConfigURL):
+//
+//   1. `--config-url <url>` command-line argument
+//   2. `multitrack_video_configuration_url` key in the active service's
+//      settings (services.json for rtmp_common, service.json for
+//      anything else).
+//
+// For rtmp_custom services, path 2 is dead - the plugin's
+// `rtmp_custom_update` only extracts 5 known keys from the settings
+// object and discards the rest, so OBS never sees our injection. The
+// CLI flag is the only durable way to enable Enhanced Broadcasting
+// alongside VOD audio (which itself requires Custom RTMP, since
+// rtmp_common services gate the VOD track checkbox on the service name
+// being literally "Twitch"). That's why this is a "Launch OBS" button
+// instead of an auto-injected file edit.
+
+/// Standard Windows install paths for obs64.exe. The first match wins.
+/// Portable / non-standard installs aren't auto-discovered (rare and
+/// the user can always launch OBS themselves with the flag).
+fn obs_executable_candidates() -> [PathBuf; 2] {
+    [
+        PathBuf::from("C:\\Program Files\\obs-studio\\bin\\64bit\\obs64.exe"),
+        PathBuf::from("C:\\Program Files (x86)\\obs-studio\\bin\\64bit\\obs64.exe"),
+    ]
+}
+
+pub fn find_obs_executable() -> Option<PathBuf> {
+    obs_executable_candidates().into_iter().find(|p| p.exists())
+}
+
+/// Spawn OBS Studio with the `--config-url` flag pointing at
+/// InstantClone's multitrack-config endpoint. Detaches from our
+/// process group so closing InstantClone afterwards doesn't take OBS
+/// down with it.
+///
+/// Returns Ok when the spawn syscall succeeded (NOT when OBS finishes
+/// loading - that's async). Errors surface "OBS not installed" or
+/// permission failures to the dashboard so the user can act.
+pub fn launch_obs_with_eb_config(web_port: u16) -> io::Result<PathBuf> {
+    let exe = find_obs_executable().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "obs64.exe not found at C:\\Program Files\\obs-studio\\bin\\64bit\\ \
+             (or the x86 path). Launch OBS manually with the \
+             --config-url <our endpoint> flag from the directory where you installed it.",
+        )
+    })?;
+    let config_url = format!("http://127.0.0.1:{web_port}/obs/multitrack-config");
+    // CREATE_NEW_PROCESS_GROUP (0x00000200) gives OBS its own console
+    // group so InstantClone closing doesn't propagate a SIGTERM-
+    // equivalent. We also pass the launcher's parent dir as the working
+    // directory because OBS's logging and locale paths are resolved
+    // relative to the bin/64bit folder.
+    use std::os::windows::process::CommandExt;
+    let workdir = exe.parent().unwrap_or(&exe);
+    std::process::Command::new(&exe)
+        .args(["--config-url", &config_url])
+        .current_dir(workdir)
+        .creation_flags(0x0000_0200)
+        .spawn()?;
+    Ok(exe)
 }
 
 /// Remove the multitrack-video-configuration-url key (matching our
@@ -614,6 +731,7 @@ fn strip_service_json_key(file: &str, web_port: u16) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32 as TestUniq, Ordering as TestOrd};
 
     fn fake_services_json() -> String {
         // Minimal but realistic shape. OBS's actual file has many more
@@ -787,11 +905,32 @@ mod tests {
     }
 
     #[test]
-    fn ini_set_removes_key_when_disabling() {
+    fn ini_set_writes_false_in_place_when_disabling() {
+        // Issue #9 follow-up: disabling REWRITES the value as `false`
+        // instead of deleting the line. OBS's config_get_bool reads
+        // `=false` and "key absent" identically, but rewriting the
+        // line in place is robust against OBS shuffling the key into
+        // a different [General] block on its own file rewrite -
+        // wherever the key ended up, we just flip the value.
         let ini = "[General]\nEnableCustomServerVodTrack=true\nName=Foo\n";
         let out = ini_set(ini, "General", "EnableCustomServerVodTrack", false);
-        assert_eq!(ini_get(&out, "General", "EnableCustomServerVodTrack"), None);
+        assert_eq!(
+            ini_get(&out, "General", "EnableCustomServerVodTrack"),
+            Some("false")
+        );
+        assert!(!out.contains("EnableCustomServerVodTrack=true"));
         assert_eq!(ini_get(&out, "General", "Name"), Some("Foo"));
+    }
+
+    #[test]
+    fn ini_set_does_not_create_false_line_when_disabling_a_virgin_file() {
+        // A user who has never toggled VOD audio on shouldn't end up
+        // with a stray `EnableCustomServerVodTrack=false` line in
+        // their user.ini just because the dashboard reconcile ran on
+        // a clean state. Insertion is still gated to the enable path.
+        let ini = "[General]\nName=Foo\n[Basic]\nProfile=A\n";
+        let out = ini_set(ini, "General", "EnableCustomServerVodTrack", false);
+        assert_eq!(out, ini, "no key found + disable should be a no-op");
     }
 
     #[test]
@@ -803,6 +942,84 @@ mod tests {
             Some("true")
         );
         assert_eq!(ini_get(&out, "Basic", "Profile"), Some("A"));
+    }
+
+    /// Reported on the v0.1.3 test build: user.ini ends up with two
+    /// `[General]` sections (OBS itself maintains a second one at the
+    /// end of the file). Our toggle-ON correctly lands the key in the
+    /// trailing block; this test confirms toggle-OFF flips its value
+    /// in place to `false` without disturbing either section's other
+    /// keys or trying to delete the line - which would be fragile
+    /// against OBS rewriting the file and moving the key around. The
+    /// file shape mirrors what OBS 32 wrote after the first toggle +
+    /// restart, trimmed down to the bits that exercise the
+    /// duplicate-section walk.
+    #[test]
+    fn ini_set_flips_value_to_false_in_trailing_duplicate_general_section() {
+        let ini = "[General]\n\
+            Pre19Defaults=false\n\
+            FirstRun=true\n\
+            \n\
+            [Basic]\n\
+            Profile=Sin Título\n\
+            \n\
+            [Audio]\n\
+            DisableAudioDucking=true\n\
+            \n\
+            [General]\n\
+            EnableCustomServerVodTrack=true\n\
+            FirstRun=true\n";
+        let out = ini_set(ini, "General", "EnableCustomServerVodTrack", false);
+
+        // Value flipped, line stays.
+        assert_eq!(
+            ini_get(&out, "General", "EnableCustomServerVodTrack"),
+            Some("false")
+        );
+        assert!(out.contains("EnableCustomServerVodTrack=false"));
+        assert!(!out.contains("EnableCustomServerVodTrack=true"));
+
+        // Both [General] sections are still there - we never want to
+        // collapse OBS's own structure, just edit our one key.
+        assert_eq!(out.matches("[General]").count(), 2);
+
+        // Sibling keys in BOTH [General] blocks survive.
+        assert!(out.contains("Pre19Defaults=false"));
+        assert!(out.contains("FirstRun=true"));
+
+        // Unrelated sections are untouched.
+        assert_eq!(ini_get(&out, "Basic", "Profile"), Some("Sin Título"));
+        assert_eq!(ini_get(&out, "Audio", "DisableAudioDucking"), Some("true"));
+    }
+
+    /// Sibling property: toggle-ON on a fresh duplicate-section file
+    /// (no key present in either [General]) lands the key in the
+    /// trailing [General] - which is what we observed during the
+    /// v0.1.3 test build. Documenting this so a future refactor that
+    /// chooses to insert into the first block instead doesn't surprise
+    /// the next maintainer.
+    #[test]
+    fn ini_set_lands_in_trailing_general_when_duplicate_sections_exist() {
+        let ini = "[General]\n\
+            FirstRun=true\n\
+            \n\
+            [Basic]\n\
+            Profile=A\n\
+            \n\
+            [General]\n\
+            ConfirmOnExit=true\n";
+        let out = ini_set(ini, "General", "EnableCustomServerVodTrack", true);
+
+        assert_eq!(
+            ini_get(&out, "General", "EnableCustomServerVodTrack"),
+            Some("true")
+        );
+        // Lands inside the trailing [General], after ConfirmOnExit.
+        let trailing = out.rfind("[General]").expect("trailing [General] kept");
+        assert!(out[trailing..].contains("EnableCustomServerVodTrack=true"));
+        // Idempotent toggle-on - second call must not double-write.
+        let twice = ini_set(&out, "General", "EnableCustomServerVodTrack", true);
+        assert_eq!(twice.matches("EnableCustomServerVodTrack=true").count(), 1);
     }
 
     // ── service.json injection ─────────────────────────────────────
@@ -821,22 +1038,29 @@ mod tests {
         .to_string()
     }
 
-    #[test]
-    fn inject_service_json_key_adds_url_into_settings() {
-        let original = fake_rtmp_custom_service_json();
-        let patched = inject_service_json_key(&original, 7799).expect("inject must succeed");
-        assert!(patched.contains("multitrack_video_configuration_url"));
-        assert!(patched.contains("http://127.0.0.1:7799/obs/multitrack-config"));
-        // Existing settings are still present.
-        assert!(patched.contains("\"server\": \"rtmp://127.0.0.1:1935/live\""));
-        assert!(patched.contains("\"type\": \"rtmp_custom\""));
+    /// Manually crafted legacy state from v0.1.0..0.1.2's broken
+    /// inject path: an `rtmp_custom` service.json that was once
+    /// patched by the old `inject_service_json_key` helper. Strip must
+    /// remove our key without disturbing real OBS settings, so an
+    /// upgrade from a polluted file ends up clean.
+    fn legacy_polluted_rtmp_custom_service_json() -> String {
+        r#"{
+    "settings": {
+        "multitrack_video_configuration_url": "http://127.0.0.1:7799/obs/multitrack-config",
+        "key": "main",
+        "server": "rtmp://127.0.0.1:1935/live",
+        "use_auth": false
+    },
+    "type": "rtmp_custom"
+}
+"#
+        .to_string()
     }
 
     #[test]
     fn strip_service_json_key_removes_only_our_line() {
-        let original = fake_rtmp_custom_service_json();
-        let patched = inject_service_json_key(&original, 7799).unwrap();
-        let stripped = strip_service_json_key(&patched, 7799);
+        let polluted = legacy_polluted_rtmp_custom_service_json();
+        let stripped = strip_service_json_key(&polluted, 7799);
         assert!(!stripped.contains("multitrack_video_configuration_url"));
         // Sibling settings stay untouched.
         assert!(stripped.contains("\"server\": \"rtmp://127.0.0.1:1935/live\""));
@@ -849,4 +1073,87 @@ mod tests {
         let stripped = strip_service_json_key(&original, 7799);
         assert_eq!(stripped, original);
     }
+
+    // ── OBS user-config path resolution ─────────────────────────────
+    //
+    // Issue #9 (v0.1.2): the EnableCustomServerVodTrack flag was
+    // being written to global.ini, but OBS 32 reads the VOD-track
+    // gate from user.ini (via App()->GetUserConfig()). These tests
+    // lock the prefer-user.ini behaviour so the file selection
+    // can't silently regress back to global.ini in a future refactor.
+
+    fn fresh_obs_dir(label: &str) -> std::path::PathBuf {
+        // Each test gets its own dir so a tempdir cleanup race
+        // between them can't make assertions flap.
+        let dir = std::env::temp_dir().join(format!(
+            "ic-obs-{}-{}-{}",
+            label,
+            std::process::id(),
+            UNIQ_OBS.fetch_add(1, TestOrd::SeqCst),
+        ));
+        std::fs::create_dir_all(&dir).expect("fresh_obs_dir create_dir_all");
+        dir
+    }
+
+    #[test]
+    fn resolve_user_config_prefers_user_ini_when_both_files_exist() {
+        let dir = fresh_obs_dir("prefer-user");
+        let user = dir.join("user.ini");
+        let global = dir.join("global.ini");
+        std::fs::write(&user, "[General]\n").unwrap();
+        std::fs::write(&global, "[General]\n").unwrap();
+
+        let resolved = resolve_user_config_in(&dir).expect("must resolve");
+        assert_eq!(
+            resolved, user,
+            "OBS 32+ keeps user.ini as the authoritative user config - \
+             writing to global.ini is the v0.1.0..0.1.2 bug from issue #9"
+        );
+    }
+
+    #[test]
+    fn resolve_user_config_falls_back_to_global_ini_when_user_ini_missing() {
+        let dir = fresh_obs_dir("fallback-global");
+        let global = dir.join("global.ini");
+        std::fs::write(&global, "[General]\n").unwrap();
+
+        let resolved = resolve_user_config_in(&dir).expect("must resolve");
+        assert_eq!(
+            resolved, global,
+            "pre-OBS-32 installs only have global.ini; the resolver \
+             must still find the user config there"
+        );
+    }
+
+    #[test]
+    fn resolve_user_config_returns_none_when_neither_exists() {
+        let dir = fresh_obs_dir("no-obs");
+        assert!(
+            resolve_user_config_in(&dir).is_none(),
+            "no OBS install means no config to write to - caller \
+             should degrade gracefully, not error"
+        );
+    }
+
+    #[test]
+    fn legacy_global_ini_only_reported_when_user_ini_present() {
+        // Case 1: OBS 32+ with both files - legacy global.ini is
+        // dead state we want to clean up.
+        let dir = fresh_obs_dir("legacy-both");
+        let user = dir.join("user.ini");
+        let global = dir.join("global.ini");
+        std::fs::write(&user, "[General]\n").unwrap();
+        std::fs::write(&global, "[General]\n").unwrap();
+        assert_eq!(legacy_global_ini_in(&dir), Some(global.clone()));
+
+        // Case 2: pre-32 install - global.ini IS the live config,
+        // not legacy. The cleanup path must skip so we don't
+        // strip the flag from the file OBS is actively reading.
+        let dir = fresh_obs_dir("legacy-no-user");
+        let global = dir.join("global.ini");
+        std::fs::write(&global, "[General]\n").unwrap();
+        assert!(legacy_global_ini_in(&dir).is_none());
+    }
+
+    static UNIQ_OBS: TestUniq = TestUniq::new(0);
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,226 @@
+//! Lightweight "is there a newer release on GitHub" check.
+//!
+//! Calls GitHub's public Releases API once per process lifetime (and on
+//! demand from the dashboard's `/update-check` endpoint), parses the
+//! `tag_name`, and compares it to our compiled-in `CARGO_PKG_VERSION`.
+//! No automatic download or install - the dashboard surfaces a small
+//! pill that links to the release page if there's a newer build.
+//!
+//! Failures are non-fatal: if the user is offline, GitHub rate-limits
+//! us, or the JSON shape changes, we silently report "couldn't check"
+//! and the dashboard hides the pill.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const RELEASES_URL: &str = "https://api.github.com/repos/Soulhackzlol/InstantClone/releases/latest";
+const RELEASES_PAGE: &str = "https://github.com/Soulhackzlol/InstantClone/releases/latest";
+const CACHE_TTL: Duration = Duration::from_secs(600); // 10 min
+
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub current: String,
+    pub latest: Option<String>,
+    pub update_available: bool,
+    pub error: Option<String>,
+}
+
+impl UpdateInfo {
+    pub fn to_json(&self) -> String {
+        let latest_field = match &self.latest {
+            Some(v) => format!("\"{}\"", v.replace('"', "'")),
+            None => "null".to_string(),
+        };
+        let error_field = match &self.error {
+            Some(e) => format!("\"{}\"", e.replace('"', "'").replace('\\', "\\\\")),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"current":"{}","latest":{},"update_available":{},"release_url":"{}","error":{}}}"#,
+            self.current.replace('"', "'"),
+            latest_field,
+            self.update_available,
+            RELEASES_PAGE,
+            error_field,
+        )
+    }
+}
+
+static CACHE: Mutex<Option<(Instant, UpdateInfo)>> = Mutex::new(None);
+
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Returns the cached result if fresh, otherwise fetches GitHub and
+/// updates the cache. The fetch happens in-line (no spawn) because the
+/// call site is the dashboard endpoint, which already runs on the web
+/// worker thread - a 10-second timeout caps the worst case.
+pub fn check_update() -> UpdateInfo {
+    if let Some((when, info)) = CACHE.lock().unwrap().as_ref() {
+        if when.elapsed() < CACHE_TTL {
+            return info.clone();
+        }
+    }
+    let info = fetch_latest();
+    *CACHE.lock().unwrap() = Some((Instant::now(), info.clone()));
+    info
+}
+
+fn fetch_latest() -> UpdateInfo {
+    let current = current_version().to_string();
+    let agent = crate::https::https_agent();
+    let req = agent
+        .get(RELEASES_URL)
+        .header("User-Agent", format!("InstantClone/{current}"))
+        .header("Accept", "application/vnd.github+json");
+    let resp = match req.call() {
+        Ok(r) => r,
+        Err(e) => {
+            return UpdateInfo {
+                current: current.clone(),
+                latest: None,
+                update_available: false,
+                error: Some(format!("network: {e}")),
+            };
+        }
+    };
+    if resp.status() != 200 {
+        return UpdateInfo {
+            current: current.clone(),
+            latest: None,
+            update_available: false,
+            error: Some(format!("github http {}", resp.status())),
+        };
+    }
+    let mut body = resp;
+    let text = match body.body_mut().read_to_string() {
+        Ok(t) => t,
+        Err(e) => {
+            return UpdateInfo {
+                current: current.clone(),
+                latest: None,
+                update_available: false,
+                error: Some(format!("body: {e}")),
+            };
+        }
+    };
+    let latest_tag = match extract_tag_name(&text) {
+        Some(t) => t,
+        None => {
+            return UpdateInfo {
+                current: current.clone(),
+                latest: None,
+                update_available: false,
+                error: Some("couldn't parse tag_name from GitHub response".to_string()),
+            };
+        }
+    };
+    let latest_stripped = latest_tag.trim_start_matches('v').to_string();
+    let update_available = is_newer(&latest_stripped, &current);
+    UpdateInfo {
+        current,
+        latest: Some(latest_stripped),
+        update_available,
+        error: None,
+    }
+}
+
+/// Pull the `"tag_name"` value out of the JSON body without a full JSON
+/// parse. The GitHub Releases API guarantees a top-level string field
+/// here for every published release, so a careful substring + bounded
+/// scan is enough; pulling in `serde_json` for one field is overkill.
+fn extract_tag_name(body: &str) -> Option<String> {
+    let key = "\"tag_name\"";
+    let key_pos = body.find(key)?;
+    let after_key = &body[key_pos + key.len()..];
+    let colon = after_key.find(':')?;
+    let after_colon = &after_key[colon + 1..];
+    let quote_start = after_colon.find('"')?;
+    let value_slice = &after_colon[quote_start + 1..];
+    let quote_end = value_slice.find('"')?;
+    Some(value_slice[..quote_end].to_string())
+}
+
+/// SemVer-ish comparison: split on `.` and `-`, compare component by
+/// component (numbers numerically, suffixes lexically). Handles
+/// `0.1.3` vs `0.1.3-beta.7` correctly (prerelease loses to release of
+/// the same base version). Returns true iff `latest` is strictly newer
+/// than `current`.
+fn is_newer(latest: &str, current: &str) -> bool {
+    let (lat_base, lat_pre) = split_prerelease(latest);
+    let (cur_base, cur_pre) = split_prerelease(current);
+    let lat_parts = parse_dotted(lat_base);
+    let cur_parts = parse_dotted(cur_base);
+    match lat_parts.cmp(&cur_parts) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => match (lat_pre, cur_pre) {
+            // Same base. Release > prerelease > different prerelease.
+            (None, None) => false,
+            (None, Some(_)) => true,
+            (Some(_), None) => false,
+            (Some(a), Some(b)) => a > b,
+        },
+    }
+}
+
+fn split_prerelease(v: &str) -> (&str, Option<&str>) {
+    match v.split_once('-') {
+        Some((base, pre)) => (base, Some(pre)),
+        None => (v, None),
+    }
+}
+
+fn parse_dotted(v: &str) -> Vec<u64> {
+    v.split('.')
+        .map(|s| s.parse::<u64>().unwrap_or(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_tag_name_handles_typical_github_payload() {
+        let json = r#"{"url":"...","tag_name":"v0.1.3","name":"v0.1.3"}"#;
+        assert_eq!(extract_tag_name(json).as_deref(), Some("v0.1.3"));
+    }
+
+    #[test]
+    fn extract_tag_name_tolerates_whitespace_around_colon() {
+        let json = r#"{ "tag_name" : "v9.9.9-rc.1" }"#;
+        assert_eq!(extract_tag_name(json).as_deref(), Some("v9.9.9-rc.1"));
+    }
+
+    #[test]
+    fn extract_tag_name_returns_none_when_field_absent() {
+        let json = r#"{"name":"oops","prerelease":false}"#;
+        assert_eq!(extract_tag_name(json), None);
+    }
+
+    #[test]
+    fn is_newer_patch_bump() {
+        assert!(is_newer("0.1.4", "0.1.3"));
+        assert!(!is_newer("0.1.3", "0.1.3"));
+        assert!(!is_newer("0.1.2", "0.1.3"));
+    }
+
+    #[test]
+    fn is_newer_minor_bump() {
+        assert!(is_newer("0.2.0", "0.1.9"));
+    }
+
+    #[test]
+    fn is_newer_release_beats_same_base_prerelease() {
+        assert!(is_newer("0.1.3", "0.1.3-beta.7"));
+        assert!(!is_newer("0.1.3-beta.7", "0.1.3"));
+    }
+
+    #[test]
+    fn is_newer_prerelease_progression() {
+        assert!(is_newer("0.1.3-beta.8", "0.1.3-beta.7"));
+        assert!(!is_newer("0.1.3-beta.6", "0.1.3-beta.7"));
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -317,6 +317,61 @@ async fn route(
                 ),
             ),
         },
+        ("POST", "/obs/launch-with-eb") => {
+            let s = settings.borrow();
+            match crate::obs_register::launch_obs_with_eb_config(s.web_port) {
+                Ok(exe) => {
+                    ctrl.log(format!(
+                        "obs-eb-launch: spawned {} with --config-url",
+                        exe.display()
+                    ));
+                    (
+                        "200 OK",
+                        "application/json",
+                        format!(
+                            r#"{{"ok":true,"message":"Launched OBS with Enhanced Broadcasting enabled. OBS will pick up multi-track video from InstantClone on this session only - if you close OBS and reopen normally, you'll need this button again.","exe":"{}"}}"#,
+                            exe.display()
+                                .to_string()
+                                .replace('\\', "\\\\")
+                                .replace('"', "'")
+                        ),
+                    )
+                }
+                Err(e) => (
+                    "500 Internal Server Error",
+                    "application/json",
+                    format!(
+                        r#"{{"ok":false,"error":"{}"}}"#,
+                        e.to_string().replace('"', "'")
+                    ),
+                ),
+            }
+        }
+        ("GET", "/update-check") => {
+            let info = crate::update_check::check_update();
+            ("200 OK", "application/json", info.to_json())
+        }
+        ("GET", "/obs/launch-status") => {
+            let exe = crate::obs_register::find_obs_executable();
+            (
+                "200 OK",
+                "application/json",
+                format!(
+                    r#"{{"installed":{},"exe":{}}}"#,
+                    exe.is_some(),
+                    match exe {
+                        Some(p) => format!(
+                            "\"{}\"",
+                            p.display()
+                                .to_string()
+                                .replace('\\', "\\\\")
+                                .replace('"', "'")
+                        ),
+                        None => "null".to_string(),
+                    }
+                ),
+            )
+        }
         ("GET", "/twitch_ingests") => ("200 OK", "application/json", twitch_ingests_json()),
         ("GET", "/profiles") => ("200 OK", "application/json", profiles_json(settings)),
         ("GET", "/logs") => ("200 OK", "application/json", logs_json(ctrl)),
@@ -347,8 +402,10 @@ async fn route(
         ("POST", "/profiles") => post_profile_add(body, settings, cfg_path).await,
         ("POST", "/profiles/delete") => post_profile_del(body, settings, cfg_path).await,
         // Destinations CRUD
-        ("POST", "/destinations") => post_destination_upsert(body, settings, cfg_path).await,
-        ("POST", "/destinations/delete") => post_destination_delete(body, settings, cfg_path).await,
+        ("POST", "/destinations") => post_destination_upsert(body, ctrl, settings, cfg_path).await,
+        ("POST", "/destinations/delete") => {
+            post_destination_delete(body, ctrl, settings, cfg_path).await
+        }
         _ => (
             "404 Not Found",
             "text/plain; charset=utf-8",
@@ -1374,7 +1431,7 @@ async fn post_config_reset(
         ctrl.clear_logs();
     }
     ctrl.log(format!("config reset (scope={})", scope));
-    reconcile_obs_vod_files(&next);
+    reconcile_obs_vod_files(&next, ctrl);
     let _ = settings.send(next);
     (
         "200 OK",
@@ -1647,6 +1704,7 @@ async fn test_egress(
 
 async fn post_destination_upsert(
     body: &str,
+    ctrl: &Arc<Controller>,
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
 ) -> (&'static str, &'static str, String) {
@@ -1740,37 +1798,56 @@ async fn post_destination_upsert(
             ),
         );
     }
-    reconcile_obs_vod_files(&ns);
+    reconcile_obs_vod_files(&ns, ctrl);
     let _ = settings.send(ns);
     ("200 OK", "application/json", r#"{"ok":true}"#.into())
 }
 
-/// Reconcile OBS's external files (global.ini, profile service.json)
-/// against the current destinations. Idempotent and silent on failure -
-/// we log to the dashboard event log instead of bubbling up an HTTP
-/// error, because the user's destination save shouldn't fail just
-/// because OBS is closed (which holds the files open).
-fn reconcile_obs_vod_files(s: &Settings) {
+/// Reconcile OBS's external files (user.ini) against the current
+/// destinations. Idempotent. A failed write does NOT abort the
+/// upstream destination save - we still want the user's config to
+/// land - but we log it to the dashboard event log so the user sees
+/// why their toggle didn't take effect. The expected failure mode is
+/// OBS holding the files open: PermissionDenied, recoverable by
+/// closing OBS and toggling once more.
+///
+/// Also runs a best-effort cleanup pass that strips any stale
+/// `multitrack_video_configuration_url` injection from the active
+/// profile's service.json. v0.1.0..0.1.2 wrote that on every
+/// `vod_audio_inject_eb` toggle, but we now know OBS's `rtmp_custom`
+/// plugin discards the key on load (see `obs_register.rs` comment
+/// block), so the injection was always dead code. The cleanup means
+/// upgraders end up with a clean file.
+fn reconcile_obs_vod_files(s: &Settings, ctrl: &Arc<Controller>) {
     let any_vod = s
         .destinations
         .iter()
         .any(|d| d.enabled && d.platform == "twitch" && d.vod_audio);
-    let any_eb = s
-        .destinations
-        .iter()
-        .any(|d| d.enabled && d.platform == "twitch" && d.vod_audio && d.vod_audio_inject_eb);
-    // global.ini flag tracks "any VOD-audio destination wants it".
-    let _ = crate::obs_register::set_vod_audio_flag(any_vod);
-    // service.json injection tracks "any VOD+EB destination wants it".
-    let _ = if any_eb {
-        crate::obs_register::inject_vod_eb(s.web_port)
-    } else {
-        crate::obs_register::revert_vod_eb(s.web_port)
-    };
+    // user.ini flag tracks "any VOD-audio destination wants it".
+    if let Err(e) = crate::obs_register::set_vod_audio_flag(any_vod) {
+        ctrl.log(format!(
+            "vod-audio: couldn't write OBS user config ({}). \
+             Close OBS, then toggle the destination off and back on to retry.",
+            e
+        ));
+    }
+    // One-time cleanup of legacy v0.1.0..0.1.2 service.json injection.
+    // Phase C now uses the --config-url CLI flag via the
+    // /obs/launch-with-eb button instead of file injection, since OBS's
+    // rtmp_custom plugin discards unknown settings keys at load time.
+    if let Err(e) = crate::obs_register::revert_vod_eb(s.web_port) {
+        ctrl.log(format!(
+            "vod-eb cleanup: couldn't strip legacy injection from \
+             service.json ({}). Harmless - the injection never reached \
+             OBS anyway.",
+            e
+        ));
+    }
 }
 
 async fn post_destination_delete(
     body: &str,
+    ctrl: &Arc<Controller>,
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
 ) -> (&'static str, &'static str, String) {
@@ -1794,7 +1871,7 @@ async fn post_destination_delete(
         ns.configured = false;
     }
     let _ = ns.save(cfg_path);
-    reconcile_obs_vod_files(&ns);
+    reconcile_obs_vod_files(&ns, ctrl);
     let _ = settings.send(ns);
     ("200 OK", "application/json", r#"{"ok":true}"#.into())
 }

--- a/web/index.html
+++ b/web/index.html
@@ -76,8 +76,10 @@ input,select,textarea{font-family:inherit;color:inherit}
   border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-1)}
 .ic-brand{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
 .ic-brand-mark{font-size:16px;font-weight:700;letter-spacing:-.01em;
-  background:linear-gradient(180deg,#fff,color-mix(in oklch,var(--accent) 30%,#fff));
-  -webkit-background-clip:text;background-clip:text;color:transparent}
+  /* Solid warm cream for max contrast vs the dark header. The previous
+     fff-to-accent-mix gradient muddied the bottom half of the letters
+     into ~30% lightness which read as low-contrast on dark themes. */
+  color:#f5efe1}
 .ic-brand-sub{color:var(--fg-3);font-size:12px}
 .ic-brand-dot{display:inline-block;width:5px;height:5px;border-radius:999px;background:var(--fg-4);margin:0 6px 2px}
 .ic-brand-credit{color:var(--fg-4);font-size:11px;margin-left:4px}
@@ -811,6 +813,7 @@ input,select,textarea{font-family:inherit;color:inherit}
     <span class="ic-pill ok" id="hdr-ebroadcast" hidden title="Enhanced Broadcasting active - multi-track simulcast is being forwarded bit-faithfully to Twitch and flattened to the primary track for any non-Twitch destinations. Twitch's transcoder serves the full quality ladder to viewers.">⚡ Enhanced Broadcasting</span>
     <span class="ic-pill bad" id="hdr-backpressure" hidden title="A destination's upload can't keep up with OBS's bitrate. Lower OBS bitrate or check upload speed.">⚠ Upload bottleneck</span>
     <span class="ic-pill warn" id="hdr-twitch-cap" hidden>⚠ <span id="hdr-twitch-cap-v">Twitch · Source-Only at 10 Mbps</span></span>
+    <a id="hdr-update" class="ic-pill" href="#" target="_blank" rel="noopener" hidden title="Click to view release notes on GitHub">⬆ <span id="hdr-update-v">update available</span></a>
     <button id="hdr-help" class="ic-btn-tiny" title="How does this work? (?)" onclick="openTour(0)" style="width:30px;height:30px;color:var(--fg-3);font-weight:700;font-size:14px;border-radius:999px;border:1px solid var(--line);background:var(--surface-3);position:relative">?
       <span id="hdr-help-hint" class="help-hint" hidden>New here? Quick tour →</span>
     </button>
@@ -1007,25 +1010,27 @@ input,select,textarea{font-family:inherit;color:inherit}
           <div style="font-weight:600;color:var(--fg)">VOD audio mode</div>
           <div class="muted" style="font-size:11.5px;margin-top:2px;line-height:1.45">
             Records a separate audio track to Twitch's VOD. Useful when your live stream has copyrighted music that should be stripped from the saved recording.
-            <b style="color:var(--warn,#d6a23a)">Disables Enhanced Broadcasting</b> (the transcoded quality ladder) unless you also enable the experimental sub-toggle below.
+            <b style="color:var(--warn,#d6a23a)">Disables Enhanced Broadcasting</b> (the transcoded quality ladder) unless you use the experimental Launch button below.
             Requires switching OBS to <b>Custom RTMP</b> + enabling the VOD Track checkbox in OBS Output settings.
           </div>
         </div>
       </label>
       <div id="dest-form-vod-eb-wrap" hidden style="margin-top:10px;padding:10px;border:1px dashed color-mix(in oklch,var(--err) 32%,var(--line));border-radius:8px;background:color-mix(in oklch,var(--err) 3%,var(--bg-2))">
-        <label style="display:flex;align-items:flex-start;gap:10px;margin:0;text-transform:none;letter-spacing:0;font-size:13px;cursor:pointer">
-          <input type="checkbox" id="dest-form-vod-inject-eb" style="margin-top:2px">
-          <div>
-            <div style="font-weight:600;color:var(--err)">
-              Also enable Enhanced Broadcasting
+        <div style="display:flex;align-items:flex-start;gap:10px">
+          <div style="flex:1;min-width:0">
+            <div style="font-weight:600;color:var(--err);font-size:13px">
+              Want Enhanced Broadcasting too?
               <span style="display:inline-block;font-size:9.5px;font-weight:700;letter-spacing:1.5px;background:color-mix(in oklch,var(--warn,#d6a23a) 22%,transparent);color:var(--warn,#d6a23a);padding:1px 6px;border-radius:99px;margin-left:4px;text-transform:uppercase;vertical-align:1px">experimental</span>
             </div>
-            <div class="muted" style="font-size:11.5px;margin-top:2px;line-height:1.45">
-              Injects <code class="mono" style="font-size:11px">multitrack_video_configuration_url</code> into your active OBS profile's <code class="mono" style="font-size:11px">service.json</code> so Custom RTMP also gets EB. Modifies OBS's internal file (with a <code class="mono" style="font-size:11px">.bak</code> backup); disabling this toggle reverts.
-              Only applies to your <b>active</b> OBS profile - switching profiles in OBS disables the injection until you re-toggle here.
+            <div class="muted" style="font-size:11.5px;margin-top:4px;line-height:1.45">
+              Use this <b>only if you want EB + VOD audio at the same time</b>. Launches OBS with the <code class="mono" style="font-size:11px">--config-url</code> CLI flag - the only path OBS honours for Custom RTMP (its plugin discards <code class="mono" style="font-size:11px">service.json</code> injections at load time). Close OBS first; the flag is per-launch, so reopening OBS normally will lose EB until you click again.
+            </div>
+            <div class="row" style="gap:8px;margin-top:10px;align-items:center">
+              <button type="button" class="ic-btn ic-btn-primary" id="obs-eb-launch-btn" onclick="launchObsWithEb()">Launch OBS for EB + VOD</button>
+              <span class="muted" id="obs-eb-launch-msg" style="font-size:11.5px"></span>
             </div>
           </div>
-        </label>
+        </div>
       </div>
     </div>
     <div class="row" style="margin-top:14px;justify-content:flex-end">
@@ -2074,32 +2079,33 @@ function openDestForm(d){
   document.getElementById('dest-form-key-hint').textContent = d && d.stream_key_set ? '(currently set)' : '';
   $('dest-form-enabled').checked = d ? d.enabled : true;
   $('dest-form-vod-audio').checked = !!(d && d.vod_audio);
-  $('dest-form-vod-inject-eb').checked = !!(d && d.vod_audio_inject_eb);
   updateVodVisibility();
+  refreshObsEbLaunchAvailability();
   $('dest-form-msg').innerHTML = '';
   $('dest-form').scrollIntoView({behavior:'smooth',block:'nearest'});
 }
 function cancelDestForm(){ $('dest-form').hidden = true; }
 
-// VOD-audio mode is Twitch-only (the gate is hardcoded in OBS). When
-// the platform isn't twitch we hide the whole block. When VOD audio
-// is OFF we hide the experimental sub-toggle so its scary warning
-// doesn't loom over destinations that have no use for it.
+// VOD-audio mode is Twitch-only (the gate is hardcoded in OBS). The
+// "Launch OBS for EB + VOD" experimental button below only matters
+// when VOD audio is actually enabled - showing it otherwise just
+// invites the user to misuse the CLI flag. Visibility cascades:
+//   platform != twitch        -> hide both
+//   platform == twitch + !vod -> show VOD toggle, hide EB launcher
+//   platform == twitch + vod  -> show both
 function updateVodVisibility(){
   const plat = $('dest-form-platform').value;
   const vodWrap = $('dest-form-vod-wrap');
   const vodEbWrap = $('dest-form-vod-eb-wrap');
-  if (!vodWrap || !vodEbWrap) return;
+  if (!vodWrap) return;
   vodWrap.hidden = plat !== 'twitch';
   if (plat !== 'twitch'){
     $('dest-form-vod-audio').checked = false;
-    $('dest-form-vod-inject-eb').checked = false;
-    vodEbWrap.hidden = true;
+    if (vodEbWrap) vodEbWrap.hidden = true;
     return;
   }
-  vodEbWrap.hidden = !$('dest-form-vod-audio').checked;
-  if (!$('dest-form-vod-audio').checked){
-    $('dest-form-vod-inject-eb').checked = false;
+  if (vodEbWrap){
+    vodEbWrap.hidden = !$('dest-form-vod-audio').checked;
   }
 }
 
@@ -2137,17 +2143,15 @@ async function saveDestForm(){
   const yingest = $('dest-form-youtube-ingest').value;
   const key = $('dest-form-key').value.trim();
   const enabled = $('dest-form-enabled').checked;
-  // VOD-audio knobs only apply to Twitch destinations. Defensive
-  // gating in case the user enabled them then switched platform
-  // without the change handler running.
+  // VOD-audio is Twitch-only. Defensive gating in case the user
+  // enabled it then switched platform without the change handler
+  // running.
   const vodAudio = platform === 'twitch' && $('dest-form-vod-audio').checked;
-  const vodInjectEb = vodAudio && $('dest-form-vod-inject-eb').checked;
   if (!name){ $('dest-form-msg').innerHTML = '<span class="err">Name required</span>'; return; }
   const body = new URLSearchParams({
     name, platform, custom_egress_url:custom, enabled:enabled?'on':'off',
     twitch_ingest:ingest, youtube_ingest:yingest,
     vod_audio: vodAudio ? 'on' : 'off',
-    vod_audio_inject_eb: vodInjectEb ? 'on' : 'off',
   });
   if (id) body.set('id', id);
   if (key) body.set('stream_key', key);
@@ -2164,7 +2168,6 @@ async function toggleDest(d){
   const body = new URLSearchParams({id:d.id, name:d.name, platform:d.platform,
     custom_egress_url:d.custom_egress_url, twitch_ingest:d.twitch_ingest||'', youtube_ingest:d.youtube_ingest||'',
     vod_audio: d.vod_audio ? 'on' : 'off',
-    vod_audio_inject_eb: d.vod_audio_inject_eb ? 'on' : 'off',
     enabled:d.enabled?'off':'on'});
   await fetch('/destinations',{method:'POST', body});
   loadDestinations();
@@ -2659,6 +2662,52 @@ async function toggleObsRegister(){
     if (msg) msg.textContent = String(e);
   }
   await refreshObsRegisterStatus();
+}
+
+// ── Phase C: Launch OBS with --config-url ────────────────────────────
+// Spawns obs64.exe with the Enhanced Broadcasting CLI flag. The user
+// has to use this every time they want EB on a Custom RTMP setup,
+// since OBS only reads --config-url at launch and rtmp_custom's
+// settings plugin discards file-injected URLs. Errors surface inline
+// next to the button so the user can fix install paths or close a
+// running OBS first.
+async function launchObsWithEb(){
+  const btn = $('obs-eb-launch-btn');
+  const msg = $('obs-eb-launch-msg');
+  if (!btn || btn.disabled) return;
+  btn.disabled = true;
+  if (msg) msg.textContent = 'Launching…';
+  try {
+    const r = await (await fetch('/obs/launch-with-eb', {method:'POST'})).json();
+    if (r.ok){
+      toast(r.message || 'OBS launched','ok');
+      if (msg) msg.textContent = 'OBS spawned. Multi-track video unlocked for this session.';
+    } else {
+      toast(r.error || 'Failed','err');
+      if (msg) msg.textContent = r.error || 'Failed';
+    }
+  } catch(e){
+    toast('Request failed','err');
+    if (msg) msg.textContent = String(e);
+  }
+  btn.disabled = false;
+}
+async function refreshObsEbLaunchAvailability(){
+  const btn = $('obs-eb-launch-btn');
+  const msg = $('obs-eb-launch-msg');
+  if (!btn) return;
+  try {
+    const r = await (await fetch('/obs/launch-status')).json();
+    if (!r.installed){
+      btn.disabled = true;
+      btn.className = 'ic-btn ic-btn-disabled';
+      if (msg) msg.textContent = 'OBS not found at the standard install path.';
+    } else {
+      btn.disabled = false;
+      btn.className = 'ic-btn ic-btn-primary';
+      if (msg && !msg.textContent) msg.textContent = '';
+    }
+  } catch(_){}
 }
 
 // ── Reset settings / Reset everything ────────────────────────────────
@@ -3227,12 +3276,31 @@ function startStateSSE(){
   } catch(_){ startStatePolling(); }
 }
 
+// One-shot update check: hit GitHub Releases API on dashboard load,
+// surface a small pill in the header if a newer tag is available.
+// Failures are silent - we don't want offline / rate-limited users to
+// see a scary error pill for a passive nicety. Cached server-side for
+// 10 min so a F5 spree doesn't hammer GitHub.
+async function checkForUpdate(){
+  try {
+    const r = await (await fetch('/update-check')).json();
+    if (!r || !r.update_available) return;
+    const pill = $('hdr-update');
+    const label = $('hdr-update-v');
+    if (!pill || !label) return;
+    label.textContent = 'v' + r.latest + ' available';
+    pill.href = r.release_url;
+    pill.hidden = false;
+  } catch(_){}
+}
+
 (async function init(){
   try { platforms = await (await fetch('/platforms')).json(); } catch(_){ platforms = []; }
   fillWizardPlatforms();
   wireChatDock();
   await loadConfig();
   refreshObsRegisterStatus();
+  checkForUpdate();
   startStateSSE();
   setInterval(pollLogs, 1500);
   document.addEventListener('keydown', e => {


### PR DESCRIPTION
Closes #9.

The reporter's "Audio VOD mode doesn't actually work" issue surfaced a stack of bugs that all bit when VOD audio was enabled. v0.1.3 fixes each layer:

## What was broken

1. **Wrong file.** OBS 32 split \`global.ini\` into \`global.ini\` (app) and \`user.ini\` (user). The VOD-track gate code reads \`App()->GetUserConfig()\` which now maps to \`user.ini\`. v0.1.0..0.1.2 wrote our \`EnableCustomServerVodTrack\` flag to the wrong file, so OBS never saw it.
2. **Fragile cleanup.** OBS rewrites \`user.ini\` on shutdown and sometimes consolidates duplicate \`[General]\` sections. Find-and-delete was unreliable - find-and-flip-value is robust.
3. **Audio passthrough tied to EB.** \`pass_through_multitrack_video\` was reused for the audio selector. Non-EB Twitch destinations with VOD audio enabled got TrackId 0 wrapped in Enhanced-RTMP multi-track framing the regular ingest can't decode, and TrackId 1 dropped entirely. Both tracks rendered silent.
4. **Wire format mis-read.** \`AudioPacketType\` was read from \`payload[1] & 0x0F\` (real position: byte 0 low nibble) and \`TrackId\` from \`payload[7]\` (real position: byte 6). Live track AAC seq-header was never detected as such, flowed into the ring like a P-frame, got trim-evicted before egress - Twitch never received an \`AudioSpecificConfig\`.
5. **Phase C dead-on-arrival.** The auto-inject of \`multitrack_video_configuration_url\` into \`service.json\` never worked - OBS's \`rtmp_custom_update\` discards unknown settings keys at LOAD time, not just save.
6. **EB cuts pixel-glitching.** \`idr_index\` recorded every ladder rung's IDRs equally, so \`compute_delay_cut\` could land on a TrackId-1..4 IDR while the legacy primary (track 0) was mid-GOP. Destination decoder garbage until next track-0 IDR.

## How v0.1.3 fixes each

| Bug | Fix |
|---|---|
| 1. Wrong file | New \`obs_user_config_path()\` prefers \`user.ini\`, falls back to \`global.ini\` |
| 2. Fragile cleanup | Toggle OFF writes \`=false\` in place instead of deleting |
| 3. Audio passthrough | New \`pass_through_multitrack_audio\` flag, true for any Twitch destination |
| 4. Wire format | \`classify_audio_tag\` / \`select_audio_bytes\` / \`audio_seq_header_track_id\` read the real byte positions |
| 5. Phase C | UI toggle removed, replaced with "Launch OBS for EB + VOD" button (under VOD audio toggle in destination editor). New \`POST /obs/launch-with-eb\` spawns \`obs64.exe --config-url <our endpoint>\` |
| 6. EB cuts | New \`is_primary_video_idr\` gate on \`idr_index\` push - only TrackId 0 / legacy AVC keyframes become cut candidates |

## Other goodies

- **Passive update check.** GitHub Releases API, 10-min cache, header pill on dashboard, silent on failure. Dormant until repo flips public.
- **Title contrast.** \`#f5efe1\` cream replaces the white→accent gradient that washed out on dark themes.

## Test plan

- [x] 154 unit tests pass (was 132). Each new test was verified to fail without its corresponding fix.
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [x] **Manual**: Twitch + YouTube simulcast, VOD audio enabled, delay cuts FWD + BACK. Audio audible on both, VOD strips its track on Twitch's recording, cuts now clean with no ladder-rung pixel glitching.
- [x] **Manual**: Launch button spawns OBS with multi-track video unlocked on Custom RTMP.
- [ ] CI: \`test + clippy\`, \`e2e\`, \`build\` all green on \`windows-2022\` runner.

## Known follow-up for v0.1.4

Tiny one-frame audio skew at cut boundaries because we pick the nearest audio tag in the ring rather than the one whose ts exactly matches the chosen IDR. Visible as a click in some setups. Out of scope here.