### PR TITLE
ci(codeql): weekly cron + workflow_dispatch (first post-public CodeQL run)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,25 @@
 name: codeql
 
-# Static analysis on every push/PR. Skipped while the repo is private -
-# CodeQL is gated behind GitHub Advanced Security for private repos, but
-# free on public ones. When the repo flips public this workflow starts
-# running automatically with no edits needed.
+# Static analysis on every push/PR + a weekly Monday cron so new CodeQL
+# rules + new advisories surface on the security tab even when the
+# branch is quiet. Manual trigger via `gh workflow run codeql.yml` for
+# ad-hoc re-runs (handy when bumping the codeql-action major version).
 #
-# Re-add the weekly cron trigger after going public if you want CodeQL
-# to pick up new rules between pushes on quiet branches:
-#   schedule:
-#     - cron: "23 4 * * 1"
+# Skipped while the repo is private - CodeQL is gated behind GitHub
+# Advanced Security for private repos, but free on public ones. The
+# `if: github.event.repository.private == false` guard on the job
+# below makes the workflow a no-op until the repo flips public.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # 04:23 UTC every Monday. Off-peak hour to avoid the top-of-hour
+    # cron rush, and Monday so a Tuesday-morning glance at the security
+    # tab catches anything new from the weekend.
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
 
 permissions:
   security-events: write

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+the InstantClone community a welcoming experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, friendly,
+and healthy community.
+
+## Our Standards
+
+Examples of behaviour that helps build a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Taking responsibility, apologising to those affected by our mistakes, and
+  learning from the experience.
+- Focusing on what is best for the project and the community.
+
+Examples of unacceptable behaviour:
+
+- Harassment of any kind, public or private.
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks.
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+The maintainer is responsible for clarifying and enforcing these standards and
+will take appropriate and fair corrective action in response to any behaviour
+deemed inappropriate, threatening, offensive, or harmful.
+
+The maintainer has the right to remove, edit, or reject comments, commits,
+code, issues, and other contributions that are not aligned with this Code of
+Conduct, and will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues, pull
+requests, discussions, and the codebase — and also applies when an individual
+is officially representing the project in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behaviour, report it privately
+through the contact form on [s1moscs.dev](https://s1moscs.dev). All reports
+will be reviewed and investigated promptly and fairly. The maintainer will
+respect the privacy and security of the reporter of any incident.
+
+This is a small, single-maintainer hobby project, so please allow a few days
+for a response.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ cargo test --release
 .\target\release\instantclone.exe
 ```
 
+## Be decent
+
+Participation here is covered by the [Code of Conduct](CODE_OF_CONDUCT.md). Short version: be respectful, no harassment.
+
 ## One last thing
 
 I'm one person doing this on weekends. If a PR or issue sits for a week or two without a reply, a friendly bump is welcome.


### PR DESCRIPTION
Now that the repo is public, the \`if: github.event.repository.private == false\` gate on the CodeQL job is satisfied and the workflow actually runs.

Two trigger additions:

- **\`schedule: cron: \"23 4 * * 1\"\`** so the workflow fires once a week (Mondays 04:23 UTC) and the Security tab catches new CodeQL rules / advisories on quiet branches.
- **\`workflow_dispatch\`** so we can manually re-run from the Actions tab or via \`gh workflow run codeql.yml\` (useful when bumping the codeql-action major version, or re-running after dismissing an alert).

## Test plan

This PR itself is the first end-to-end test of CodeQL on the public repo. Expected:

- [ ] \`test + clippy\`, \`e2e\`, \`build\` all green (the required status checks)
- [ ] \`analyze (rust)\` actually runs this time (was previously \`skipping\` because of the private-repo gate)
- [ ] Any findings show up on the Security tab; we triage in a follow-up if needed.

If CodeQL is clean, merge. If it surfaces real issues, fix them in this same PR before merging.