### PR TITLE
Local test sink destination: rehearse the whole pipeline with zero risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes will land here. Format loosely follows
 
 ## [Unreleased]
 
+### Local test sink destination
+
+**Try the whole pipeline with zero risk.** The in-binary RTMP sink
+(`instantclone sink`, until now a CLI-only tool) is available as a
+destination: pick **Local test sink** in the Destinations tab and
+InstantClone spawns its own tiny receiver on this PC and streams to it.
+No platform account, no stream key, nothing leaves your machine - test
+arm / activate / cut (and vertical) end to end before touching a real
+key.
+
+- The managed child process follows the destination's lifecycle: spawned
+  when a sink destination is enabled (one child serves any number of
+  them), killed when the last one is disabled or removed, reaped and
+  respawned if it dies, and taken down with the app. It lives on fixed
+  high ports (rtmp :19350, player :19351) so manual `instantclone sink`
+  runs on the documented defaults (:1936/:1937) never collide with it.
+- The destination card gets a **▶ Watch output** link to the sink's
+  built-in live player - watch exactly what a platform would receive,
+  delay and cuts included.
+- The sink's own log lines (`publish accepted`, the 1 Hz stat windows)
+  are forwarded into the dashboard's Logs tab, so the feedback loop is
+  visible without a terminal.
+- The destination form hides the stream-key field for it (any key works)
+  and explains the feature inline; the first-run wizard deliberately
+  does not offer it - the wizard wires your real platform.
+
 ### "Cut after this airs" - scheduled safe cut
 
 **Stop counting your delay down in your head.** With a delay active, a new

--- a/README.es.md
+++ b/README.es.md
@@ -49,7 +49,7 @@ Cuando ya lo tenía hecho, las piezas que de verdad quería eran: una activació
 <tr><td><b>RSS inactivo</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Hilos</b></td><td align="right"><code>1 tokio + 1 bandeja</code></td></tr>
 <tr><td><b>Deps en runtime</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>234 / 234</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>235 / 235</code></td></tr>
 </table>
 
 </td>
@@ -155,7 +155,7 @@ Seguramente desaparezca tu chat de twitch en OBS porque OBS detecta que no "vas 
 </table>
 
 > [!TIP]
-> Haz fan-out de un único feed de OBS a varios destinos a la vez. Añade Twitch, YouTube y un endpoint RTMP personalizado, activa cada uno por separado y mira su bitrate en vivo por destino.
+> Haz fan-out de un único feed de OBS a varios destinos a la vez. Añade Twitch, YouTube y un endpoint RTMP personalizado, activa cada uno por separado y mira su bitrate en vivo por destino. También hay un destino **Local test sink**: InstantClone lanza su propio receptor diminuto en tu PC y emite hacia él, para ensayar armar/activar/cortar de punta a punta - sin stream key, sin que nada salga de tu máquina, y con un enlace **Watch output** que muestra exactamente lo que recibiría una plataforma.
 
 > [!TIP]
 > **Vertical gratis.** Activa el **Formato Dual** de Twitch (Enhanced Broadcasting) en OBS y pon el **Formato de stream** de cualquier destino que no sea Twitch en **Vertical**: InstantClone reutiliza el lienzo 9:16 que OBS ya genera para Twitch y lo envía a YouTube Shorts, Kick móvil o cualquier RTMP personalizado, sin codificación extra. El vertical solo fluye mientras el Formato Dual está activo; hasta entonces el destino muestra "Esperando Formato Dual" y nada más se ve afectado. (Twitch gestiona ambos lienzos por su cuenta, así que ahí la opción se oculta.)
@@ -281,7 +281,7 @@ cargo build --release
 
 Sin npm, sin submódulos, sin SDK de plataforma. El HTML del panel se minifica y comprime con gzip en tiempo de compilación desde `build.rs` (usa `flate2`, solo build-dep) y se embebe en el binario; en runtime se sirve con `Content-Encoding: gzip`.
 
-`cargo test --release` cubre la máquina de estados (`arm → preparing → ready → active → cut`), detección de IDR en AVC + Enhanced RTMP, codec AMF0 incluyendo Strict Array (la `fourCcList` de Enhanced-RTMP) + guardia de recursión, round-trip de settings, evicción del ring-buffer con protección de lecturas en vuelo, parsing HTTP, política CSRF, pre-flight de puertos, la negociación de contenido `accepts_gzip`, la caché de cabeceras de secuencia por-pista de Enhanced Broadcasting + selección de tags consciente del TrackId, el audio multi-pista de Enhanced-RTMP (pista de VOD de Twitch), el filtro de IDR de pista primaria para que los cortes con EB no glitcheen las escaleras, el parseo de orientación del SPS para la selección de lienzo vertical (9:16), la resolución de `user.ini` / `global.ini` en OBS 32, el parcheado de `services.json` de OBS, el parser de releases de GitHub + comparador SemVer-ish para el chequeo de actualizaciones, la implementación propia de SHA-256 (vectores NIST), el lector/escritor del flujo de chunks RTMP (cabeceras fmt 0-3, timestamps extendidos, fragmentación entre chunks, control Set-Chunk-Size / Window-Ack en banda, y guardias ante entrada malformada), la máquina de estados del corte programado ("cortar cuando esto salga"), y la descarga + verificación de checksum + intercambio del exe en disco de la auto-actualización. 234 tests, todos en verde.
+`cargo test --release` cubre la máquina de estados (`arm → preparing → ready → active → cut`), detección de IDR en AVC + Enhanced RTMP, codec AMF0 incluyendo Strict Array (la `fourCcList` de Enhanced-RTMP) + guardia de recursión, round-trip de settings, evicción del ring-buffer con protección de lecturas en vuelo, parsing HTTP, política CSRF, pre-flight de puertos, la negociación de contenido `accepts_gzip`, la caché de cabeceras de secuencia por-pista de Enhanced Broadcasting + selección de tags consciente del TrackId, el audio multi-pista de Enhanced-RTMP (pista de VOD de Twitch), el filtro de IDR de pista primaria para que los cortes con EB no glitcheen las escaleras, el parseo de orientación del SPS para la selección de lienzo vertical (9:16), la resolución de `user.ini` / `global.ini` en OBS 32, el parcheado de `services.json` de OBS, el parser de releases de GitHub + comparador SemVer-ish para el chequeo de actualizaciones, la implementación propia de SHA-256 (vectores NIST), el lector/escritor del flujo de chunks RTMP (cabeceras fmt 0-3, timestamps extendidos, fragmentación entre chunks, control Set-Chunk-Size / Window-Ack en banda, y guardias ante entrada malformada), la máquina de estados del corte programado ("cortar cuando esto salga"), y la descarga + verificación de checksum + intercambio del exe en disco de la auto-actualización. 235 tests, todos en verde.
 
 <br/>
 
@@ -289,7 +289,7 @@ Sin npm, sin submódulos, sin SDK de plataforma. El HTML del panel se minifica y
 
 ## Estado
 
-**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 234 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
+**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 235 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
 
 **Lo que está sólido**
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once it existed, the parts I'd actually wanted ended up in: a real two-phase arm
 <tr><td><b>Idle RSS</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Threads</b></td><td align="right"><code>1 tokio + 1 tray</code></td></tr>
 <tr><td><b>Runtime deps</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>234 / 234</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>235 / 235</code></td></tr>
 </table>
 
 </td>
@@ -155,7 +155,7 @@ Click **Start Streaming**. The OBS pill in InstantClone turns green. Your real T
 </table>
 
 > [!TIP]
-> Fan out one OBS feed to several destinations at once. Add Twitch, YouTube, and a custom RTMP endpoint, toggle each on independently, watch their per-destination bitrate live.
+> Fan out one OBS feed to several destinations at once. Add Twitch, YouTube, and a custom RTMP endpoint, toggle each on independently, watch their per-destination bitrate live. There is also a **Local test sink** destination: InstantClone spawns its own tiny receiver on your PC and streams to it, so you can rehearse arm/activate/cut end to end - stream key not needed, nothing leaves your machine, and a **Watch output** link shows exactly what a platform would receive.
 
 > [!TIP]
 > **Go vertical for free.** Turn on Twitch **Dual Format** (Enhanced Broadcasting) in OBS and set any non-Twitch destination's **Stream format** to **Vertical** - InstantClone reuses the 9:16 canvas OBS is already making for Twitch and sends it to YouTube Shorts, Kick mobile, or any custom RTMP target, with no extra encoding. Vertical only flows while Dual Format is on; until then the destination shows "Waiting for Dual Format" and nothing else is affected. (Twitch handles both canvases itself, so the option is hidden there.)
@@ -281,7 +281,7 @@ cargo build --release
 
 No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzipped at build time by `build.rs` (uses `flate2`, build-only) and embedded into the binary; at runtime it's served with `Content-Encoding: gzip`.
 
-`cargo test --release` covers the state machine (`arm → preparing → ready → active → cut`), AVC + Enhanced RTMP IDR detection, AMF0 codec including Strict Array (Enhanced-RTMP `fourCcList`) + recursion guard, settings round-trip, ring-buffer eviction with in-flight-read protection, HTTP parsing, CSRF policy, port pre-flight, `accepts_gzip` content negotiation, Enhanced Broadcasting per-track seq-header cache + TrackId-aware tag selection, Enhanced-RTMP multi-track audio (Twitch's VOD audio track), primary-track IDR gate so EB cuts don't pixel-glitch ladder rungs, SPS orientation parsing for vertical-canvas (9:16) selection, OBS 32 `user.ini` / legacy `global.ini` path resolution, the OBS services.json patcher, the GitHub releases update-check parser + SemVer-ish comparator, the hand-rolled SHA-256 (NIST vectors), the RTMP chunk-stream reader/writer (fmt 0-3 headers, extended timestamps, cross-chunk fragmentation, in-band Set-Chunk-Size / Window-Ack control, and malformed-input guards), the scheduled safe-cut ("cut after this airs") state machine, and the self-update download + checksum-verify + on-disk exe swap. 234 tests, all green.
+`cargo test --release` covers the state machine (`arm → preparing → ready → active → cut`), AVC + Enhanced RTMP IDR detection, AMF0 codec including Strict Array (Enhanced-RTMP `fourCcList`) + recursion guard, settings round-trip, ring-buffer eviction with in-flight-read protection, HTTP parsing, CSRF policy, port pre-flight, `accepts_gzip` content negotiation, Enhanced Broadcasting per-track seq-header cache + TrackId-aware tag selection, Enhanced-RTMP multi-track audio (Twitch's VOD audio track), primary-track IDR gate so EB cuts don't pixel-glitch ladder rungs, SPS orientation parsing for vertical-canvas (9:16) selection, OBS 32 `user.ini` / legacy `global.ini` path resolution, the OBS services.json patcher, the GitHub releases update-check parser + SemVer-ish comparator, the hand-rolled SHA-256 (NIST vectors), the RTMP chunk-stream reader/writer (fmt 0-3 headers, extended timestamps, cross-chunk fragmentation, in-band Set-Chunk-Size / Window-Ack control, and malformed-input guards), the scheduled safe-cut ("cut after this airs") state machine, and the self-update download + checksum-verify + on-disk exe swap. 235 tests, all green.
 
 <br/>
 
@@ -289,7 +289,7 @@ No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzippe
 
 ## Status
 
-**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 234 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
+**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 235 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
 
 **What's solid**
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,15 @@ const MAX_PROFILES: usize = 256;
 /// hand-edited config sets `buffer_mb=0`.
 const MIN_BUFFER_MB: u64 = 50;
 
+/// Ports for the built-in "Local test sink" destination (platform
+/// `"sink"`). The egress supervisor spawns `instantclone sink` as a
+/// child process on these when such a destination is enabled. Fixed
+/// (not configurable) on purpose: the sink's own CLI defaults (1936 /
+/// 1937) are what people use for MANUAL sink runs and the e2e script,
+/// so the managed instance stays out of their way on a high pair.
+pub const SINK_RTMP_PORT: u16 = 19350;
+pub const SINK_WEB_PORT: u16 = 19351;
+
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub ingest_port: u16,
@@ -92,7 +101,9 @@ pub struct Destination {
     pub id: String,   // stable across renames; UI key
     pub name: String, // user label ("Twitch", "Backup", etc.)
     pub enabled: bool,
-    pub platform: String, // "twitch" | "youtube" | "kick" | "trovo" | "restream" | "custom"
+    // "twitch" | "youtube" | "kick" | "trovo" | "restream" | "custom"
+    // | "sink" (the built-in local test sink - see SINK_RTMP_PORT)
+    pub platform: String,
     pub stream_key: String,
     pub custom_egress_url: String, // used when platform == "custom"
     /// Only meaningful when platform == "twitch". Empty = auto-route via
@@ -154,6 +165,14 @@ impl Destination {
     /// rules as the top-level single-dest path: if a custom URL already has
     /// app+key, the key field is ignored; otherwise the key is appended.
     pub fn egress_url(&self) -> Option<String> {
+        // Local test sink: fully self-contained. The URL is fixed (the
+        // supervisor spawns the matching `instantclone sink` child on
+        // SINK_RTMP_PORT) and the stream key is ignored - the sink
+        // accepts any key, so requiring one would just add a fake
+        // field to fill in.
+        if self.platform == "sink" {
+            return Some(format!("rtmp://127.0.0.1:{}/live/test", SINK_RTMP_PORT));
+        }
         if self.platform == "custom" {
             let base = non_empty(&self.custom_egress_url)?
                 .trim_end_matches('/')
@@ -811,6 +830,8 @@ impl Settings {
                     errs.push(format!("{}: custom URL must start with rtmp://", d.name));
                     continue;
                 }
+            } else if d.platform == "sink" {
+                // Self-contained: fixed local URL, no key needed.
             } else if platform_base(&d.platform).is_none() {
                 errs.push(format!("{}: unknown platform '{}'", d.name, d.platform));
                 continue;
@@ -1122,6 +1143,38 @@ mod tests {
         assert!(is_path_safe(&PathBuf::from("./instantclone.buf")));
         assert!(is_path_safe(&PathBuf::from("D:\\streams\\buffer.bin")));
         assert!(is_path_safe(&PathBuf::from("/home/user/buf")));
+    }
+
+    #[test]
+    fn sink_destination_is_self_contained() {
+        // No stream key, no custom URL - the local test sink needs
+        // neither. The URL is the fixed managed-child endpoint, and
+        // validate() must not demand a key for it.
+        let d = Destination {
+            id: "x".into(),
+            name: "Test sink".into(),
+            enabled: true,
+            platform: "sink".into(),
+            stream_key: String::new(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: "horizontal".into(),
+        };
+        assert_eq!(
+            d.egress_url().as_deref(),
+            Some(format!("rtmp://127.0.0.1:{}/live/test", SINK_RTMP_PORT).as_str())
+        );
+        assert!(d.is_well_formed());
+        let mut s = Settings::defaults();
+        s.destinations.push(d);
+        assert!(
+            s.validate().is_empty(),
+            "sink destination must validate without a key: {:?}",
+            s.validate()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,6 +369,14 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
     let initial_webhook = { rx.borrow().discord_webhook_url.clone() };
     ctrl.update_webhook(initial_webhook);
 
+    // Managed "Local test sink" child process. Spawned while any
+    // enabled destination has platform "sink"; killed when the last
+    // one is disabled or removed. Lives here (not in the pump) because
+    // several sink destinations share the one child, exactly like
+    // several Twitch destinations share the one Twitch edge.
+    let mut sink_child: Option<tokio::process::Child> = None;
+    let mut sink_last_spawn: Option<std::time::Instant> = None;
+
     // Behaviour-toggle state. Auto-arm uses the `prev_ingest_alive`
     // edge detector (fires once per publisher session, on the false ->
     // true transition). Auto-activate reads the controller's
@@ -385,6 +393,13 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
     loop {
         // Snapshot the current desired destinations.
         let desired: Vec<(config::Destination, String)> = { rx.borrow().active_destinations() };
+
+        // Keep the managed test-sink child in sync with the desired set
+        // BEFORE the pump diff below, so a freshly enabled sink
+        // destination has its receiver listening by the time its pump
+        // dials 127.0.0.1.
+        let wants_sink = desired.iter().any(|(d, _)| d.platform == "sink");
+        manage_test_sink(&mut sink_child, &mut sink_last_spawn, wants_sink, &ctrl).await;
 
         // 1) Stop any pump whose dest is no longer desired (or whose URL changed).
         let desired_ids: std::collections::HashSet<String> =
@@ -708,6 +723,109 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
                 // so the diff loop above respawns them.
                 running.retain(|_, (_, h)| !h.is_finished());
             }
+        }
+    }
+}
+
+/// Spawn / reap / kill the `instantclone sink` child that backs "Local
+/// test sink" destinations. Called every supervisor tick.
+///
+/// Lifecycle rules:
+/// * want && not running  → spawn (throttled to one attempt / 10 s so a
+///   port conflict doesn't respawn-spam every 2 s tick)
+/// * want && running      → no-op (one child serves all sink dests)
+/// * !want && running     → kill; the destination was disabled/removed
+/// * child died on its own → reap + log, next tick may respawn
+///
+/// The child's `[sink]`-prefixed lines are forwarded into the dashboard
+/// log ring, so "publish accepted" and the 1 Hz stat lines show up in
+/// the Logs tab - that's the whole point of a testing destination.
+async fn manage_test_sink(
+    child: &mut Option<tokio::process::Child>,
+    last_spawn: &mut Option<std::time::Instant>,
+    want: bool,
+    ctrl: &Arc<controller::Controller>,
+) {
+    // Reap first: a child that died (port conflict, crash) must not
+    // count as running, or we would never respawn it.
+    if let Some(c) = child.as_mut() {
+        if let Ok(Some(status)) = c.try_wait() {
+            ctrl.log(format!("[test-sink] exited ({status})"));
+            *child = None;
+        }
+    }
+    if !want {
+        if let Some(mut c) = child.take() {
+            let _ = c.kill().await;
+            ctrl.log("[test-sink] stopped - no sink destination enabled");
+        }
+        return;
+    }
+    if child.is_some() {
+        return;
+    }
+    if let Some(t) = last_spawn {
+        if t.elapsed() < Duration::from_secs(10) {
+            return;
+        }
+    }
+    *last_spawn = Some(std::time::Instant::now());
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            ctrl.log(format!("[test-sink] can't locate own exe: {e}"));
+            return;
+        }
+    };
+    let mut cmd = tokio::process::Command::new(exe);
+    cmd.args([
+        "sink",
+        "--port",
+        &config::SINK_RTMP_PORT.to_string(),
+        "--web-port",
+        &config::SINK_WEB_PORT.to_string(),
+    ])
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped())
+    // The runtime dropping the supervisor task (app quit) takes the
+    // child with it - no orphaned sink holding the ports.
+    .kill_on_drop(true);
+    // The parent runs without a console (windows_subsystem = windows);
+    // without this flag the child would flash one open.
+    #[cfg(windows)]
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    match cmd.spawn() {
+        Ok(mut c) => {
+            if let Some(out) = c.stdout.take() {
+                tokio::spawn(forward_sink_lines(out, ctrl.clone()));
+            }
+            if let Some(err) = c.stderr.take() {
+                tokio::spawn(forward_sink_lines(err, ctrl.clone()));
+            }
+            ctrl.log(format!(
+                "[test-sink] started - rtmp :{}, live player http://127.0.0.1:{}/",
+                config::SINK_RTMP_PORT,
+                config::SINK_WEB_PORT
+            ));
+            *child = Some(c);
+        }
+        Err(e) => ctrl.log(format!("[test-sink] failed to spawn: {e}")),
+    }
+}
+
+/// Pipe one of the sink child's output streams into the dashboard log.
+/// Only `[sink...]`-prefixed lines pass - the startup banner box art and
+/// blank lines stay out of the 512-entry log ring.
+async fn forward_sink_lines(
+    stream: impl tokio::io::AsyncRead + Unpin,
+    ctrl: Arc<controller::Controller>,
+) {
+    use tokio::io::AsyncBufReadExt;
+    let mut lines = tokio::io::BufReader::new(stream).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if line.starts_with("[sink") {
+            ctrl.log(line);
         }
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -779,8 +779,9 @@ fn platforms_json() -> String {
   {"slug":"kick","label":"Kick","key_url":"https://kick.com/dashboard/settings/stream","key_help":"Kick Creator Dashboard → Settings → Stream","tip":"Kick ingests on AWS IVS (low-latency). What it actually enforces: H.264, CBR, keyframe interval 2 s, bitrate ≤ 8000 kbps, up to 60 fps. B-frames: contrary to a lot of older guides, Kick's normal RTMP ingest accepts them - the strict no-B-frames rule is AWS IVS real-time/WHIP, which Kick doesn't use for OBS streaming, so you usually don't need to change anything. If Kick ever rejects your stream, set B-frames to 0 in OBS (Output → Advanced); that's safe for Twitch/YouTube too. InstantClone forwards one encode without re-encoding, so B-frames can't be stripped for Kick alone. And with Twitch Enhanced Broadcasting on, Twitch chooses the encode settings (including B-frames) for you."},
   {"slug":"trovo","label":"Trovo","key_url":"https://studio.trovo.live/channel/myinfo","key_help":"Trovo Studio → Channel → My Info → Stream Key","tip":null},
   {"slug":"restream","label":"Restream.io","key_url":"https://app.restream.io/channel-settings","key_help":"Restream → Channel Settings → Stream Key","tip":"Restream relays your single stream to multiple platforms - per-platform limits apply on the downstream side, not here."},
-  {"slug":"custom","label":"Custom RTMP URL","key_url":null,"key_help":null,"tip":null}
-]"#.to_string()
+  {"slug":"custom","label":"Custom RTMP URL","key_url":null,"key_help":null,"tip":null},
+  {"slug":"sink","label":"Local test sink (nothing leaves your PC)","key_url":null,"key_help":null,"tip":"InstantClone runs its own tiny RTMP receiver on this PC and streams to it - test arm / activate / cut end to end with zero risk: no real platform, no stream key, nothing leaves your machine. While it's receiving, open http://127.0.0.1:SINK_WEB_PORT/ to watch exactly what a platform would get (including the delay)."}
+]"#.replace("SINK_WEB_PORT", &crate::config::SINK_WEB_PORT.to_string())
 }
 
 /// Serve the multi-track-video config endpoint OBS calls when its

--- a/web/index.html
+++ b/web/index.html
@@ -532,6 +532,10 @@ input,select,textarea{font-family:inherit;color:inherit}
 .dcard.platform-trovo    {--dc:#67e8f9}
 .dcard.platform-restream {--dc:#5eead4}
 .dcard.platform-custom   {--dc:#fcd34d}
+.dcard.platform-sink     {--dc:#93c5fd}
+.dcard-player{display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--dc,var(--accent));
+  text-decoration:none;margin-left:auto}
+.dcard-player:hover{text-decoration:underline;text-underline-offset:2px}
 .dcard-head{display:flex;align-items:center;gap:9px}
 .dcard-icon{width:34px;height:34px;border-radius:9px;display:inline-flex;align-items:center;justify-content:center;
   background:color-mix(in oklch,var(--dc,var(--fg-3)) 16%,var(--surface-3));
@@ -1564,7 +1568,7 @@ input,select,textarea{font-family:inherit;color:inherit}
       Nothing to set here - a <b>normal Twitch stream just works</b>, and so does regular <b>Enhanced Broadcasting</b> (that's horizontal too); InstantClone simply forwards whatever OBS sends. Only Twitch's new <b>Dual Format</b> (a beta add-on to Enhanced Broadcasting) also sends a vertical 9:16 canvas - when it's on, InstantClone forwards both automatically, no toggle needed. <a href="https://help.twitch.tv/s/article/dual-format-vertical-video?language=en_US" target="_blank" rel="noopener">How to enable Twitch Dual Format →</a>
     </div>
     <div class="dfg-sep">Stream key &amp; status</div>
-    <label>Stream key <span class="muted" id="dest-form-key-hint"></span></label>
+    <label id="dest-form-key-label">Stream key <span class="muted" id="dest-form-key-hint"></span></label>
     <input id="dest-form-key" type="password" class="ic-input mono" autocomplete="off">
     <div id="dest-form-key-help" class="w-key-help" hidden></div>
     <div class="row"><label style="display:inline-flex;align-items:center;gap:8px;margin:0;text-transform:none;letter-spacing:0;font-size:13px">
@@ -2259,8 +2263,11 @@ function computeStatePill(s){
   if (ds === 'active') return { label:'ACTIVE',    desc:'· Delay live',     c:'var(--live)',   pulse:true };
   return { label:'IDLE', desc:'', c:'var(--idle)', pulse:false };
 }
-const PLATFORM_INITIAL = { twitch:'T', youtube:'Y', kick:'K', trovo:'V', restream:'R', custom:'·' };
-const PLATFORM_LABEL = { twitch:'Twitch', youtube:'YouTube', kick:'Kick', trovo:'Trovo', restream:'Restream', custom:'Custom' };
+const PLATFORM_INITIAL = { twitch:'T', youtube:'Y', kick:'K', trovo:'V', restream:'R', custom:'·', sink:'⌂' };
+const PLATFORM_LABEL = { twitch:'Twitch', youtube:'YouTube', kick:'Kick', trovo:'Trovo', restream:'Restream', custom:'Custom', sink:'Local test sink' };
+// Fixed ports of the managed test-sink child - mirror config.rs
+// SINK_RTMP_PORT / SINK_WEB_PORT (documented as non-configurable).
+const SINK_PLAYER_URL = 'http://127.0.0.1:19351/';
 const SETTINGS_FIELDS = {
   'ingest_port':'s-iport','web_port':'s-wport','buffer_mb':'s-bmb','buffer_path':'s-bpath',
   'discord webhook':'s-webhook','webhook':'s-webhook','overlays_dir':'s-ovdir',
@@ -2992,6 +2999,7 @@ function buildDestCard(d){
       <div class="dcard-body">
         <div class="dcard-rate-row"><span class="dcard-rate mono">-</span><span class="dcard-rate-u">kbps</span></div>
         <span class="dcard-foot-meta"><span class="dcard-frames">0</span>f · <span class="dcard-cuts">0</span>c · <span class="dcard-rec">0</span>r</span>
+        <a class="dcard-player" target="_blank" rel="noopener" hidden title="Open the sink's built-in live player - watch exactly what a platform would receive, delay included">▶ Watch output</a>
       </div>
       <div class="dcard-res mono" hidden></div>
       <svg class="dcard-spark" viewBox="0 0 400 40" preserveAspectRatio="none">
@@ -3022,6 +3030,7 @@ function buildDestCard(d){
     toggle: el.querySelector('.dcard-toggle'),
     edit: el.querySelector('.dcard-edit'),
     del: el.querySelector('.dcard-del'),
+    player: el.querySelector('.dcard-player'),
     lastPlatform: '',
   };
   refs.edit.onclick = () => openDestForm(refs.last);
@@ -3094,6 +3103,14 @@ function updateDestCard(r, d){
   r.toggle.title = d.enabled ? 'Disable this destination' : 'Enable this destination';
   r.toggle.classList.toggle('on', d.enabled);
   r.toggle.setAttribute('aria-checked', d.enabled ? 'true' : 'false');
+  // Test-sink card: link to the sink's built-in live player. The
+  // managed child runs whenever the destination is enabled, so gate on
+  // enabled (not alive - the player page is up even between publishes).
+  if (r.player){
+    const showPlayer = d.platform === 'sink' && d.enabled;
+    r.player.hidden = !showPlayer;
+    if (showPlayer && r.player.href !== SINK_PLAYER_URL) r.player.href = SINK_PLAYER_URL;
+  }
 }
 
 async function loadDestinations(){
@@ -3198,6 +3215,12 @@ function fillDestPlatforms(){
       const isTwitch = sel.value === 'twitch';
       $('dest-form-format-wrap').hidden = isTwitch;
       $('dest-form-twitch-native-note').hidden = !isTwitch;
+      // The local test sink takes any key, so asking for one would just
+      // be a fake required field. The key-help block stays visible - it
+      // carries the "what is this / where's the player" explainer.
+      const isSink = sel.value === 'sink';
+      $('dest-form-key-label').hidden = isSink;
+      $('dest-form-key').hidden = isSink;
       renderKeyHelp(sel.value, 'dest-form-key-help');
       updateVodVisibility();
       refreshFormatOptionAvailability();
@@ -3533,7 +3556,11 @@ function wireChatDock(){
 
 function fillWizardPlatforms(){
   const sel = $('w-platform'); sel.innerHTML = '';
-  platforms.forEach(p => { const o = document.createElement('option'); o.value = p.slug; o.textContent = p.label; sel.appendChild(o); });
+  // The test sink is excluded here on purpose: the wizard writes the
+  // legacy single-destination config (which requires a key), and its
+  // job is wiring your REAL platform. The sink lives in Destinations.
+  platforms.filter(p => p.slug !== 'sink')
+    .forEach(p => { const o = document.createElement('option'); o.value = p.slug; o.textContent = p.label; sel.appendChild(o); });
   if (!sel._wired){
     sel._wired = true;
     sel.addEventListener('change', () => {
@@ -3634,10 +3661,15 @@ function renderKeyHelp(slug, hostId){
     // exception - its B-frames rule silently drops the stream, so
     // we expand it by default for that one platform.
     const isKick = slug === 'kick';
-    const label = isKick ? '⚠ Things to know about Kick' : `Things to know about ${p.label || 'this platform'}`;
+    // The sink's tip IS the feature explanation (what it does, where
+    // the player lives) - open it by default like Kick's warning.
+    const isSink = slug === 'sink';
+    const label = isKick ? '⚠ Things to know about Kick'
+                : isSink ? 'What is the local test sink?'
+                : `Things to know about ${p.label || 'this platform'}`;
     const cls = isKick ? 'w-key-tip warn' : 'w-key-tip';
     parts.push(`
-      <details class="ic-disclose w-key-disclose"${isKick ? ' open' : ''}>
+      <details class="ic-disclose w-key-disclose"${isKick || isSink ? ' open' : ''}>
         <summary class="${cls}">${label}</summary>
         <div class="ic-disclose-body">${p.tip}</div>
       </details>


### PR DESCRIPTION
> **Stacked on #33** - merge that first; GitHub retargets this one to `main` automatically.

## What

The in-binary RTMP sink (`instantclone sink`) becomes a destination type. Pick **Local test sink** in the Destinations tab and InstantClone spawns its own tiny receiver on this PC and streams to it. No platform account, no stream key, nothing leaves the machine - test arm/activate/cut (and vertical) end to end before touching a real key.

## How

- **Managed child process.** The egress supervisor owns one `instantclone sink` child for all sink destinations: spawned when one is enabled (before the pump dials, so the receiver is listening first), killed when the last is disabled or removed, reaped and respawned (10 s throttle) if it dies, `kill_on_drop` so app exit takes it down, `CREATE_NO_WINDOW` so nothing flashes.
- **Fixed high ports** (rtmp `:19350`, player `:19351`) so manual sink runs on the documented `:1936`/`:1937` defaults and the e2e script never collide with the managed instance.
- **Feedback where you can see it.** The sink's `[sink]` log lines (`publish accepted`, the 1 Hz stat windows) are forwarded into the dashboard's Logs tab, and the destination card gets a **▶ Watch output** link to the sink's built-in live player - watch exactly what a platform would receive, delay and cuts included.
- **Form UX.** The stream-key field hides for sink (any key works), and an open-by-default disclosure explains the feature inline. The first-run wizard deliberately does not offer it: the wizard writes the legacy single-destination config and its job is wiring your real platform.

## Verification

- `cargo fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test --release`: **235 passed** (new config test: sink destination is self-contained - fixed URL, well-formed and valid with no key).
- Verified live end to end: app started with an enabled sink destination -> child spawned and both ports answered; a real ffmpeg publish flowed proxy -> sink with "publish accepted" landing in the dashboard log; the card reported alive + bitrate; the built-in player served on `:19351`; disabling the destination killed the child and freed the ports, with the stop logged.