### PR TITLE
ci(release): make rust-cache restore-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Restore-only: release runs on tags (rare), so populating the cache
+          # buys nothing and the save step is flaky on Windows runners (tar of
+          # a large release target/), which red-X'd the job after publishing.
+          save-if: false
       - name: fmt check
         run: cargo fmt --all -- --check
       - name: clippy
@@ -39,6 +44,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Restore-only: release runs on tags (rare), so populating the cache
+          # buys nothing and the save step is flaky on Windows runners (tar of
+          # a large release target/), which red-X'd the job after publishing.
+          save-if: false
 
       - name: build release
         run: cargo build --release


### PR DESCRIPTION
The `v0.1.5` release published successfully, but the `build` job showed a red X: the `Swatinem/rust-cache@v2` **cache-save** post-step (tar of a large release `target/`) failed on the Windows runner *after* the release was already created and assets uploaded.

Fix: set `save-if: false` on both rust-cache steps in `release.yml`. The release workflow runs only on tags, so populating the cache buys nothing; restore-only avoids the flaky save step and keeps future release runs green.

No effect on the release artifacts or the build/test gates - only the post-job cache housekeeping is skipped.