### PR TITLE
feat(behavior): auto-arm on connect + auto-activate when ready (v0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ All notable changes will land here. Format loosely follows
 
 Nothing yet.
 
+## [0.1.4] - Auto-arm + auto-activate behavior toggles
+
+Two independent System settings, both default off, for streamers who
+don't want to remember the manual arm/activate ceremony every
+session. The deliberate two-phase flow stays canonical for everyone
+else.
+
+**Auto-arm on OBS connect.** When the publisher handshake completes,
+the supervisor detects the false-to-true edge on `ingest_alive` and
+fires `arm_delay(auto_arm_delay_ms)`. Skipped if the streamer
+manually disarmed earlier in the same session (since `armed_delay_ms`
+stays at 0 until the next publisher reconnect). Designed for
+tournament players + IRL streamers who always want a safety buffer.
+
+**Auto-activate when buffer ready.** Independent toggle. The
+supervisor detects the phase transition into `ready` and fires
+`activate_delay()`. With both toggles on, every OBS-connect becomes
+a zero-touch path to live-with-delay. With only auto-activate on,
+every manual arm becomes one-step. Loses the "click when I'm ready"
+deliberate moment but matches casual-stream UX.
+
+**Default delay.** New `auto_arm_delay_ms` field tracks the last
+value the streamer manually armed at, so "default" matches habit
+without a separate UI to maintain it. `persist_delay_state` writes
+this on every non-zero arm; Disarm (`arm_delay(0)`) preserves the
+preference. Default 15s on fresh install. `sanitize_load` clamps to
+the same 10-min ceiling as the other delay fields and replaces 0
+with 15s so a hand-edited config never auto-arms at "0 seconds of
+delay" (which would be a no-op + confusing).
+
+**System tab UI.** New "Behavior" section sits at the top of the
+existing System tab grid: two checkboxes + one number input,
+descriptions below each. Step 1 of the planned multi-step System
+tab redesign; the rest follows in v0.1.6.
+
+**Tests added: 154 -> 160.** Six new regressions in `config::tests`
+and `web::tests` covering the `apply_field_str` dispatch path
+(post_config's whitelist + the match arm), the save/load round-trip
+(conditional emit + parse path), the config-lean default-omission,
+and the sanitize-load clamp + zero-fallback. Modeled after the
+existing `tracing_enabled` regression which caught the same class of
+bug between beta builds.
+
 ## [0.1.3] - VOD audio flag actually works (issue #9)
 
 **VOD audio toggle did nothing on OBS 32.** Reported as issue #9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "instantclone"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instantclone"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["s1moscs"]
 license = "GPL-3.0-only"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,25 @@ pub struct Settings {
     /// diagnostic data; toggleable in the System tab so users past the
     /// debugging phase can stop the file from growing.
     pub tracing_enabled: bool,
+    /// Behaviour: when OBS's RTMP publisher handshake completes, auto-arm
+    /// the delay at `auto_arm_delay_ms`. Off by default - the
+    /// deliberate-arm-then-activate flow stays the explicit one. Turning
+    /// this on suits streamers who *always* want delay (tournament
+    /// players, IRL streamers behind a delay-for-safety) and don't want
+    /// to remember to arm every session.
+    pub auto_arm_on_connect: bool,
+    /// Behaviour: when the buffer hits the armed amount and phase
+    /// transitions to "ready", auto-fire the activate. Independent of
+    /// `auto_arm_on_connect`; with this on, every manual arm becomes
+    /// a one-step "go live with delay" (you give up the deliberate
+    /// click-when-i'm-ready moment, you get zero-touch delayed streaming).
+    pub auto_activate_when_ready: bool,
+    /// Behaviour: target delay for `auto_arm_on_connect`. Also serves
+    /// as the pre-filled default in the manual delay input. Tracks the
+    /// last value the user manually armed at (saved every time the
+    /// streamer hits Arm with a non-zero value) so "last used" sticks
+    /// across sessions without a separate UI knob to maintain it.
+    pub auto_arm_delay_ms: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -223,6 +242,16 @@ impl Settings {
             // `tracing_enabled=true` from earlier betas are honoured
             // - only fresh installs default to off.
             tracing_enabled: false,
+            // Behaviour toggles default off so the two-phase
+            // arm/activate ceremony stays the canonical flow. Streamers
+            // who always want delay opt in once via System -> Behavior.
+            auto_arm_on_connect: false,
+            auto_activate_when_ready: false,
+            // 15 s is the same default the wizard suggests and matches
+            // the "Quick" delay profile, so a streamer who flips
+            // auto_arm_on_connect without otherwise customising lands
+            // on a familiar number.
+            auto_arm_delay_ms: 15_000,
         }
     }
 
@@ -298,6 +327,14 @@ impl Settings {
         self.armed_delay_ms = self.armed_delay_ms.min(600_000);
         self.target_delay_ms = self.target_delay_ms.min(600_000);
         self.initial_delay_ms = self.initial_delay_ms.min(600_000);
+        // auto_arm_delay_ms is the value used when auto-arm fires. Clamp
+        // to the same 10-minute ceiling; a 0 from a fresh install or a
+        // hand-edited config falls back to the 15 s default so we never
+        // auto-arm at "0 s of delay" (which would be a no-op + confusing).
+        self.auto_arm_delay_ms = self.auto_arm_delay_ms.min(600_000);
+        if self.auto_arm_delay_ms == 0 {
+            self.auto_arm_delay_ms = 15_000;
+        }
     }
 
     pub fn load_or_default(path: &Path) -> Self {
@@ -397,6 +434,20 @@ impl Settings {
         writeln!(f, "discord_webhook_url={}", self.discord_webhook_url)?;
         writeln!(f, "overlays_dir={}", self.overlays_dir.display())?;
         writeln!(f, "tracing_enabled={}", self.tracing_enabled)?;
+        // Behaviour. Only emit when non-default so a downgrade to a
+        // pre-v0.2 build that doesn't know these keys keeps parsing
+        // (apply_field's `_ => {}` arm drops keys it doesn't recognise,
+        // so this is belt-and-braces; but keeping config files lean on
+        // disk is worth a couple of conditional writes).
+        if self.auto_arm_on_connect {
+            writeln!(f, "auto_arm_on_connect=true")?;
+        }
+        if self.auto_activate_when_ready {
+            writeln!(f, "auto_activate_when_ready=true")?;
+        }
+        if self.auto_arm_delay_ms != 15_000 {
+            writeln!(f, "auto_arm_delay_ms={}", self.auto_arm_delay_ms)?;
+        }
         for (i, p) in self.profiles.iter().enumerate() {
             writeln!(f, "profile.{}.name={}", i, p.name)?;
             writeln!(f, "profile.{}.delay_ms={}", i, p.delay_ms)?;
@@ -471,6 +522,13 @@ impl Settings {
             "discord_webhook_url" => self.discord_webhook_url = value.into(),
             "overlays_dir" => self.overlays_dir = PathBuf::from(value),
             "tracing_enabled" => self.tracing_enabled = value.parse().unwrap_or(false),
+            "auto_arm_on_connect" => self.auto_arm_on_connect = value == "true",
+            "auto_activate_when_ready" => self.auto_activate_when_ready = value == "true",
+            "auto_arm_delay_ms" => {
+                if let Ok(v) = value.parse() {
+                    self.auto_arm_delay_ms = v;
+                }
+            }
             k if k.starts_with("profile.") => {
                 let rest = &k[8..];
                 if let Some(dot) = rest.find('.') {
@@ -642,7 +700,7 @@ impl Settings {
         }
         dests.push(']');
         format!(
-            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"initial_delay_ms":{id},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"destinations":{dests}}}"#,
+            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"initial_delay_ms":{id},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"destinations":{dests}}}"#,
             c = self.configured,
             ip = self.ingest_port,
             iba = self.ingest_bind_all,
@@ -657,6 +715,9 @@ impl Settings {
             ws = !self.discord_webhook_url.is_empty(),
             ov = json_str(&self.overlays_dir.display().to_string()),
             te = self.tracing_enabled,
+            aaoc = self.auto_arm_on_connect,
+            aawr = self.auto_activate_when_ready,
+            aadm = self.auto_arm_delay_ms,
             dests = dests,
         )
     }
@@ -1202,6 +1263,130 @@ mod tests {
         assert_eq!(loaded.profiles.len(), 2);
         assert_eq!(loaded.profiles[0].delay_ms, 10_000);
         assert_eq!(loaded.profiles[1].name, "Long");
+    }
+
+    #[test]
+    fn behavior_toggles_round_trip_through_save_and_load() {
+        // v0.1.4 added three Settings fields for the auto-arm /
+        // auto-activate behaviour. Save them, load them back, assert
+        // every field survives. The format::Display writer is
+        // conditional (only emits non-default values) so this also
+        // verifies the apply_field reader sees those conditional keys.
+        let path = std::env::temp_dir().join(format!(
+            "ic-test-behavior-roundtrip-{}-{}.ini",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let mut s = Settings::defaults();
+        s.auto_arm_on_connect = true;
+        s.auto_activate_when_ready = true;
+        s.auto_arm_delay_ms = 30_000;
+        // Need a destination so save() doesn't bail on the
+        // configured-but-empty path.
+        s.destinations.push(Destination {
+            id: "test".into(),
+            name: "Test".into(),
+            enabled: true,
+            platform: "twitch".into(),
+            stream_key: "test".into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+        });
+        s.save(&path).expect("save");
+
+        let loaded = Settings::load(&path).expect("load");
+        assert!(
+            loaded.auto_arm_on_connect,
+            "auto_arm_on_connect must survive round-trip"
+        );
+        assert!(
+            loaded.auto_activate_when_ready,
+            "auto_activate_when_ready must survive round-trip"
+        );
+        assert_eq!(
+            loaded.auto_arm_delay_ms, 30_000,
+            "auto_arm_delay_ms must survive round-trip"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn behavior_defaults_omitted_from_save_to_keep_config_lean() {
+        // The save writer skips default values for the behaviour keys
+        // so a fresh install's config file stays clean. Verify by
+        // saving a defaults() snapshot and grepping the file.
+        let path = std::env::temp_dir().join(format!(
+            "ic-test-behavior-defaults-{}-{}.ini",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let mut s = Settings::defaults();
+        s.destinations.push(Destination {
+            id: "test".into(),
+            name: "Test".into(),
+            enabled: true,
+            platform: "twitch".into(),
+            stream_key: "test".into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+        });
+        s.save(&path).expect("save");
+
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !text.contains("auto_arm_on_connect"),
+            "default off must not be written"
+        );
+        assert!(
+            !text.contains("auto_activate_when_ready"),
+            "default off must not be written"
+        );
+        assert!(
+            !text.contains("auto_arm_delay_ms"),
+            "default 15000 must not be written"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn behavior_sanitize_clamps_and_fills_zero() {
+        // sanitize_load() runs after load(); it should clamp the
+        // delay to 600s and replace a zero (e.g. from a hand-edited
+        // legacy config or downgrade roundtrip) with the 15 s default
+        // so auto-arm never tries to arm at 0 s (= disarm, confusing).
+        let mut s = Settings::defaults();
+
+        s.auto_arm_delay_ms = 0;
+        s.sanitize_load();
+        assert_eq!(
+            s.auto_arm_delay_ms, 15_000,
+            "zero must fall back to 15 s default"
+        );
+
+        s.auto_arm_delay_ms = 9_999_999;
+        s.sanitize_load();
+        assert_eq!(
+            s.auto_arm_delay_ms, 600_000,
+            "above ceiling must clamp to 10 min"
+        );
     }
 
     #[test]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -236,6 +236,22 @@ pub struct Controller {
     // consumer cursors; deferred until requested.
     armed_delay_ms: AtomicU32,
     target_delay_ms: AtomicU32,
+    /// "There is an outstanding arm action that hasn't been activated
+    /// yet, and the user hasn't cut since arming." Set true by
+    /// `arm_delay` when arming from a non-active state (target was 0).
+    /// Cleared by `activate_delay` on success, by `stop_delay` (cut),
+    /// and by `begin_publish` (fresh publisher session).
+    ///
+    /// Used by `supervise_egress` to gate the auto-activate-when-ready
+    /// behaviour: fires once per arm action, not once per publisher
+    /// session. So after Cut, this stays false until the next arm
+    /// action - the cut sticks. Re-arming sets it true again, so a
+    /// fresh arm (manual, profile activation, or auto-pre-arm on
+    /// reconnect) gets its own auto-activate. Live-update arms (arming
+    /// a new value while target > 0) do NOT set this, because the
+    /// streamer is already in the active state and a subsequent cut
+    /// shouldn't snap back to "active" via auto-activate.
+    auto_activate_pending: AtomicBool,
     ingest_alive: AtomicBool,
     buffer_building: AtomicBool,
     publisher_token: AtomicU64,
@@ -319,6 +335,7 @@ impl Controller {
             ring,
             armed_delay_ms: AtomicU32::new(initial_armed_delay_ms),
             target_delay_ms: AtomicU32::new(0),
+            auto_activate_pending: AtomicBool::new(false),
             ingest_alive: AtomicBool::new(false),
             buffer_building: AtomicBool::new(false),
             publisher_token: AtomicU64::new(0),
@@ -549,13 +566,26 @@ impl Controller {
     /// rewind once enough buffer has accumulated.
     pub fn arm_delay(&self, ms: u32) {
         let ms = ms.min(600_000);
+        let previous_target = self.target_delay_ms.load(Ordering::Relaxed);
         self.armed_delay_ms.store(ms, Ordering::Relaxed);
         if ms == 0 {
             // Disarm wipes target as well.
             self.target_delay_ms.store(0, Ordering::Relaxed);
-        } else if self.target_delay_ms.load(Ordering::Relaxed) > 0 {
-            // Already active → live-update what we're delivering.
+            // Disarm clears any pending auto-activate too - there's
+            // nothing to auto-activate into anymore.
+            self.auto_activate_pending.store(false, Ordering::Relaxed);
+        } else if previous_target > 0 {
+            // Already active → live-update what we're delivering. This
+            // is NOT a fresh arm action; the streamer is mid-stream and
+            // adjusting the delay value. Leave auto_activate_pending
+            // alone so a subsequent cut doesn't snap back to active via
+            // auto-activate-when-ready.
             self.target_delay_ms.store(ms, Ordering::Relaxed);
+        } else {
+            // Fresh arm: target was 0 (we were disarmed, in cut-hold,
+            // or in passthrough). Mark the auto-activate slot eligible
+            // - one shot when the buffer hits ready.
+            self.auto_activate_pending.store(true, Ordering::Relaxed);
         }
     }
 
@@ -576,6 +606,13 @@ impl Controller {
             return Err(ActivateError::BufferShort { remaining_ms });
         }
         self.target_delay_ms.store(armed, Ordering::Relaxed);
+        // Successful activate consumes the pending slot. Both manual
+        // and auto-activate share this path; either way, the slot is
+        // used up and won't re-fire until the next arm event refills
+        // it. Matters for auto-activate: after Cut, target drops to 0
+        // and phase reverts to "ready", which would otherwise look
+        // like a fresh "*->ready" transition to the supervisor.
+        self.auto_activate_pending.store(false, Ordering::Relaxed);
         Ok(armed)
     }
 
@@ -584,6 +621,18 @@ impl Controller {
     /// behavior the streamer described.
     pub fn stop_delay(&self) {
         self.target_delay_ms.store(0, Ordering::Relaxed);
+        // Cut consumes the pending slot. The streamer made a
+        // deliberate "go live without delay" decision; auto-activate
+        // mustn't override it. The slot stays consumed until the next
+        // arm event (re-arm at a non-zero value with target = 0)
+        // refills it.
+        self.auto_activate_pending.store(false, Ordering::Relaxed);
+    }
+
+    /// Snapshot read of the auto-activate-pending slot. Used by the
+    /// supervisor to gate the auto-activate-when-ready behaviour.
+    pub fn auto_activate_pending(&self) -> bool {
+        self.auto_activate_pending.load(Ordering::Relaxed)
     }
 
     pub fn armed_delay_ms(&self) -> u32 {
@@ -788,6 +837,11 @@ impl Controller {
         // trim_older_than cannot recover from this either: its cutoff
         // also saturates to 0 against the new session's low current_ts.
         self.ring.clear();
+
+        // Defensive: clear any stale auto-activate slot. A fresh
+        // publisher session is a clean slate; the prior session's
+        // arm-or-not state shouldn't leak into the new one.
+        self.auto_activate_pending.store(false, Ordering::Relaxed);
 
         // Bump token so any prior egress reader knows it's stale.
         let token = self.publisher_token.fetch_add(1, Ordering::SeqCst) + 1;
@@ -2087,6 +2141,113 @@ mod tests {
         assert_eq!(h.ctrl.armed_delay_ms(), 2_000, "armed must survive stop");
         // With buffer still full, phase is `ready` again - not `idle`.
         assert_eq!(h.ctrl.phase(), "ready");
+    }
+
+    // ── auto-activate-pending state machine ────────────────────────
+    //
+    // The v0.1.4 "Cut delay didn't stick" bug: auto-activate-when-ready
+    // fired again immediately after the user hit Cut, because phase
+    // reverted from "active" back to "ready" (buffer still full,
+    // armed_delay_ms still set) and the edge detector treated that as
+    // a fresh "*->ready" transition. Fix: Controller tracks an
+    // auto_activate_pending slot - set on arm-from-non-active, cleared
+    // on activate-success, cut, and begin_publish. Supervisor now
+    // reads that slot instead of trying to infer state from phase
+    // transitions. These tests pin the four edges of that machine.
+
+    #[test]
+    fn arm_from_disarmed_sets_auto_activate_pending() {
+        let h = harness(0);
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "fresh controller must start clean"
+        );
+        h.ctrl.arm_delay(5_000);
+        assert!(
+            h.ctrl.auto_activate_pending(),
+            "arm from target=0 must arm the pending slot"
+        );
+    }
+
+    #[test]
+    fn activate_consumes_auto_activate_pending() {
+        let h = harness(0);
+        h.ctrl.arm_delay(2_000);
+        feed_seconds(&h.ctrl, 0, 3, 30);
+        assert!(h.ctrl.auto_activate_pending());
+        h.ctrl.activate_delay().expect("buffer is full");
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "successful activate must consume the pending slot"
+        );
+    }
+
+    #[test]
+    fn cut_consumes_auto_activate_pending_so_it_sticks() {
+        // The bug-of-record: without this clear, the supervisor sees
+        // phase revert to "ready" after cut and re-fires activate_delay.
+        let h = harness(0);
+        h.ctrl.arm_delay(2_000);
+        feed_seconds(&h.ctrl, 0, 3, 30);
+        h.ctrl.activate_delay().unwrap();
+        // Slot was already cleared by activate. Re-arm to set it again,
+        // then exercise the cut path explicitly. (arm_delay live-update
+        // path - target > 0, so this DOESN'T set pending; we have to
+        // simulate the post-cut state.)
+        h.ctrl.stop_delay(); // cut: target -> 0, pending -> false
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "cut must keep pending false so the supervisor doesn't re-activate"
+        );
+        // Now re-arm (target=0 so this IS a fresh arm event) and verify
+        // the slot refills - so the NEXT arm cycle auto-activates as
+        // expected. This is the "auto-activate works after re-arming"
+        // half of the user-requested semantics.
+        h.ctrl.arm_delay(3_000);
+        assert!(
+            h.ctrl.auto_activate_pending(),
+            "re-arm from cut-hold state must refill the pending slot"
+        );
+    }
+
+    #[test]
+    fn live_update_arm_does_not_set_auto_activate_pending() {
+        // When the streamer is already active and adjusts the armed
+        // value (slider drag, profile click during live), that's a
+        // live-update, not a fresh arm. The pending slot must stay
+        // false so a subsequent cut doesn't snap back to active via
+        // auto-activate-when-ready.
+        let h = harness(0);
+        h.ctrl.arm_delay(2_000);
+        feed_seconds(&h.ctrl, 0, 3, 30);
+        h.ctrl.activate_delay().unwrap();
+        assert!(!h.ctrl.auto_activate_pending(), "consumed by activate");
+
+        // Live-update arm: target > 0, so this should NOT set pending.
+        h.ctrl.arm_delay(2_500);
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "live-update arm during active must not arm the pending slot"
+        );
+
+        // Cut now → pending stays false → no auto-re-activate.
+        h.ctrl.stop_delay();
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "cut after live-update arm must NOT magically refill pending"
+        );
+    }
+
+    #[test]
+    fn disarm_clears_auto_activate_pending() {
+        let h = harness(0);
+        h.ctrl.arm_delay(2_000);
+        assert!(h.ctrl.auto_activate_pending());
+        h.ctrl.arm_delay(0); // disarm
+        assert!(
+            !h.ctrl.auto_activate_pending(),
+            "disarm clears pending - there's nothing to auto-activate into"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,15 +306,18 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
     let initial_webhook = { rx.borrow().discord_webhook_url.clone() };
     ctrl.update_webhook(initial_webhook);
 
-    // Behaviour-toggle state machine. Both auto-arm and auto-activate
-    // fire on edge transitions (false -> true ingest_alive, "*" -> "ready"
-    // phase) so a snapshot-every-2-seconds supervisor doesn't re-arm
-    // every tick. Initialised pessimistically (assume the worst-case
-    // prior state) so the first iteration's transition detection is
-    // accurate even on a fresh process start where ingest is already
-    // live from a tight relaunch.
+    // Behaviour-toggle state. Auto-arm uses the `prev_ingest_alive`
+    // edge detector (fires once per publisher session, on the false ->
+    // true transition). Auto-activate reads the controller's
+    // `auto_activate_pending` slot which fires once per arm action -
+    // arm sets it, cut clears it. See Controller::auto_activate_pending
+    // for the full state semantics.
+    //
+    // Initialised pessimistically (assume the worst-case prior state)
+    // so the first iteration's transition detection is accurate even
+    // on a fresh process start where ingest is already live from a
+    // tight relaunch.
     let mut prev_ingest_alive = ctrl.ingest_alive();
-    let mut prev_phase: &'static str = ctrl.phase();
 
     loop {
         // Snapshot the current desired destinations.
@@ -492,14 +495,14 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
         // users had to toggle a destination off+on to get the supervisor
         // to look at the world again.) Settings changes still preempt
         // the wait via `rx.changed()` for instant response.
-        // ── Behaviour: auto-arm on connect ─────────────────────────
+        // ── Behaviour: auto-pre-arm on stream start ───────────────
         //
         // Edge-detect ingest_alive going false -> true. That's the
-        // moment OBS's publisher handshake just completed (begin_publish
-        // sets ingest_alive to true at the end). If the user has
-        // auto-arm enabled AND we're not already armed (so the
-        // streamer's manual disarm earlier in the same session sticks),
-        // fire arm_delay with the persisted last-used delay.
+        // moment OBS's publisher handshake just completed. Pre-arm
+        // fires once per publisher session (the edge condition
+        // self-limits) and only when nothing is already armed (so a
+        // user who pre-armed and then manually disarmed in the same
+        // session doesn't get auto-rearmed).
         {
             let s = rx.borrow();
             let armed_now = ctrl.armed_delay_ms();
@@ -509,9 +512,13 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
                 && armed_now == 0
                 && s.auto_arm_delay_ms > 0
             {
+                // arm_delay sets target=0 -> non-active, so it'll also
+                // flip Controller's auto_activate_pending slot true.
+                // That means a pre-arm + auto-activate combo auto-goes-
+                // live without the streamer touching anything.
                 ctrl.arm_delay(s.auto_arm_delay_ms);
                 ctrl.log(format!(
-                    "auto-arm: OBS connected -> armed {} s of delay",
+                    "pre-arm: stream started -> armed {} s of delay",
                     s.auto_arm_delay_ms / 1000
                 ));
             }
@@ -519,20 +526,26 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
 
         // ── Behaviour: auto-activate when ready ────────────────────
         //
-        // Edge-detect phase entering "ready" (buffer just filled past
-        // the armed amount). If the user has auto-activate enabled AND
-        // we haven't already activated (target_delay_ms == 0 means we
-        // haven't transitioned to active yet), fire activate_delay.
-        // The activate_delay() call has its own buffer-sufficiency
-        // guard, so a race where the phase string says "ready" but the
-        // buffer drained slightly below the threshold in the meantime
-        // is handled safely (returns an Err we ignore).
+        // Fires once per arm action, gated by Controller's
+        // `auto_activate_pending` slot (set by arm_delay when arming
+        // from a non-active state, cleared by activate_delay /
+        // stop_delay / begin_publish). This makes Cut actually stick:
+        // after the streamer cuts, the slot is clear and the next
+        // phase-reverts-to-ready tick doesn't snap us back to active.
+        // A subsequent re-arm refills the slot, so the NEXT arm cycle
+        // still auto-activates as expected.
+        //
+        // Phase check stays as the readiness signal - we fire when the
+        // buffer's actually full enough, not the instant the slot is
+        // pending. If the slot is pending but activate_delay returns
+        // BufferShort (a transient race where phase reports ready but
+        // the stricter buffer check disagrees), we quietly skip; the
+        // slot stays true so the next tick retries.
         {
-            let phase_now = ctrl.phase();
             let s = rx.borrow();
-            if phase_now == "ready"
-                && prev_phase != "ready"
+            if ctrl.auto_activate_pending()
                 && s.auto_activate_when_ready
+                && ctrl.phase() == "ready"
                 && ctrl.target_delay_ms() == 0
             {
                 match ctrl.activate_delay() {
@@ -543,11 +556,12 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
                     Err(_) => {
                         // Phase said "ready" but activate_delay's
                         // stricter buffer check disagreed. Quietly skip;
-                        // next 2 s tick re-evaluates.
+                        // next 2 s tick re-evaluates. The pending slot
+                        // stays set (activate_delay didn't reach the
+                        // Ok arm) so the retry actually happens.
                     }
                 }
             }
-            prev_phase = phase_now;
         }
         prev_ingest_alive = ingest_alive;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,16 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
     let initial_webhook = { rx.borrow().discord_webhook_url.clone() };
     ctrl.update_webhook(initial_webhook);
 
+    // Behaviour-toggle state machine. Both auto-arm and auto-activate
+    // fire on edge transitions (false -> true ingest_alive, "*" -> "ready"
+    // phase) so a snapshot-every-2-seconds supervisor doesn't re-arm
+    // every tick. Initialised pessimistically (assume the worst-case
+    // prior state) so the first iteration's transition detection is
+    // accurate even on a fresh process start where ingest is already
+    // live from a tight relaunch.
+    let mut prev_ingest_alive = ctrl.ingest_alive();
+    let mut prev_phase: &'static str = ctrl.phase();
+
     loop {
         // Snapshot the current desired destinations.
         let desired: Vec<(config::Destination, String)> = { rx.borrow().active_destinations() };
@@ -482,6 +492,65 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
         // users had to toggle a destination off+on to get the supervisor
         // to look at the world again.) Settings changes still preempt
         // the wait via `rx.changed()` for instant response.
+        // ── Behaviour: auto-arm on connect ─────────────────────────
+        //
+        // Edge-detect ingest_alive going false -> true. That's the
+        // moment OBS's publisher handshake just completed (begin_publish
+        // sets ingest_alive to true at the end). If the user has
+        // auto-arm enabled AND we're not already armed (so the
+        // streamer's manual disarm earlier in the same session sticks),
+        // fire arm_delay with the persisted last-used delay.
+        {
+            let s = rx.borrow();
+            let armed_now = ctrl.armed_delay_ms();
+            if !prev_ingest_alive
+                && ingest_alive
+                && s.auto_arm_on_connect
+                && armed_now == 0
+                && s.auto_arm_delay_ms > 0
+            {
+                ctrl.arm_delay(s.auto_arm_delay_ms);
+                ctrl.log(format!(
+                    "auto-arm: OBS connected -> armed {} s of delay",
+                    s.auto_arm_delay_ms / 1000
+                ));
+            }
+        }
+
+        // ── Behaviour: auto-activate when ready ────────────────────
+        //
+        // Edge-detect phase entering "ready" (buffer just filled past
+        // the armed amount). If the user has auto-activate enabled AND
+        // we haven't already activated (target_delay_ms == 0 means we
+        // haven't transitioned to active yet), fire activate_delay.
+        // The activate_delay() call has its own buffer-sufficiency
+        // guard, so a race where the phase string says "ready" but the
+        // buffer drained slightly below the threshold in the meantime
+        // is handled safely (returns an Err we ignore).
+        {
+            let phase_now = ctrl.phase();
+            let s = rx.borrow();
+            if phase_now == "ready"
+                && prev_phase != "ready"
+                && s.auto_activate_when_ready
+                && ctrl.target_delay_ms() == 0
+            {
+                match ctrl.activate_delay() {
+                    Ok(ms) => ctrl.log(format!(
+                        "auto-activate: buffer ready -> live with {} s delay",
+                        ms / 1000
+                    )),
+                    Err(_) => {
+                        // Phase said "ready" but activate_delay's
+                        // stricter buffer check disagreed. Quietly skip;
+                        // next 2 s tick re-evaluates.
+                    }
+                }
+            }
+            prev_phase = phase_now;
+        }
+        prev_ingest_alive = ingest_alive;
+
         let periodic_wake = tokio::time::sleep(Duration::from_secs(2));
         tokio::select! {
             ch = rx.changed() => {

--- a/src/web.rs
+++ b/src/web.rs
@@ -1267,6 +1267,9 @@ async fn post_config(
                 | "initial_delay_ms"
                 | "overlays_dir"
                 | "tracing_enabled"
+                | "auto_arm_on_connect"
+                | "auto_activate_when_ready"
+                | "auto_arm_delay_ms"
         ) {
             apply_field_str(&mut new_settings, k, v);
         }
@@ -1548,9 +1551,21 @@ fn persist_delay_state(
     let mut ns = settings.borrow().clone();
     let armed = ctrl.armed_delay_ms();
     let target = ctrl.target_delay_ms();
-    if ns.armed_delay_ms != armed || ns.target_delay_ms != target {
+    // Track "last manually armed delay" in auto_arm_delay_ms so the
+    // System -> Behavior auto-arm picks up wherever the streamer last
+    // explicitly armed. Only updates on non-zero arm so a Disarm
+    // (arm_delay(0)) doesn't wipe the preference.
+    let new_auto_arm = if armed > 0 { Some(armed) } else { None };
+    let auto_arm_changed = match new_auto_arm {
+        Some(v) => ns.auto_arm_delay_ms != v,
+        None => false,
+    };
+    if ns.armed_delay_ms != armed || ns.target_delay_ms != target || auto_arm_changed {
         ns.armed_delay_ms = armed;
         ns.target_delay_ms = target;
+        if let Some(v) = new_auto_arm {
+            ns.auto_arm_delay_ms = v;
+        }
         let _ = ns.save(cfg_path);
         let _ = settings.send(ns);
     }
@@ -2152,6 +2167,17 @@ fn apply_field_str(s: &mut Settings, key: &str, value: &str) {
             let on = !matches!(value, "" | "false" | "0" | "off");
             s.tracing_enabled = on;
         }
+        "auto_arm_on_connect" => {
+            s.auto_arm_on_connect = !matches!(value, "" | "false" | "0" | "off");
+        }
+        "auto_activate_when_ready" => {
+            s.auto_activate_when_ready = !matches!(value, "" | "false" | "0" | "off");
+        }
+        "auto_arm_delay_ms" => {
+            if let Ok(v) = value.parse() {
+                s.auto_arm_delay_ms = v;
+            }
+        }
         _ => {}
     }
 }
@@ -2737,6 +2763,49 @@ mod tests {
         assert!(s.tracing_enabled);
         apply_field_str(&mut s, "tracing_enabled", "false");
         assert!(!s.tracing_enabled);
+    }
+
+    // ── Behavior toggles: dispatch path tests ─────────────────────
+    //
+    // Same regression class as the tracing_enabled test above. The
+    // post_config form-key whitelist plus apply_field_str's match arm
+    // both have to know each new behaviour key, or settings silently
+    // round-trip to the default. These tests pin both sides for the
+    // v0.1.4 auto-arm fields.
+
+    #[test]
+    fn apply_field_str_persists_auto_arm_on_connect() {
+        let mut s = crate::config::Settings::defaults();
+        assert!(!s.auto_arm_on_connect);
+        apply_field_str(&mut s, "auto_arm_on_connect", "true");
+        assert!(s.auto_arm_on_connect);
+        apply_field_str(&mut s, "auto_arm_on_connect", "false");
+        assert!(!s.auto_arm_on_connect);
+        apply_field_str(&mut s, "auto_arm_on_connect", "on");
+        assert!(s.auto_arm_on_connect, "checkbox 'on' must read as truthy");
+    }
+
+    #[test]
+    fn apply_field_str_persists_auto_activate_when_ready() {
+        let mut s = crate::config::Settings::defaults();
+        assert!(!s.auto_activate_when_ready);
+        apply_field_str(&mut s, "auto_activate_when_ready", "true");
+        assert!(s.auto_activate_when_ready);
+        apply_field_str(&mut s, "auto_activate_when_ready", "off");
+        assert!(!s.auto_activate_when_ready);
+    }
+
+    #[test]
+    fn apply_field_str_parses_auto_arm_delay_ms() {
+        let mut s = crate::config::Settings::defaults();
+        // defaults() seeds at 15 s; replace via the form-key path.
+        assert_eq!(s.auto_arm_delay_ms, 15_000);
+        apply_field_str(&mut s, "auto_arm_delay_ms", "30000");
+        assert_eq!(s.auto_arm_delay_ms, 30_000);
+        // Garbage values are ignored (parse failure leaves the field
+        // alone) so a hand-edited form doesn't reset to zero.
+        apply_field_str(&mut s, "auto_arm_delay_ms", "not-a-number");
+        assert_eq!(s.auto_arm_delay_ms, 30_000);
     }
 
     // ── OBS multitrack-config proxy helpers ──────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -1263,14 +1263,14 @@ input,select,textarea{font-family:inherit;color:inherit}
   <div class="sys-grid">
     <section class="sys-section">
       <div class="ic-label">Behavior</div>
-      <div class="tab-sub">How InstantClone reacts when OBS connects and when the buffer fills.</div>
+      <div class="tab-sub">How InstantClone reacts when OBS starts streaming and when the buffer fills.</div>
       <div style="margin-top:14px;display:flex;flex-direction:column;gap:14px">
         <div style="display:flex;align-items:flex-start;gap:14px">
           <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
             <input type="checkbox" id="s-auto-arm" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
-              <div style="font-weight:600">Auto-arm on OBS connect</div>
-              <div class="tab-sub" style="margin-top:2px">Start filling the delay buffer the moment OBS publishes. Useful if you always stream with delay.</div>
+              <div style="font-weight:600">Pre-arm delay on stream start</div>
+              <div class="tab-sub" style="margin-top:2px">Start filling the delay buffer the moment OBS starts streaming. Useful if you always stream with delay.</div>
             </div>
           </label>
         </div>
@@ -1279,14 +1279,14 @@ input,select,textarea{font-family:inherit;color:inherit}
             <input type="checkbox" id="s-auto-act" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
               <div style="font-weight:600">Auto-activate when buffer ready</div>
-              <div class="tab-sub" style="margin-top:2px">Skip the manual "Activate" step. Loses the deliberate go-live moment but is the right call for casual streams.</div>
+              <div class="tab-sub" style="margin-top:2px">Skip the manual "Activate" step. Fires every time you arm (manual, profile, or pre-arm). Cut still sticks - the next arm re-enables it.</div>
             </div>
           </label>
         </div>
         <div style="display:flex;align-items:center;gap:14px">
           <div style="flex:1">
             <div style="font-weight:600">Default delay</div>
-            <div class="tab-sub" style="margin-top:2px">Used by auto-arm. Also tracks the last value you manually armed at.</div>
+            <div class="tab-sub" style="margin-top:2px">Used by pre-arm. Also tracks the last value you manually armed at.</div>
           </div>
           <div style="display:flex;align-items:center;gap:6px">
             <input id="s-auto-arm-secs" class="ic-input mono" type="number" min="1" max="600" style="width:80px;text-align:right">

--- a/web/index.html
+++ b/web/index.html
@@ -1262,6 +1262,40 @@ input,select,textarea{font-family:inherit;color:inherit}
   <div class="restart-banner hidden" id="restart-banner">⚠ Buffer size or path changed. Restart the app for it to take effect.</div>
   <div class="sys-grid">
     <section class="sys-section">
+      <div class="ic-label">Behavior</div>
+      <div class="tab-sub">How InstantClone reacts when OBS connects and when the buffer fills.</div>
+      <div style="margin-top:14px;display:flex;flex-direction:column;gap:14px">
+        <div style="display:flex;align-items:flex-start;gap:14px">
+          <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
+            <input type="checkbox" id="s-auto-arm" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
+            <div>
+              <div style="font-weight:600">Auto-arm on OBS connect</div>
+              <div class="tab-sub" style="margin-top:2px">Start filling the delay buffer the moment OBS publishes. Useful if you always stream with delay.</div>
+            </div>
+          </label>
+        </div>
+        <div style="display:flex;align-items:flex-start;gap:14px">
+          <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
+            <input type="checkbox" id="s-auto-act" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
+            <div>
+              <div style="font-weight:600">Auto-activate when buffer ready</div>
+              <div class="tab-sub" style="margin-top:2px">Skip the manual "Activate" step. Loses the deliberate go-live moment but is the right call for casual streams.</div>
+            </div>
+          </label>
+        </div>
+        <div style="display:flex;align-items:center;gap:14px">
+          <div style="flex:1">
+            <div style="font-weight:600">Default delay</div>
+            <div class="tab-sub" style="margin-top:2px">Used by auto-arm. Also tracks the last value you manually armed at.</div>
+          </div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <input id="s-auto-arm-secs" class="ic-input mono" type="number" min="1" max="600" style="width:80px;text-align:right">
+            <span class="muted" style="font-size:12px">s</span>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="sys-section">
       <div class="ic-label">Network</div>
       <div class="form-row tight">
         <div><span class="ic-label">Ingest port</span><input id="s-iport" class="ic-input mono" type="number" min="1" max="65535"></div>
@@ -2275,6 +2309,10 @@ async function loadConfig(){
     $('s-ovdir').value = c.overlays_dir || '';
     $('ov-dir-display').textContent = c.overlays_dir || 'overlays/';
     $('s-trace').checked = c.tracing_enabled !== false;
+    // Behavior section
+    $('s-auto-arm').checked = !!c.auto_arm_on_connect;
+    $('s-auto-act').checked = !!c.auto_activate_when_ready;
+    $('s-auto-arm-secs').value = Math.round((c.auto_arm_delay_ms || 15000) / 1000);
     // OBS panel
     $('obs-srv').textContent = c.obs_url;
     if ($('wiz-obs-srv')) $('wiz-obs-srv').textContent = c.obs_url;
@@ -2588,6 +2626,9 @@ async function saveSettings(){
     discord_webhook_url:$('s-webhook').value.trim(),
     overlays_dir:$('s-ovdir').value.trim(),
     tracing_enabled:$('s-trace').checked?'true':'false',
+    auto_arm_on_connect:$('s-auto-arm').checked?'true':'false',
+    auto_activate_when_ready:$('s-auto-act').checked?'true':'false',
+    auto_arm_delay_ms:String(Math.max(1, Math.min(600, parseInt($('s-auto-arm-secs').value,10)||15)) * 1000),
   });
   const j = await(await fetch('/config',{method:'POST',body})).json();
   if (j.ok){


### PR DESCRIPTION
First behavior toggles in the System tab. Both default off the deliberate two-phase arm/activate ceremony stays canonical. Streamers who *always* want delay (tournament players, IRL streamers, casual sessions) get a one-click opt-in.

## Three new Settings fields

```rust
pub auto_arm_on_connect: bool,           // default false
pub auto_activate_when_ready: bool,      // default false
pub auto_arm_delay_ms: u32,              // default 15_000, tracks last manually-armed value
```

Independent because:
- Auto-arm without auto-activate: buffer fills on every OBS connect, streamer still hits Activate when ready.
- Auto-activate without auto-arm: every manual arm becomes a one-step "go live with delay."
- Both on: zero-touch delayed streaming from OBS connect to live.

## Wiring

**Supervisor edge detection** (\`main.rs::supervise_egress\`): tracks \`prev_ingest_alive\` + \`prev_phase\` across loop iterations. On \`false→true\` ingest_alive transition + auto-arm enabled + armed_delay_ms == 0, fires \`arm_delay\`. On \`*→ready\` phase transition + auto-activate enabled + target_delay_ms == 0, fires \`activate_delay\`. The 2s tick is fine for both — auto-arm fires within ~2s of OBS connect, auto-activate within ~2s of the buffer filling.

**Last-armed tracking** (\`web.rs::persist_delay_state\`): every non-zero arm bumps \`auto_arm_delay_ms\`. Disarm (\`arm_delay(0)\`) preserves the preference so the streamer's habit persists across sessions.

**Sanitise on load** (\`config.rs::sanitize_load\`): clamps to 600s ceiling + replaces 0 with 15s so a hand-edited config or downgrade round-trip never causes auto-arm to fire at \"0 seconds of delay.\"

## UI

System tab gains a Behavior section at the top of the grid:

Same visual conventions as the rest of the System tab.

## Tests added: 154 → 160

Six new regressions across \`config::tests\` and \`web::tests\`:
1. \`apply_field_str_persists_auto_arm_on_connect\`
2. \`apply_field_str_persists_auto_activate_when_ready\`
3. \`apply_field_str_parses_auto_arm_delay_ms\` (incl. garbage-input rejection)
4. \`behavior_toggles_round_trip_through_save_and_load\`
5. \`behavior_defaults_omitted_from_save_to_keep_config_lean\`
6. \`behavior_sanitize_clamps_and_fills_zero\`

Modeled after the existing \`apply_field_str_persists_tracing_enabled_value\` regression - same class of bug (silently-dropped form key when whitelist + match-arm fall out of sync between settings additions).

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [x] \`cargo test --release\` shows 160/160 passing
- [ ] CI: \`test + clippy\`, \`e2e\`, \`analyze (rust)\` all green
- [ ] Manual: enable auto-arm + auto-activate, start OBS streaming, watch buffer fill + auto-activate at default 15s
- [ ] Manual: manually disarm mid-stream, verify auto-arm doesn't re-fire until next OBS publisher reconnect

## Notes: Being tested ATM. Might need name change to better suggest what it really does.