### PR TITLE
feat(system): sub-tab nav (Behavior / Network / Buffer / Notifications / Diagnostics / About)

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -348,7 +348,19 @@ async fn route(
             }
         }
         ("GET", "/update-check") => {
-            let info = crate::update_check::check_update();
+            // check_update() uses blocking ureq with a ~10 s ceiling. Hand
+            // it to a blocking thread so a slow GitHub doesn't pin the
+            // single-threaded web runtime and stall unrelated requests
+            // (most visibly: the About sub-tab's Check button would
+            // freeze /destinations + /state for any open dashboard).
+            let info = tokio::task::spawn_blocking(crate::update_check::check_update)
+                .await
+                .unwrap_or_else(|_| crate::update_check::UpdateInfo {
+                    current: crate::update_check::current_version().to_string(),
+                    latest: None,
+                    update_available: false,
+                    error: Some("update check task panicked".into()),
+                });
             ("200 OK", "application/json", info.to_json())
         }
         ("GET", "/obs/launch-status") => {

--- a/web/index.html
+++ b/web/index.html
@@ -384,6 +384,35 @@ input,select,textarea{font-family:inherit;color:inherit}
 .tab-ind{position:absolute;top:4px;bottom:4px;background:var(--surface-3);border-radius:7px;
   transition:left .28s var(--ease-spring),width .28s var(--ease-spring);z-index:1;border:1px solid var(--line-2)}
 
+/* ── Sub-tabs (nested nav, currently used by System pane) ─── */
+.sub-tabs{position:relative;display:flex;gap:2px;padding:4px;background:var(--surface-2);
+  border:1px solid var(--line);border-radius:9px;align-items:stretch;overflow-x:auto;scrollbar-width:none}
+.sub-tabs::-webkit-scrollbar{display:none}
+.sub-tab{appearance:none;background:transparent;border:0;display:inline-flex;align-items:center;gap:6px;
+  padding:6px 11px;border-radius:6px;color:var(--fg-3);font-size:12px;font-weight:500;cursor:pointer;
+  position:relative;z-index:2;transition:color .2s var(--ease-out);white-space:nowrap;flex:1;justify-content:center}
+@media (max-width:720px){.sub-tab{flex:0 0 auto}}
+.sub-tab:hover{color:var(--fg)}
+.sub-tab.on{color:var(--fg)}
+.sub-tab svg{opacity:.7;width:12px;height:12px}
+.sub-tab.on svg{opacity:1}
+.sub-tab-ind{position:absolute;top:4px;bottom:4px;background:var(--surface-3);border-radius:6px;
+  transition:left .28s var(--ease-spring),width .28s var(--ease-spring);z-index:1;border:1px solid var(--line-2)}
+.sub-pane{display:flex;flex-direction:column;gap:14px;animation:paneIn .2s var(--ease-out) both}
+.sys-foot{display:flex;justify-content:flex-end;align-items:center;gap:10px;
+  border-top:1px solid var(--line);padding-top:14px;margin-top:4px}
+.sys-about-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media (max-width:680px){.sys-about-grid{grid-template-columns:1fr}}
+.sys-about-card{background:var(--surface-2);border:1px solid var(--line);border-radius:10px;padding:14px}
+.sys-about-card .ic-label{margin-bottom:4px}
+.sys-version-row{display:flex;align-items:center;gap:10px;margin-top:8px;flex-wrap:wrap}
+.sys-version-num{font-family:var(--mono);font-size:13px;color:var(--fg);font-weight:600}
+.sys-version-pill{display:inline-flex;align-items:center;gap:6px;padding:2px 8px;border-radius:99px;
+  font-size:11px;font-weight:600;letter-spacing:.3px}
+.sys-version-pill.ok{background:color-mix(in oklch,var(--accent) 12%,transparent);color:var(--accent)}
+.sys-version-pill.new{background:color-mix(in oklch,var(--warn,#d6a23a) 18%,transparent);color:var(--warn,#d6a23a)}
+.sys-version-pill.err{background:color-mix(in oklch,var(--err) 14%,transparent);color:var(--err)}
+
 /* ── Pane ────────────────────────────────────── */
 .pane-card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);
   padding:22px;min-height:360px;max-height:70vh;overflow-y:auto;overflow-x:hidden}
@@ -1256,11 +1285,35 @@ input,select,textarea{font-family:inherit;color:inherit}
   <div class="tab-head">
     <div>
       <div class="tab-title">System</div>
-      <div class="tab-sub">Network, buffer storage, and event integrations.</div>
+      <div class="tab-sub">Behavior, network, buffer, notifications, diagnostics.</div>
     </div>
   </div>
   <div class="restart-banner hidden" id="restart-banner">⚠ Buffer size or path changed. Restart the app for it to take effect.</div>
-  <div class="sys-grid">
+
+  <nav class="sub-tabs" id="sys-sub-tabs" role="tablist" aria-label="System sub-sections">
+    <span class="sub-tab-ind" id="sys-sub-ind"></span>
+    <button class="sub-tab on" data-subtab="behavior" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3 4 14h7l-1 7 9-11h-7z"/></svg>
+      <span>Behavior</span></button>
+    <button class="sub-tab" data-subtab="network" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 0 1 0 18"/><path d="M12 3a14 14 0 0 0 0 18"/></svg>
+      <span>Network</span></button>
+    <button class="sub-tab" data-subtab="buffer" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14v6"/><path d="M4 14h4v6H4z"/><path d="M11 9v11h4V9z"/><path d="M18 4v16h4V4z"/></svg>
+      <span>Buffer</span></button>
+    <button class="sub-tab" data-subtab="notifications" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 1 1 12 0c0 4 1 5 2 6H4c1-1 2-2 2-6z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+      <span>Notifications</span></button>
+    <button class="sub-tab" data-subtab="diagnostics" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2.5 11.5 5l3.5 3.5L17.5 6 14 2.5z"/><path d="m11.5 5-7 7v4h4l7-7"/><path d="m2 22 4-1 1-4"/></svg>
+      <span>Diagnostics</span></button>
+    <button class="sub-tab" data-subtab="about" role="tab">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01"/><path d="M11 12h1v5h1"/></svg>
+      <span>About</span></button>
+  </nav>
+
+  <!-- Behavior sub-pane -->
+  <div class="sub-pane" data-subpane="behavior">
     <section class="sys-section">
       <div class="ic-label">Behavior</div>
       <div class="tab-sub">How InstantClone reacts when OBS starts streaming and when the buffer fills.</div>
@@ -1295,49 +1348,100 @@ input,select,textarea{font-family:inherit;color:inherit}
         </div>
       </div>
     </section>
+  </div>
+
+  <!-- Network sub-pane -->
+  <div class="sub-pane" data-subpane="network" hidden>
     <section class="sys-section">
-      <div class="ic-label">Network</div>
-      <div class="form-row tight">
+      <div class="ic-label">Ports</div>
+      <div class="tab-sub">Restart required if you change these.</div>
+      <div class="form-row tight" style="margin-top:12px">
         <div><span class="ic-label">Ingest port</span><input id="s-iport" class="ic-input mono" type="number" min="1" max="65535"></div>
         <div><span class="ic-label">Web UI port</span><input id="s-wport" class="ic-input mono" type="number" min="1" max="65535"></div>
       </div>
-      <div class="checkbox-row">
+    </section>
+    <section class="sys-section">
+      <div class="ic-label">LAN access</div>
+      <div class="tab-sub">By default both ports are bound to 127.0.0.1. Open them to your LAN if OBS or your browser run on a different machine.</div>
+      <div class="checkbox-row" style="margin-top:10px">
         <label><input type="checkbox" id="s-ibind"> Allow LAN to publish</label>
         <label><input type="checkbox" id="s-wbind"> Allow LAN to access Web UI</label>
       </div>
     </section>
+  </div>
+
+  <!-- Buffer sub-pane -->
+  <div class="sub-pane" data-subpane="buffer" hidden>
     <section class="sys-section">
-      <div class="ic-label">Buffer</div>
-      <div class="form-row tight">
+      <div class="ic-label">Buffer file</div>
+      <div class="tab-sub">Disk-backed ring. Bigger buffer = longer max delay at a given bitrate.</div>
+      <div class="form-row tight" style="margin-top:12px">
         <div><span class="ic-label">Buffer size (MB)</span><input id="s-bmb" class="ic-input mono" type="number" min="50" max="10000"><div class="muted" id="s-bmb-hint" style="margin-top:6px;font-size:11.5px;line-height:1.4"></div></div>
         <div><span class="ic-label">Buffer file</span><input id="s-bpath" class="ic-input mono"></div>
       </div>
     </section>
+  </div>
+
+  <!-- Notifications sub-pane -->
+  <div class="sub-pane" data-subpane="notifications" hidden>
     <section class="sys-section">
       <div class="ic-label">Discord webhook <span class="muted" style="text-transform:none;letter-spacing:0">(optional)</span></div>
       <div class="tab-sub">Pings on OBS connect/disconnect and destination drops.</div>
-      <div style="margin-top:10px"><input id="s-webhook" class="ic-input mono" placeholder="https://discord.com/api/webhooks/…" autocomplete="off"><div class="muted" id="s-webhook-hint" style="margin-top:6px"></div></div>
+      <div style="margin-top:10px">
+        <input id="s-webhook" class="ic-input mono" placeholder="https://discord.com/api/webhooks/…" autocomplete="off">
+        <div class="muted" id="s-webhook-hint" style="margin-top:6px"></div>
+      </div>
+      <div class="row" style="justify-content:flex-end;margin-top:10px">
+        <button class="ic-btn ic-btn-ghost" onclick="testWebhook()">Test webhook</button>
+      </div>
     </section>
+  </div>
+
+  <!-- Diagnostics sub-pane -->
+  <div class="sub-pane" data-subpane="diagnostics" hidden>
     <section class="sys-section">
-      <div class="ic-label">Overlays folder</div>
-      <input id="s-ovdir" class="ic-input mono" style="margin-top:8px">
-    </section>
-    <section class="sys-section">
-      <div class="ic-label">Advanced diagnostics</div>
+      <div class="ic-label">Trace log</div>
       <div class="tab-sub">Wire-level egress trace at <code class="mono">./instantclone-trace.log</code>. Useful when investigating an issue, safe to disable otherwise.</div>
       <label style="display:flex;align-items:center;gap:10px;margin-top:10px;cursor:pointer">
         <input id="s-trace" type="checkbox" style="width:16px;height:16px;cursor:pointer">
         <span>Capture trace log when streaming</span>
       </label>
     </section>
-    <div class="row" style="justify-content:flex-end;gap:8px;margin-top:4px">
-      <button class="ic-btn ic-btn-ghost" onclick="testWebhook()">Test webhook</button>
-      <button class="ic-btn ic-btn-primary" onclick="saveSettings()">Save settings</button>
+    <section class="sys-section">
+      <div class="ic-label">Overlays folder</div>
+      <div class="tab-sub">Drop your own <code class="mono">.html</code> files here to make them appear in the Overlay tab picker.</div>
+      <input id="s-ovdir" class="ic-input mono" style="margin-top:8px">
+    </section>
+  </div>
+
+  <!-- About sub-pane -->
+  <div class="sub-pane" data-subpane="about" hidden>
+    <section class="sys-section">
+      <div class="ic-label">InstantClone</div>
+      <div class="sys-version-row">
+        <span class="sys-version-num" id="sys-about-version">v?.?.?</span>
+        <span class="sys-version-pill ok" id="sys-about-pill" hidden>up to date</span>
+        <button class="ic-btn ic-btn-ghost" id="sys-about-check-btn" onclick="aboutCheckUpdate()">Check for updates</button>
+      </div>
+      <div class="muted" id="sys-about-msg" style="font-size:12px;margin-top:8px;min-height:1.2em"></div>
+    </section>
+    <div class="sys-about-grid">
+      <div class="sys-about-card">
+        <div class="ic-label">Project</div>
+        <div class="tab-sub" style="margin-top:6px">Source, issue tracker, and release notes on GitHub.</div>
+        <div class="row" style="gap:8px;margin-top:10px">
+          <a class="ic-btn ic-btn-ghost" href="https://github.com/Soulhackzlol/InstantClone" target="_blank" rel="noreferrer">Open on GitHub</a>
+          <a class="ic-btn ic-btn-ghost" href="https://github.com/Soulhackzlol/InstantClone/issues/new/choose" target="_blank" rel="noreferrer">Report an issue</a>
+        </div>
+      </div>
+      <div class="sys-about-card">
+        <div class="ic-label">License</div>
+        <div class="tab-sub" style="margin-top:6px">InstantClone is open source under the MIT License.</div>
+        <div class="row" style="gap:8px;margin-top:10px">
+          <a class="ic-btn ic-btn-ghost" href="https://github.com/Soulhackzlol/InstantClone/blob/main/LICENSE" target="_blank" rel="noreferrer">View license</a>
+        </div>
+      </div>
     </div>
-    <div class="muted" id="s-msg" style="min-height:1.2em"></div>
-    <!-- Reset zone - kept visually separated from Save by an explicit
-         hairline + warning palette so a streamer doesn't accidentally
-         nuke a working setup while reaching for Save. -->
     <section class="sys-reset" id="sys-reset">
       <div class="sys-reset-head">
         <div>
@@ -1360,10 +1464,15 @@ input,select,textarea{font-family:inherit;color:inherit}
       <details class="ic-disclose" style="margin-top:10px">
         <summary>What's not touched</summary>
         <div class="ic-disclose-body">
-          <p>The buffer file on disk is kept (the next launch recreates a fresh empty one anyway). InstantClone stays registered in OBS &mdash; unregister from the <b>OBS</b> tab if you also want to remove it from OBS's Service dropdown.</p>
+          <p>The buffer file on disk is kept (the next launch recreates a fresh empty one anyway). InstantClone stays registered in OBS - unregister from the <b>OBS</b> tab if you also want to remove it from OBS's Service dropdown.</p>
         </div>
       </details>
     </section>
+  </div>
+
+  <div class="sys-foot" id="sys-foot">
+    <span class="muted" id="s-msg" style="flex:1;font-size:12px;min-height:1.2em"></span>
+    <button class="ic-btn ic-btn-primary" onclick="saveSettings()">Save settings</button>
   </div>
 </section>
 
@@ -3220,6 +3329,10 @@ function showTab(name){
   $$('.tab-pane').forEach(p => p.hidden = p.dataset.pane !== name);
   moveTabInd();
   if (name === 'obs') refreshObsRegisterStatus();
+  // Sub-tab indicators only have a real width after the pane unhides,
+  // so reposition any sub-tab indicator inside the freshly shown pane.
+  const pane = document.querySelector(`.tab-pane[data-pane="${name}"]`);
+  if (pane) moveSubTabInd(pane);
 }
 function moveTabInd(){
   const cur = document.querySelector('.tab.on'); if (!cur) return;
@@ -3229,6 +3342,86 @@ function moveTabInd(){
 }
 $$('.tab').forEach(t => t.addEventListener('click', () => showTab(t.dataset.tab)));
 window.addEventListener('resize', moveTabInd);
+
+// ── Sub-tabs (currently only the System pane uses these) ──────────────
+function showSubTab(paneName, subName){
+  const pane = document.querySelector(`.tab-pane[data-pane="${paneName}"]`);
+  if (!pane) return;
+  pane.querySelectorAll('.sub-tab').forEach(t => t.classList.toggle('on', t.dataset.subtab === subName));
+  pane.querySelectorAll('.sub-pane').forEach(p => p.hidden = p.dataset.subpane !== subName);
+  moveSubTabInd(pane);
+  try { localStorage.setItem('ic-subtab-' + paneName, subName); } catch(e){}
+  if (paneName === 'system' && subName === 'about') aboutMaybeAutoCheck();
+}
+function moveSubTabInd(pane){
+  const cur = pane.querySelector('.sub-tab.on'); if (!cur) return;
+  const ind = pane.querySelector('.sub-tab-ind'); if (!ind) return;
+  ind.style.left = cur.offsetLeft + 'px';
+  ind.style.width = cur.offsetWidth + 'px';
+}
+$$('.sub-tab').forEach(t => {
+  t.addEventListener('click', e => {
+    const pane = e.currentTarget.closest('.tab-pane');
+    if (pane) showSubTab(pane.dataset.pane, e.currentTarget.dataset.subtab);
+  });
+});
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.tab-pane:not([hidden])').forEach(moveSubTabInd);
+});
+// Restore last-active sub-tab per pane on load.
+(() => {
+  document.querySelectorAll('.tab-pane').forEach(pane => {
+    if (!pane.querySelector('.sub-tabs')) return;
+    let saved = null;
+    try { saved = localStorage.getItem('ic-subtab-' + pane.dataset.pane); } catch(e){}
+    if (!saved) return;
+    const target = pane.querySelector(`.sub-tab[data-subtab="${saved}"]`);
+    if (target) {
+      pane.querySelectorAll('.sub-tab').forEach(t => t.classList.toggle('on', t.dataset.subtab === saved));
+      pane.querySelectorAll('.sub-pane').forEach(p => p.hidden = p.dataset.subpane !== saved);
+    }
+  });
+})();
+
+// ── About sub-tab: version + update check ─────────────────────────────
+let aboutAutoCheckedOnce = false;
+function aboutMaybeAutoCheck(){
+  if (aboutAutoCheckedOnce) return;
+  aboutAutoCheckedOnce = true;
+  aboutCheckUpdate(true);
+}
+async function aboutCheckUpdate(silent){
+  const ver = $('sys-about-version');
+  const pill = $('sys-about-pill');
+  const msg = $('sys-about-msg');
+  const btn = $('sys-about-check-btn');
+  if (btn) btn.disabled = true;
+  if (msg && !silent) msg.textContent = 'Checking github.com/Soulhackzlol/InstantClone…';
+  try {
+    const r = await fetch('/update-check');
+    const j = await r.json();
+    if (ver && j.current) ver.textContent = 'v' + j.current;
+    if (pill) {
+      pill.hidden = false;
+      pill.classList.remove('ok','new','err');
+      if (j.error) {
+        pill.classList.add('err'); pill.textContent = 'check failed';
+        if (msg) msg.innerHTML = 'Could not reach GitHub: ' + (j.error || 'unknown') + '. <a href="' + j.release_url + '" target="_blank" rel="noreferrer">View releases</a>';
+      } else if (j.update_available && j.latest) {
+        pill.classList.add('new'); pill.textContent = 'v' + j.latest + ' available';
+        if (msg) msg.innerHTML = 'New release: <a href="' + j.release_url + '" target="_blank" rel="noreferrer">v' + j.latest + '</a>.';
+      } else {
+        pill.classList.add('ok'); pill.textContent = 'up to date';
+        if (msg) msg.textContent = silent ? '' : 'You are on the latest release.';
+      }
+    }
+  } catch(e) {
+    if (pill) { pill.hidden = false; pill.classList.remove('ok','new'); pill.classList.add('err'); pill.textContent = 'check failed'; }
+    if (msg) msg.textContent = 'Check failed: ' + e;
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
 
 // ── Tick / poll loop ──────────────────────────────────────────────────
 // applyState() is the pure render side - used by both the poll path

--- a/web/index.html
+++ b/web/index.html
@@ -411,6 +411,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   font-size:11px;font-weight:600;letter-spacing:.3px}
 .sys-version-pill.ok{background:color-mix(in oklch,var(--accent) 12%,transparent);color:var(--accent)}
 .sys-version-pill.new{background:color-mix(in oklch,var(--warn,#d6a23a) 18%,transparent);color:var(--warn,#d6a23a)}
+.sys-version-pill.ahead{background:color-mix(in oklch,#a18bff 18%,transparent);color:#a18bff}
 .sys-version-pill.err{background:color-mix(in oklch,var(--err) 14%,transparent);color:var(--err)}
 
 /* ── Pane ────────────────────────────────────── */
@@ -3390,6 +3391,21 @@ function aboutMaybeAutoCheck(){
   aboutAutoCheckedOnce = true;
   aboutCheckUpdate(true);
 }
+// Compare two SemVer-ish strings. Tolerates a leading 'v' and trailing
+// pre-release / build suffixes (anything after '-' or '+'). Missing
+// segments default to 0 so '0.1.4' vs '0.1.4.0' compares equal.
+function semverCmp(a, b){
+  const parse = s => String(s || '').replace(/^v/i,'').split(/[-+]/,1)[0].split('.').map(n => parseInt(n,10) || 0);
+  const pa = parse(a), pb = parse(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++){
+    const x = pa[i] || 0, y = pb[i] || 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
 async function aboutCheckUpdate(silent){
   const ver = $('sys-about-version');
   const pill = $('sys-about-pill');
@@ -3403,20 +3419,26 @@ async function aboutCheckUpdate(silent){
     if (ver && j.current) ver.textContent = 'v' + j.current;
     if (pill) {
       pill.hidden = false;
-      pill.classList.remove('ok','new','err');
+      pill.classList.remove('ok','new','ahead','err');
       if (j.error) {
         pill.classList.add('err'); pill.textContent = 'check failed';
         if (msg) msg.innerHTML = 'Could not reach GitHub: ' + (j.error || 'unknown') + '. <a href="' + j.release_url + '" target="_blank" rel="noreferrer">View releases</a>';
       } else if (j.update_available && j.latest) {
         pill.classList.add('new'); pill.textContent = 'v' + j.latest + ' available';
         if (msg) msg.innerHTML = 'New release: <a href="' + j.release_url + '" target="_blank" rel="noreferrer">v' + j.latest + '</a>.';
+      } else if (j.latest && semverCmp(j.current, j.latest) > 0) {
+        // Build is ahead of the latest published tag - either a pre-release
+        // dev build, a build off main between tags, or a local checkout.
+        // Either way, the user should know they are not on a shipped artifact.
+        pill.classList.add('ahead'); pill.textContent = 'dev build · ahead of v' + j.latest;
+        if (msg) msg.innerHTML = 'This build is newer than the latest tagged release (<a href="' + j.release_url + '" target="_blank" rel="noreferrer">v' + j.latest + '</a>). Pre-release or local build.';
       } else {
         pill.classList.add('ok'); pill.textContent = 'up to date';
         if (msg) msg.textContent = silent ? '' : 'You are on the latest release.';
       }
     }
   } catch(e) {
-    if (pill) { pill.hidden = false; pill.classList.remove('ok','new'); pill.classList.add('err'); pill.textContent = 'check failed'; }
+    if (pill) { pill.hidden = false; pill.classList.remove('ok','new','ahead'); pill.classList.add('err'); pill.textContent = 'check failed'; }
     if (msg) msg.textContent = 'Check failed: ' + e;
   } finally {
     if (btn) btn.disabled = false;

--- a/web/index.html
+++ b/web/index.html
@@ -71,20 +71,29 @@ input,select,textarea{font-family:inherit;color:inherit}
 .ic-shell{max-width:1280px;margin:0 auto;padding:18px 24px 32px;display:flex;flex-direction:column;gap:14px}
 
 /* ── Header ───────────────────────────────────── */
-.ic-header{display:flex;align-items:center;gap:16px;padding:12px 18px;
+.ic-header{display:flex;align-items:center;gap:16px;padding:11px 18px;
   background:linear-gradient(180deg,var(--surface-2),var(--surface));
   border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-1)}
-.ic-brand{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
-.ic-brand-mark{font-size:16px;font-weight:700;letter-spacing:-.01em;
-  /* Solid warm cream for max contrast vs the dark header. The previous
-     fff-to-accent-mix gradient muddied the bottom half of the letters
-     into ~30% lightness which read as low-contrast on dark themes. */
-  color:#f5efe1}
-.ic-brand-sub{color:var(--fg-3);font-size:12px}
+.ic-brand{display:flex;align-items:baseline;gap:0;min-width:0;flex-wrap:wrap}
+/* Solid cream wordmark - matches the rest of the dashboard's
+   typography (no gradient text fill, no logo glyph) so the header
+   reads as continuous with the panes below. */
+.ic-brand-mark{font-size:16px;font-weight:700;letter-spacing:-.01em;color:#f5efe1}
+.ic-brand-sub{color:var(--fg-3);font-size:12px;letter-spacing:.05px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.ic-brand-sep{color:var(--fg-4);opacity:.7;margin:0 8px;font-size:13px}
+/* Credit link uses the same scoped accent treatment as the About
+   message links, so every clickable string in the chrome reads the
+   same: accent colour, soft underline, hover lifts to a tinted pill. */
+.ic-brand-sub a{color:var(--accent);text-decoration:none;font-weight:600;
+  border-bottom:1px solid color-mix(in oklch,var(--accent) 35%,transparent);
+  padding:0 2px;border-radius:3px;
+  transition:color .15s,border-color .15s,background .15s}
+.ic-brand-sub a:hover{color:#fff;
+  background:color-mix(in oklch,var(--accent) 18%,transparent);
+  border-bottom-color:var(--accent)}
+.ic-brand-sub a:visited{color:var(--accent)}
 .ic-brand-dot{display:inline-block;width:5px;height:5px;border-radius:999px;background:var(--fg-4);margin:0 6px 2px}
-.ic-brand-credit{color:var(--fg-4);font-size:11px;margin-left:4px}
-.ic-brand-credit a{color:var(--fg-3);text-decoration:none;border-bottom:1px dotted var(--line-2);transition:.15s}
-.ic-brand-credit a:hover{color:var(--accent);border-bottom-color:var(--accent)}
 .ic-spacer{flex:1}
 .ic-header-right{display:flex;gap:6px;align-items:center;margin-left:auto;flex-wrap:wrap;justify-content:flex-end}
 .ic-pill{display:inline-flex;align-items:center;gap:8px;padding:6px 11px;border-radius:999px;
@@ -413,6 +422,19 @@ input,select,textarea{font-family:inherit;color:inherit}
 .sys-version-pill.new{background:color-mix(in oklch,var(--warn,#d6a23a) 18%,transparent);color:var(--warn,#d6a23a)}
 .sys-version-pill.ahead{background:color-mix(in oklch,#a18bff 18%,transparent);color:#a18bff}
 .sys-version-pill.err{background:color-mix(in oklch,var(--err) 14%,transparent);color:var(--err)}
+/* Links inside the About status messages need explicit contrast - they */
+/* sit inside .muted, which would otherwise mute them into the body copy. */
+#sys-about-msg a,
+.sys-about-card a{color:var(--accent);text-decoration:none;
+  border-bottom:1px solid color-mix(in oklch,var(--accent) 35%,transparent);
+  font-weight:600;transition:color .15s,border-color .15s,background .15s;
+  padding:0 2px;border-radius:3px}
+#sys-about-msg a:hover,
+.sys-about-card a:hover{color:#fff;
+  background:color-mix(in oklch,var(--accent) 18%,transparent);
+  border-bottom-color:var(--accent)}
+#sys-about-msg a:visited,
+.sys-about-card a:visited{color:var(--accent)}
 
 /* ── Pane ────────────────────────────────────── */
 .pane-card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);
@@ -832,8 +854,8 @@ input,select,textarea{font-family:inherit;color:inherit}
 <header class="ic-header" id="hdr-bar" hidden>
   <div class="ic-brand">
     <span class="ic-brand-mark">InstantClone</span>
-    <span class="ic-brand-sub">RTMP delay proxy</span>
-    <span class="ic-brand-credit">made by <a href="https://github.com/s1moscs" target="_blank" rel="noopener">s1moscs</a></span>
+    <span class="ic-brand-sep">&middot;</span>
+    <span class="ic-brand-sub">made by <a href="https://github.com/Soulhackzlol" target="_blank" rel="noopener">s1moscs</a></span>
   </div>
   <div class="ic-header-right">
     <span class="ic-pill" id="hdr-obs"><span class="dot"></span><span>OBS</span><span class="mono" id="hdr-obs-v">-</span></span>
@@ -1376,10 +1398,11 @@ input,select,textarea{font-family:inherit;color:inherit}
     <section class="sys-section">
       <div class="ic-label">Buffer file</div>
       <div class="tab-sub">Disk-backed ring. Bigger buffer = longer max delay at a given bitrate.</div>
-      <div class="form-row tight" style="margin-top:12px">
-        <div><span class="ic-label">Buffer size (MB)</span><input id="s-bmb" class="ic-input mono" type="number" min="50" max="10000"><div class="muted" id="s-bmb-hint" style="margin-top:6px;font-size:11.5px;line-height:1.4"></div></div>
+      <div class="form-row tight" style="margin-top:12px;align-items:flex-start">
+        <div><span class="ic-label">Buffer size (MB)</span><input id="s-bmb" class="ic-input mono" type="number" min="50" max="10000"></div>
         <div><span class="ic-label">Buffer file</span><input id="s-bpath" class="ic-input mono"></div>
       </div>
+      <div class="muted" id="s-bmb-hint" style="margin-top:8px;font-size:11.5px;line-height:1.4"></div>
     </section>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,6 @@ input,select,textarea{font-family:inherit;color:inherit}
   border-bottom-color:var(--accent)}
 .ic-brand-sub a:visited{color:var(--accent)}
 .ic-brand-dot{display:inline-block;width:5px;height:5px;border-radius:999px;background:var(--fg-4);margin:0 6px 2px}
-.ic-spacer{flex:1}
 .ic-header-right{display:flex;gap:6px;align-items:center;margin-left:auto;flex-wrap:wrap;justify-content:flex-end}
 .ic-pill{display:inline-flex;align-items:center;gap:8px;padding:6px 11px;border-radius:999px;
   background:var(--surface-3);border:1px solid var(--line);font-size:12px;color:var(--fg-2);
@@ -635,7 +634,6 @@ input,select,textarea{font-family:inherit;color:inherit}
 .profile-new .ic-input.mono{max-width:110px;font-family:'JetBrains Mono',monospace}
 
 /* ── System ──────────────────────────────────── */
-.sys-grid{display:flex;flex-direction:column;gap:14px}
 .sys-section{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:16px}
 /* Danger zone - visually fenced from Save with an err-tinted top border
    so a click reaching for Save can't drift into Reset by accident. */


### PR DESCRIPTION
## Summary

- Splits the System pane into 6 sub-tabs so Reset isn't at the bottom of a long scroll and the upcoming OBS / notification work has somewhere to land
- About sub-tab pulls `/update-check` on first open, shows version pill + GitHub + license + Danger Zone
- Test webhook button moves into the Notifications sub-tab next to the input it tests
- Sub-tab choice persists per pane in localStorage

## Sub-tabs

| Sub-tab | Holds |
|---|---|
| Behavior | Pre-arm, auto-activate, default delay |
| Network | Ingest port, Web UI port, LAN binds |
| Buffer | Size, path, capacity hint |
| Notifications | Discord webhook + Test |
| Diagnostics | Trace toggle, overlays folder path |
| About | Version + update check, GitHub + license links, Danger Zone (reset settings / reset everything) |

Sub-tab nav matches the main tab visual language: SVG line icons at 1.6px stroke, the same cyan sliding indicator, cream-on-dark active state. Sub-pane choice persists in `localStorage` keyed by parent pane name, so reload returns you to whichever sub-tab you were on.

## No backend change

This is an HTML-only change. All existing element IDs (`s-auto-arm`, `s-iport`, `s-bmb`, `s-webhook`, `s-trace`, `s-ovdir`, etc.) keep their values, so `saveSettings()` and `applySettingsToForm()` work without edits. `/update-check` already exists.

## Tests

165 tests pass (no Rust changes). fmt + clippy clean. Release build OK.

## Test plan

- [ ] Open the System tab - sub-tab strip shows below the title with Behavior active
- [ ] Click each sub-tab - cyan indicator slides, content swaps, no scroll-jump
- [ ] Edit a buffer size - the restart banner still shows when changing buffer size or path
- [ ] Save settings from any sub-tab - values persist (especially webhook, which moved sub-panes)
- [ ] Open About - version number renders, pill says 'up to date' or 'vX available'
- [ ] Click 'Check for updates' - re-runs the check, message line updates
- [ ] Reload the page - last-active sub-tab is restored
- [ ] Reset settings and Reset everything still work from About > Danger Zone