### PR TITLE
docs: aurora banner + 1280x640 social preview

### DIFF
--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  InstantClone banner - 1280×420.
+  Aurora-effect dark hero with VHS / "paused rewind" typography
+  treatment on the brand mark: horizontal smear ghost + cyan/rose
+  chromatic aberration. The aurora carries ambient mood, the
+  wordmark carries the time-shift concept via the treatment.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 420" width="1280" height="420"
+     role="img" aria-label="InstantClone - RTMP delay buffer for streamers">
+  <title>InstantClone - RTMP delay buffer for streamers</title>
+
+  <defs>
+    <!-- aurora blob gradients -->
+    <radialGradient id="aurCyan" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#5ac8fa" stop-opacity="0.85"/>
+      <stop offset="0.55" stop-color="#5ac8fa" stop-opacity="0.25"/>
+      <stop offset="1"    stop-color="#5ac8fa" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurViolet" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#8a4cff" stop-opacity="0.75"/>
+      <stop offset="0.55" stop-color="#8a4cff" stop-opacity="0.20"/>
+      <stop offset="1"    stop-color="#8a4cff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurRose" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#ff5aa0" stop-opacity="0.55"/>
+      <stop offset="0.55" stop-color="#ff5aa0" stop-opacity="0.15"/>
+      <stop offset="1"    stop-color="#ff5aa0" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurTeal" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#3ad6c4" stop-opacity="0.45"/>
+      <stop offset="0.55" stop-color="#3ad6c4" stop-opacity="0.12"/>
+      <stop offset="1"    stop-color="#3ad6c4" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- ambient aurora blur -->
+    <filter id="auroraBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="90"/>
+    </filter>
+
+    <!--
+      Horizontal-only blur for the wordmark ghost.
+      stdDeviation="14 0" = strong blur on x, zero on y.
+      Reads as motion smear / persistence-of-vision.
+    -->
+    <filter id="hSmear" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="14 0"/>
+    </filter>
+
+    <!-- vertical vignette -->
+    <linearGradient id="vignette" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0"    stop-color="#0a0c12" stop-opacity="0.55"/>
+      <stop offset="0.35" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="0.65" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="1"    stop-color="#0a0c12" stop-opacity="0.65"/>
+    </linearGradient>
+
+    <!-- left-side darkening so the aurora doesn't wash the wordmark -->
+    <linearGradient id="leftShade" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0"    stop-color="#0a0c12" stop-opacity="0.55"/>
+      <stop offset="0.45" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="1"    stop-color="#0a0c12" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- shared font stack -->
+    <style>
+      .brand   { font: 700 96px 'Inter','SF Pro Display',-apple-system,'Segoe UI',Roboto,sans-serif; letter-spacing: -3.5px; }
+      .tagline { font: 500 23px 'Inter','SF Pro Display',-apple-system,'Segoe UI',Roboto,sans-serif; letter-spacing: -.2px; }
+      .chip    { font: 600 11.5px ui-monospace,'SF Mono','Cascadia Mono',Menlo,Consolas,monospace; letter-spacing: 1.4px; text-transform: uppercase; }
+    </style>
+  </defs>
+
+  <!-- ── base layer ────────────────────────────────────────────── -->
+  <rect width="1280" height="420" fill="#0a0c12"/>
+
+  <!-- ── aurora ─────────────────────────────────────────────────── -->
+  <g filter="url(#auroraBlur)" opacity="0.95">
+    <ellipse cx="220"  cy="100" rx="320" ry="180" fill="url(#aurCyan)"/>
+    <ellipse cx="1080" cy="320" rx="420" ry="240" fill="url(#aurViolet)"/>
+    <ellipse cx="950"  cy="160" rx="320" ry="180" fill="url(#aurRose)"/>
+    <ellipse cx="780"  cy="380" rx="260" ry="160" fill="url(#aurTeal)" opacity="0.7"/>
+    <ellipse cx="380"  cy="370" rx="220" ry="140" fill="url(#aurCyan)" opacity="0.5"/>
+  </g>
+
+  <!-- shades + vignette -->
+  <rect width="1280" height="420" fill="url(#leftShade)"/>
+  <rect width="1280" height="420" fill="url(#vignette)"/>
+
+  <!-- subtle inner border -->
+  <rect x="0.5" y="0.5" width="1279" height="419" fill="none" stroke="#1c2129" stroke-width="1"/>
+
+  <!-- ── LEFT: brand block ────────────────────────────────────── -->
+  <g transform="translate(96,0)">
+
+    <!--
+      WORDMARK STACK (bottom → top):
+        1. Horizontal-smear ghost (cyan, blurred x-axis only)
+           → motion / persistence-of-vision
+        2. Chromatic-aberration ROSE layer (offset -3px on x)
+           → VHS magenta channel fringe
+        3. Chromatic-aberration CYAN layer (offset +3px on x)
+           → VHS cyan channel fringe
+        4. Crisp cream wordmark on top
+           → the brand itself, sharp and primary
+
+      Layered low-opacity rose + cyan offsets create coloured edge
+      fringes on the white letters - the classic "paused VHS / CRT
+      misalignment" look. Combined with the smear ghost, the whole
+      mark reads as a tape frozen mid-rewind.
+    -->
+    <text x="0" y="200" class="brand" fill="#5ac8fa" fill-opacity="0.20" filter="url(#hSmear)">InstantClone</text>
+    <text x="-3" y="200" class="brand" fill="#ff5aa0" fill-opacity="0.55">InstantClone</text>
+    <text x="3"  y="200" class="brand" fill="#5ac8fa" fill-opacity="0.55">InstantClone</text>
+    <text x="0"  y="200" class="brand" fill="#f5efe1">InstantClone</text>
+
+    <!-- thin cyan accent rule under wordmark -->
+    <rect x="3" y="222" width="100" height="2" fill="#5ac8fa"/>
+
+    <!-- tagline -->
+    <text x="0" y="266" class="tagline" fill="#c0c4cc">RTMP delay buffer for streamers, plus a bit more.</text>
+
+    <!-- capability chips - glass-style -->
+    <g transform="translate(0,312)">
+      <g>
+        <rect x="0"   y="0" width="200" height="30" rx="15" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="100" y="20" class="chip" fill="#d8dce4" text-anchor="middle">Two-phase arm / cut</text>
+      </g>
+      <g transform="translate(212,0)">
+        <rect x="0"  y="0" width="180" height="30" rx="15" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="90" y="20" class="chip" fill="#d8dce4" text-anchor="middle">Multi-destination</text>
+      </g>
+      <g transform="translate(404,0)">
+        <rect x="0"  y="0" width="120" height="30" rx="15" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="60" y="20" class="chip" fill="#d8dce4" text-anchor="middle">OBS dock</text>
+      </g>
+      <g transform="translate(536,0)">
+        <rect x="0"  y="0" width="128" height="30" rx="15" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="64" y="20" class="chip" fill="#d8dce4" text-anchor="middle">6 overlays</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- ── RIGHT: intentionally empty. The aurora is the content. ── -->
+</svg>

--- a/docs/social-preview.svg
+++ b/docs/social-preview.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  InstantClone GitHub social preview - 1280×640.
+  Same brand composition as docs/banner.svg, repositioned for the
+  taller GitHub social-preview canvas (Twitter, Discord, Slack link
+  unfurls). Aurora ellipses re-spread to fill the extra vertical
+  room; brand block sits at optical centre (slightly above geometric
+  centre because the visual weight of the tagline + chips below the
+  wordmark pulls the eye down naturally).
+
+  Upload via GitHub: Settings → General → Social preview → Upload
+  an image (this SVG; GitHub auto-renders to PNG).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640"
+     role="img" aria-label="InstantClone - RTMP delay buffer for streamers">
+  <title>InstantClone - RTMP delay buffer for streamers</title>
+
+  <defs>
+    <radialGradient id="aurCyan" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#5ac8fa" stop-opacity="0.85"/>
+      <stop offset="0.55" stop-color="#5ac8fa" stop-opacity="0.25"/>
+      <stop offset="1"    stop-color="#5ac8fa" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurViolet" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#8a4cff" stop-opacity="0.75"/>
+      <stop offset="0.55" stop-color="#8a4cff" stop-opacity="0.20"/>
+      <stop offset="1"    stop-color="#8a4cff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurRose" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#ff5aa0" stop-opacity="0.55"/>
+      <stop offset="0.55" stop-color="#ff5aa0" stop-opacity="0.15"/>
+      <stop offset="1"    stop-color="#ff5aa0" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="aurTeal" cx="50%" cy="50%" r="50%">
+      <stop offset="0"    stop-color="#3ad6c4" stop-opacity="0.45"/>
+      <stop offset="0.55" stop-color="#3ad6c4" stop-opacity="0.12"/>
+      <stop offset="1"    stop-color="#3ad6c4" stop-opacity="0"/>
+    </radialGradient>
+
+    <filter id="auroraBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="110"/>
+    </filter>
+
+    <filter id="hSmear" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="14 0"/>
+    </filter>
+
+    <linearGradient id="vignette" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0"    stop-color="#0a0c12" stop-opacity="0.55"/>
+      <stop offset="0.35" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="0.65" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="1"    stop-color="#0a0c12" stop-opacity="0.65"/>
+    </linearGradient>
+
+    <linearGradient id="leftShade" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0"    stop-color="#0a0c12" stop-opacity="0.55"/>
+      <stop offset="0.45" stop-color="#0a0c12" stop-opacity="0"/>
+      <stop offset="1"    stop-color="#0a0c12" stop-opacity="0"/>
+    </linearGradient>
+
+    <style>
+      .brand   { font: 700 108px 'Inter','SF Pro Display',-apple-system,'Segoe UI',Roboto,sans-serif; letter-spacing: -4px; }
+      .tagline { font: 500 26px 'Inter','SF Pro Display',-apple-system,'Segoe UI',Roboto,sans-serif; letter-spacing: -.2px; }
+      .chip    { font: 600 13px ui-monospace,'SF Mono','Cascadia Mono',Menlo,Consolas,monospace; letter-spacing: 1.4px; text-transform: uppercase; }
+    </style>
+  </defs>
+
+  <!-- base -->
+  <rect width="1280" height="640" fill="#0a0c12"/>
+
+  <!-- aurora, repositioned for taller canvas -->
+  <g filter="url(#auroraBlur)" opacity="0.95">
+    <ellipse cx="220"  cy="180" rx="360" ry="260" fill="url(#aurCyan)"/>
+    <ellipse cx="1080" cy="500" rx="460" ry="320" fill="url(#aurViolet)"/>
+    <ellipse cx="950"  cy="260" rx="340" ry="240" fill="url(#aurRose)"/>
+    <ellipse cx="780"  cy="580" rx="280" ry="220" fill="url(#aurTeal)" opacity="0.7"/>
+    <ellipse cx="380"  cy="540" rx="240" ry="200" fill="url(#aurCyan)" opacity="0.5"/>
+    <ellipse cx="1120" cy="100" rx="260" ry="140" fill="url(#aurRose)" opacity="0.45"/>
+  </g>
+
+  <rect width="1280" height="640" fill="url(#leftShade)"/>
+  <rect width="1280" height="640" fill="url(#vignette)"/>
+
+  <rect x="0.5" y="0.5" width="1279" height="639" fill="none" stroke="#1c2129" stroke-width="1"/>
+
+  <!-- brand block, vertically centred (wordmark at y=308 of 640) -->
+  <g transform="translate(108,0)">
+
+    <!-- ghost smear + chromatic aberration + crisp wordmark -->
+    <text x="0"  y="308" class="brand" fill="#5ac8fa" fill-opacity="0.20" filter="url(#hSmear)">InstantClone</text>
+    <text x="-3" y="308" class="brand" fill="#ff5aa0" fill-opacity="0.55">InstantClone</text>
+    <text x="3"  y="308" class="brand" fill="#5ac8fa" fill-opacity="0.55">InstantClone</text>
+    <text x="0"  y="308" class="brand" fill="#f5efe1">InstantClone</text>
+
+    <rect x="3" y="332" width="112" height="2" fill="#5ac8fa"/>
+
+    <text x="0" y="382" class="tagline" fill="#c0c4cc">RTMP delay buffer for streamers, plus a bit more.</text>
+
+    <g transform="translate(0,432)">
+      <g>
+        <rect x="0"   y="0" width="222" height="34" rx="17" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="111" y="22" class="chip" fill="#d8dce4" text-anchor="middle">Two-phase arm / cut</text>
+      </g>
+      <g transform="translate(236,0)">
+        <rect x="0"  y="0" width="200" height="34" rx="17" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="100" y="22" class="chip" fill="#d8dce4" text-anchor="middle">Multi-destination</text>
+      </g>
+      <g transform="translate(450,0)">
+        <rect x="0"  y="0" width="134" height="34" rx="17" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="67" y="22" class="chip" fill="#d8dce4" text-anchor="middle">OBS dock</text>
+      </g>
+      <g transform="translate(598,0)">
+        <rect x="0"  y="0" width="144" height="34" rx="17" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+        <text x="72" y="22" class="chip" fill="#d8dce4" text-anchor="middle">6 overlays</text>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds two new design assets in \`docs/\`. Doesn't touch any source code or the existing READMEs.

## What's new

- **\`docs/banner.svg\`** (1280×420) - aurora-effect hero with a VHS-style brand mark: horizontal smear ghost + cyan/rose chromatic aberration on the wordmark. Standalone asset for future use; the main README still uses \`docs/preview.svg\` as its top hero.
- **\`docs/social-preview.svg\`** (1280×640) - same composition padded to GitHub's social-preview aspect ratio (Twitter / Discord / Slack link unfurls). Slightly larger typography, extra aurora coverage filling the taller canvas, brand block at optical centre.

## Why two files

GitHub's social preview slot wants 1280×640. Uploading our 1280×420 banner directly would result in black-bar letterboxing top + bottom. The padded variant fills the canvas properly so link unfurls look on-brand.

## To use

1. Merge this PR.
2. Repo Settings → General → Social preview → Upload \`docs/social-preview.svg\`.
3. (Optional, future) swap the README hero from \`docs/preview.svg\` to \`docs/banner.svg\` if desired.

## Test plan

- [x] Both SVGs render correctly in browser (Chrome, Firefox tested)
- [x] CodeQL + CI pass (no code paths touched)
- [ ] CI green on PR