### PR TITLE
Customizable OBS browser dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes will land here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.1.10] - Improving visuals, adding "sink" test mode as destination, UX improvements and OBS dock
+
 ### Customizable OBS browser dock
 
 A composable, per-slot browser dock so you can drive InstantClone from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes will land here. Format loosely follows
 
 ## [Unreleased]
 
+### Customizable OBS browser dock
+
+A composable, per-slot browser dock so you can drive InstantClone from
+inside OBS without opening the full dashboard - competitive players keep
+the CPU free and only show what they need.
+
+- **Widgets + presets** - status bar, delay number, buffer bar, egress
+  glance, hint, destinations, delay profiles, health stats, auto
+  behavior, live-safe settings, and an overlays picker. Toggle, reorder
+  (drag), and restyle each from an in-dock editor. Presets range from
+  **Delay only** to a full **Dashboard**.
+- **Multiple docks** - `?dock=<id>` slots, each with its own saved
+  layout, plus copy-URL flows to run a second dock in OBS. Layouts save
+  server-side (survive OBS wiping its cache) and sync live across docks.
+- **Destinations on the dock** - rows or icons, platform-coded colors,
+  and a two-tap misclick guard on every toggle.
+- **Safe cut on the dock** - schedule "cut after this airs" and watch a
+  live, cancellable countdown; a cut scheduled anywhere shows on every
+  dock.
+- **Buffer-capacity gate** - a delay too big to fill at the current
+  bitrate is greyed out and refused, with a tooltip naming the buffer
+  size it needs. Enforced on the dock, the dashboard, and server-side on
+  `/arm` so a stale page or scripted call can't stall in "arming".
+
 ### Fixes
 
 - The OBS dock showed a phantom **1.0s** delay in passthrough. It fed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "instantclone"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "instantclone"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["s1moscs"]
 license = "GPL-3.0-only"
 description = "Free open-source RTMP delay proxy for Windows streamers. Two-phase arm/activate, IDR-aligned cuts, multi-destination egress, Twitch Enhanced Broadcasting + VOD audio, OBS-native dock and overlay."
 repository = "https://github.com/Soulhackzlol/InstantClone"
-homepage = "https://github.com/Soulhackzlol/InstantClone"
+homepage = "https://s1moscs.dev/instantclone"
 readme = "README.md"
 keywords = ["rtmp", "obs", "twitch", "streaming", "delay"]
 categories = ["multimedia::video", "command-line-utilities"]

--- a/README.es.md
+++ b/README.es.md
@@ -49,7 +49,7 @@ Cuando ya lo tenía hecho, las piezas que de verdad quería eran: una activació
 <tr><td><b>RSS inactivo</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Hilos</b></td><td align="right"><code>1 tokio + 1 bandeja</code></td></tr>
 <tr><td><b>Deps en runtime</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>235 / 235</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>236 / 236</code></td></tr>
 </table>
 
 </td>
@@ -281,7 +281,7 @@ cargo build --release
 
 Sin npm, sin submódulos, sin SDK de plataforma. El HTML del panel se minifica y comprime con gzip en tiempo de compilación desde `build.rs` (usa `flate2`, solo build-dep) y se embebe en el binario; en runtime se sirve con `Content-Encoding: gzip`.
 
-`cargo test --release` cubre la máquina de estados (`arm → preparing → ready → active → cut`), detección de IDR en AVC + Enhanced RTMP, codec AMF0 incluyendo Strict Array (la `fourCcList` de Enhanced-RTMP) + guardia de recursión, round-trip de settings, evicción del ring-buffer con protección de lecturas en vuelo, parsing HTTP, política CSRF, pre-flight de puertos, la negociación de contenido `accepts_gzip`, la caché de cabeceras de secuencia por-pista de Enhanced Broadcasting + selección de tags consciente del TrackId, el audio multi-pista de Enhanced-RTMP (pista de VOD de Twitch), el filtro de IDR de pista primaria para que los cortes con EB no glitcheen las escaleras, el parseo de orientación del SPS para la selección de lienzo vertical (9:16), la resolución de `user.ini` / `global.ini` en OBS 32, el parcheado de `services.json` de OBS, el parser de releases de GitHub + comparador SemVer-ish para el chequeo de actualizaciones, la implementación propia de SHA-256 (vectores NIST), el lector/escritor del flujo de chunks RTMP (cabeceras fmt 0-3, timestamps extendidos, fragmentación entre chunks, control Set-Chunk-Size / Window-Ack en banda, y guardias ante entrada malformada), la máquina de estados del corte programado ("cortar cuando esto salga"), y la descarga + verificación de checksum + intercambio del exe en disco de la auto-actualización. 235 tests, todos en verde.
+`cargo test --release` cubre la máquina de estados (`arm → preparing → ready → active → cut`), detección de IDR en AVC + Enhanced RTMP, codec AMF0 incluyendo Strict Array (la `fourCcList` de Enhanced-RTMP) + guardia de recursión, round-trip de settings, evicción del ring-buffer con protección de lecturas en vuelo, parsing HTTP, política CSRF, pre-flight de puertos, la negociación de contenido `accepts_gzip`, la caché de cabeceras de secuencia por-pista de Enhanced Broadcasting + selección de tags consciente del TrackId, el audio multi-pista de Enhanced-RTMP (pista de VOD de Twitch), el filtro de IDR de pista primaria para que los cortes con EB no glitcheen las escaleras, el parseo de orientación del SPS para la selección de lienzo vertical (9:16), la resolución de `user.ini` / `global.ini` en OBS 32, el parcheado de `services.json` de OBS, el parser de releases de GitHub + comparador SemVer-ish para el chequeo de actualizaciones, la implementación propia de SHA-256 (vectores NIST), el lector/escritor del flujo de chunks RTMP (cabeceras fmt 0-3, timestamps extendidos, fragmentación entre chunks, control Set-Chunk-Size / Window-Ack en banda, y guardias ante entrada malformada), la máquina de estados del corte programado ("cortar cuando esto salga"), y la descarga + verificación de checksum + intercambio del exe en disco de la auto-actualización. 236 tests, todos en verde.
 
 <br/>
 
@@ -289,7 +289,7 @@ Sin npm, sin submódulos, sin SDK de plataforma. El HTML del panel se minifica y
 
 ## Estado
 
-**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 235 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
+**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 236 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
 
 **Lo que está sólido**
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once it existed, the parts I'd actually wanted ended up in: a real two-phase arm
 <tr><td><b>Idle RSS</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Threads</b></td><td align="right"><code>1 tokio + 1 tray</code></td></tr>
 <tr><td><b>Runtime deps</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>235 / 235</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>236 / 236</code></td></tr>
 </table>
 
 </td>
@@ -281,7 +281,7 @@ cargo build --release
 
 No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzipped at build time by `build.rs` (uses `flate2`, build-only) and embedded into the binary; at runtime it's served with `Content-Encoding: gzip`.
 
-`cargo test --release` covers the state machine (`arm → preparing → ready → active → cut`), AVC + Enhanced RTMP IDR detection, AMF0 codec including Strict Array (Enhanced-RTMP `fourCcList`) + recursion guard, settings round-trip, ring-buffer eviction with in-flight-read protection, HTTP parsing, CSRF policy, port pre-flight, `accepts_gzip` content negotiation, Enhanced Broadcasting per-track seq-header cache + TrackId-aware tag selection, Enhanced-RTMP multi-track audio (Twitch's VOD audio track), primary-track IDR gate so EB cuts don't pixel-glitch ladder rungs, SPS orientation parsing for vertical-canvas (9:16) selection, OBS 32 `user.ini` / legacy `global.ini` path resolution, the OBS services.json patcher, the GitHub releases update-check parser + SemVer-ish comparator, the hand-rolled SHA-256 (NIST vectors), the RTMP chunk-stream reader/writer (fmt 0-3 headers, extended timestamps, cross-chunk fragmentation, in-band Set-Chunk-Size / Window-Ack control, and malformed-input guards), the scheduled safe-cut ("cut after this airs") state machine, and the self-update download + checksum-verify + on-disk exe swap. 235 tests, all green.
+`cargo test --release` covers the state machine (`arm → preparing → ready → active → cut`), AVC + Enhanced RTMP IDR detection, AMF0 codec including Strict Array (Enhanced-RTMP `fourCcList`) + recursion guard, settings round-trip, ring-buffer eviction with in-flight-read protection, HTTP parsing, CSRF policy, port pre-flight, `accepts_gzip` content negotiation, Enhanced Broadcasting per-track seq-header cache + TrackId-aware tag selection, Enhanced-RTMP multi-track audio (Twitch's VOD audio track), primary-track IDR gate so EB cuts don't pixel-glitch ladder rungs, SPS orientation parsing for vertical-canvas (9:16) selection, OBS 32 `user.ini` / legacy `global.ini` path resolution, the OBS services.json patcher, the GitHub releases update-check parser + SemVer-ish comparator, the hand-rolled SHA-256 (NIST vectors), the RTMP chunk-stream reader/writer (fmt 0-3 headers, extended timestamps, cross-chunk fragmentation, in-band Set-Chunk-Size / Window-Ack control, and malformed-input guards), the scheduled safe-cut ("cut after this airs") state machine, and the self-update download + checksum-verify + on-disk exe swap. 236 tests, all green.
 
 <br/>
 
@@ -289,7 +289,7 @@ No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzippe
 
 ## Status
 
-**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 235 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
+**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 236 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
 
 **What's solid**
 

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,9 @@ fn main() {
     for (name, do_min) in &[
         ("index.html", true),
         ("dock.html", true),
+        // Dock logic is template-literal / regex heavy (same reasons as the
+        // overlay runtime), so skip the line minifier and let gzip do it.
+        ("dock.js", false),
         ("overlay-runtime.js", false),
     ] {
         let src_path = web_dir.join(name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@
 //! editable by hand and trivially parseable without a serde dependency.
 //! For wire transport (web UI), `to_json` emits a small JSON object.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -16,6 +17,13 @@ use std::path::{Path, PathBuf};
 /// are both already absurd for a single streamer.
 const MAX_DESTINATIONS: usize = 128;
 const MAX_PROFILES: usize = 256;
+/// Ceiling on saved dock layouts (each is one OBS browser dock's widget
+/// arrangement). Persisted server-side so a layout survives OBS clearing
+/// its browser cache; capped so a runaway client can't bloat the config.
+pub const MAX_DOCKS: usize = 64;
+/// Max serialized length of one dock layout blob. Comfortably fits the
+/// widget list; guards the on-disk file against a giant POST body.
+pub const MAX_DOCK_LAYOUT_LEN: usize = 8 * 1024;
 /// Minimum on-disk buffer size (MB). Below this, the ring is too small
 /// to hold a single typical IDR (which can be 100 KB at 1080p60).
 /// Also guards against the `% 0` panic in `DiskRing::append` if a
@@ -85,6 +93,11 @@ pub struct Settings {
     /// Reset to false (and the overlays wiped) by "Restore default overlays"
     /// and the factory reset, which re-seeds on the next dashboard load.
     pub overlays_seeded: bool,
+    /// Saved OBS dock layouts, keyed by the dock's `?dock=<id>` slot. The
+    /// value is the dock's own opaque layout JSON (the server never parses
+    /// it - the dock owns its schema). Persisted here so a customized dock
+    /// survives OBS wiping its browser cache or the machine restarting.
+    pub docks: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -303,6 +316,7 @@ impl Settings {
             // Fresh install hasn't seeded the preset overlays yet; the
             // dashboard does it on first load, then flips this true.
             overlays_seeded: false,
+            docks: BTreeMap::new(),
         }
     }
 
@@ -503,6 +517,12 @@ impl Settings {
         if self.overlays_seeded {
             writeln!(f, "overlays_seeded=true")?;
         }
+        // Dock layouts. The value is single-line JSON (no `=`/newline in
+        // compact JSON), so it round-trips through the line-based parser
+        // even though it is opaque to us.
+        for (id, layout) in &self.docks {
+            writeln!(f, "dock.{}={}", id, layout)?;
+        }
         for (i, p) in self.profiles.iter().enumerate() {
             writeln!(f, "profile.{}.name={}", i, p.name)?;
             writeln!(f, "profile.{}.delay_ms={}", i, p.delay_ms)?;
@@ -589,6 +609,12 @@ impl Settings {
             "auto_arm_delay_ms" => {
                 if let Ok(v) = value.parse() {
                     self.auto_arm_delay_ms = v;
+                }
+            }
+            k if k.starts_with("dock.") => {
+                let id = &k["dock.".len()..];
+                if !id.is_empty() && id.len() <= 40 && self.docks.len() < MAX_DOCKS {
+                    self.docks.insert(id.to_string(), value.to_string());
                 }
             }
             k if k.starts_with("profile.") => {
@@ -1383,6 +1409,38 @@ mod tests {
         assert_eq!(loaded.profiles.len(), 2);
         assert_eq!(loaded.profiles[0].delay_ms, 10_000);
         assert_eq!(loaded.profiles[1].name, "Long");
+    }
+
+    #[test]
+    fn dock_layouts_round_trip_through_save_and_load() {
+        // Dock layouts are opaque single-line JSON blobs stored as
+        // `dock.<id>=<json>`. Prove a value containing `=`, `:`, and quotes
+        // survives the line parser (it splits on the first `=` only, so the
+        // JSON body is preserved verbatim).
+        let mut s = Settings::defaults();
+        s.docks.insert(
+            "default".into(),
+            r#"{"v":1,"preset":"minimal","w":{"number":{"on":true,"step":5}}}"#.into(),
+        );
+        s.docks
+            .insert("gaming".into(), r#"{"preset":"delay","eq":"a=b"}"#.into());
+
+        let path = std::env::temp_dir().join(format!("ic-test-docks-{}.ini", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        s.save(&path).expect("save");
+        let loaded = Settings::load(&path).expect("load");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(loaded.docks.len(), 2);
+        assert_eq!(
+            loaded.docks.get("default").map(String::as_str),
+            Some(r#"{"v":1,"preset":"minimal","w":{"number":{"on":true,"step":5}}}"#)
+        );
+        assert_eq!(
+            loaded.docks.get("gaming").map(String::as_str),
+            Some(r#"{"preset":"delay","eq":"a=b"}"#),
+            "value after the first = (including embedded =) must survive"
+        );
     }
 
     #[test]

--- a/src/web.rs
+++ b/src/web.rs
@@ -1726,8 +1726,40 @@ async fn post_arm(
     sysstat: &Arc<SysStat>,
 ) -> (&'static str, &'static str, String) {
     let form = config::parse_form(body);
-    let ms: u32 = form.get("ms").and_then(|v| v.parse().ok()).unwrap_or(0);
-    ctrl.arm_delay(ms.min(600_000));
+    let ms: u32 = form
+        .get("ms")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+        .min(600_000);
+
+    // Server-side capacity guard. A delay bigger than the ring can hold at
+    // the current bitrate never fills - it stalls in "arming" forever, which
+    // looks like a hang. The dashboard and dock both gate this client-side,
+    // but a stale page, a second dock, or a scripted call could still ask for
+    // the impossible, so we refuse it here too. Same estimate we publish as
+    // buffer_capacity_ms_est; bitrate is floored at 2 Mbps so an idle or
+    // low-bitrate stream stays generous and never blocks a reasonable pre-arm.
+    // ms == 0 is disarm and always allowed.
+    if ms > 0 {
+        let cap_ms = {
+            let s = settings.borrow();
+            let kbps = ctrl.bitrate_kbps().max(2_000) as u64;
+            (s.buffer_mb * 1024 * 1024 * 8 / kbps) as u32
+        };
+        if cap_ms > 0 && ms > cap_ms {
+            return (
+                "409 Conflict",
+                "application/json",
+                format!(
+                    r#"{{"ok":false,"error":"Buffer too small for {}s - it holds about {}s at the current bitrate. Raise the buffer size in the dashboard."}}"#,
+                    ms / 1000,
+                    cap_ms / 1000
+                ),
+            );
+        }
+    }
+
+    ctrl.arm_delay(ms);
     persist_delay_state(ctrl, settings, cfg_path);
     (
         "200 OK",

--- a/src/web.rs
+++ b/src/web.rs
@@ -2215,7 +2215,10 @@ async fn post_destination_toggle(
         return (
             "500 Internal Server Error",
             "application/json",
-            format!(r#"{{"ok":false,"error":"{}"}}"#, json_escape(&e.to_string())),
+            format!(
+                r#"{{"ok":false,"error":"{}"}}"#,
+                json_escape(&e.to_string())
+            ),
         );
     }
     reconcile_obs_vod_files(&ns, ctrl);
@@ -2355,7 +2358,10 @@ async fn dock_layout_save(
         return (
             "500 Internal Server Error",
             "application/json",
-            format!(r#"{{"ok":false,"error":"{}"}}"#, json_escape(&e.to_string())),
+            format!(
+                r#"{{"ok":false,"error":"{}"}}"#,
+                json_escape(&e.to_string())
+            ),
         );
     }
     let _ = settings.send(ns);

--- a/src/web.rs
+++ b/src/web.rs
@@ -293,8 +293,7 @@ async fn route(
     // `null`); POST /docks/<id> saves the request body as that dock's
     // layout, or clears it when the body is empty. Persisted in settings
     // so a customized dock survives OBS wiping its browser cache.
-    if bare_path.starts_with("/docks/") {
-        let id = &bare_path["/docks/".len()..];
+    if let Some(id) = bare_path.strip_prefix("/docks/") {
         if method == "GET" {
             return dock_layout_get(id, settings);
         }

--- a/src/web.rs
+++ b/src/web.rs
@@ -157,7 +157,7 @@ async fn serve(
     // Overlay Studio runtime - static pre-gzipped JS, same fast-path as
     // the dashboard. Served to the dashboard tab only; baked overlays
     // inline what they need and never request this.
-    if method == "GET" && bare_path == "/overlay-runtime.js" {
+    if method == "GET" && (bare_path == "/overlay-runtime.js" || bare_path == "/dock.js") {
         if !accept_gzip {
             let body = b"this build serves gzip-encoded JS; \
                          retry with Accept-Encoding: gzip" as &[u8];
@@ -170,15 +170,20 @@ async fn serve(
             sock.write_all(body).await?;
             return Ok(());
         }
+        let blob: &'static [u8] = if bare_path == "/dock.js" {
+            DOCK_JS_GZ
+        } else {
+            OVERLAY_RUNTIME_JS_GZ
+        };
         let r = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/javascript; charset=utf-8\r\n\
              Content-Encoding: gzip\r\nVary: Accept-Encoding\r\n\
              Content-Length: {}\r\n\
              Access-Control-Allow-Origin: *\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
-            OVERLAY_RUNTIME_JS_GZ.len()
+            blob.len()
         );
         sock.write_all(r.as_bytes()).await?;
-        sock.write_all(OVERLAY_RUNTIME_JS_GZ).await?;
+        sock.write_all(blob).await?;
         return Ok(());
     }
 
@@ -284,6 +289,20 @@ async fn route(
         return overlay_save(rest, body, settings);
     }
 
+    // Dock layouts: GET /docks/<id> returns the saved layout JSON (or
+    // `null`); POST /docks/<id> saves the request body as that dock's
+    // layout, or clears it when the body is empty. Persisted in settings
+    // so a customized dock survives OBS wiping its browser cache.
+    if bare_path.starts_with("/docks/") {
+        let id = &bare_path["/docks/".len()..];
+        if method == "GET" {
+            return dock_layout_get(id, settings);
+        }
+        if method == "POST" {
+            return dock_layout_save(id, body, settings, cfg_path).await;
+        }
+    }
+
     match (method, bare_path) {
         // GET / and GET /dock are handled in serve() as a fast-path
         // (static gz blob, no allocation, no String round-trip).
@@ -294,6 +313,7 @@ async fn route(
             state_json(ctrl, settings, sysstat),
         ),
         ("GET", "/config") => ("200 OK", "application/json", settings.borrow().to_json()),
+        ("GET", "/docks") => dock_list_json(settings),
         ("GET", "/platforms") => ("200 OK", "application/json", platforms_json()),
         // OBS sends a POST with a system-info payload (CPU/GPU/encoder
         // capabilities + the user's stream-key field as the auth
@@ -611,6 +631,9 @@ async fn route(
         ("POST", "/profiles/delete") => post_profile_del(body, settings, cfg_path).await,
         // Destinations CRUD
         ("POST", "/destinations") => post_destination_upsert(body, ctrl, settings, cfg_path).await,
+        ("POST", "/destinations/toggle") => {
+            post_destination_toggle(body, ctrl, settings, cfg_path).await
+        }
         ("POST", "/destinations/delete") => {
             post_destination_delete(body, ctrl, settings, cfg_path).await
         }
@@ -2125,6 +2148,49 @@ fn reconcile_obs_vod_files(s: &Settings, ctrl: &Arc<Controller>) {
     }
 }
 
+/// Flip a single destination's `enabled` flag and nothing else. The dock's
+/// quick-toggle strip calls this instead of `/destinations` because the full
+/// upsert rebuilds the destination from its form and would blank the fields
+/// the dock doesn't send (stream key, custom URL, VOD-audio, etc.).
+async fn post_destination_toggle(
+    body: &str,
+    ctrl: &Arc<Controller>,
+    settings: &Arc<watch::Sender<Settings>>,
+    cfg_path: &Path,
+) -> (&'static str, &'static str, String) {
+    let form = config::parse_form(body);
+    let id = form.get("id").cloned().unwrap_or_default();
+    let enabled = matches!(
+        form.get("enabled").map(String::as_str),
+        Some("on" | "true" | "1")
+    );
+
+    let mut ns = settings.borrow().clone();
+    let Some(dest) = ns.destinations.iter_mut().find(|d| d.id == id) else {
+        return (
+            "404 Not Found",
+            "application/json",
+            r#"{"ok":false,"error":"no such destination"}"#.into(),
+        );
+    };
+    dest.enabled = enabled;
+
+    ns.configured = ns
+        .destinations
+        .iter()
+        .any(|d| d.enabled && d.is_well_formed());
+    if let Err(e) = ns.save(cfg_path) {
+        return (
+            "500 Internal Server Error",
+            "application/json",
+            format!(r#"{{"ok":false,"error":"{}"}}"#, json_escape(&e.to_string())),
+        );
+    }
+    reconcile_obs_vod_files(&ns, ctrl);
+    let _ = settings.send(ns);
+    ("200 OK", "application/json", r#"{"ok":true}"#.into())
+}
+
 async fn post_destination_delete(
     body: &str,
     ctrl: &Arc<Controller>,
@@ -2152,6 +2218,114 @@ async fn post_destination_delete(
     }
     let _ = ns.save(cfg_path);
     reconcile_obs_vod_files(&ns, ctrl);
+    let _ = settings.send(ns);
+    ("200 OK", "application/json", r#"{"ok":true}"#.into())
+}
+
+/// Restrict a dock slot id to a filesystem/config-safe charset so it can
+/// key a `dock.<id>=` line without needing escaping. Returns the trimmed
+/// id or None if it is empty, too long, or has a disallowed character.
+fn sanitize_dock_id(id: &str) -> Option<String> {
+    let id = id.trim();
+    if id.is_empty() || id.len() > 40 {
+        return None;
+    }
+    if id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        Some(id.to_string())
+    } else {
+        None
+    }
+}
+
+/// JSON array of the saved dock slot ids, so the editor can show which docks
+/// exist and offer to copy their URLs.
+fn dock_list_json(settings: &Arc<watch::Sender<Settings>>) -> (&'static str, &'static str, String) {
+    let s = settings.borrow();
+    let mut out = String::from("[");
+    for (i, id) in s.docks.keys().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&json_escape(id));
+        out.push('"');
+    }
+    out.push(']');
+    ("200 OK", "application/json", out)
+}
+
+fn dock_layout_get(
+    id: &str,
+    settings: &Arc<watch::Sender<Settings>>,
+) -> (&'static str, &'static str, String) {
+    let Some(id) = sanitize_dock_id(id) else {
+        return (
+            "400 Bad Request",
+            "application/json",
+            r#"{"ok":false,"error":"bad dock id"}"#.into(),
+        );
+    };
+    // Return the opaque layout blob verbatim, or JSON null so the dock
+    // falls back to its built-in default preset.
+    match settings.borrow().docks.get(&id) {
+        Some(layout) => ("200 OK", "application/json", layout.clone()),
+        None => ("200 OK", "application/json", "null".into()),
+    }
+}
+
+async fn dock_layout_save(
+    id: &str,
+    body: &str,
+    settings: &Arc<watch::Sender<Settings>>,
+    cfg_path: &Path,
+) -> (&'static str, &'static str, String) {
+    let Some(id) = sanitize_dock_id(id) else {
+        return (
+            "400 Bad Request",
+            "application/json",
+            r#"{"ok":false,"error":"bad dock id"}"#.into(),
+        );
+    };
+    let body = body.trim();
+    if body.len() > config::MAX_DOCK_LAYOUT_LEN {
+        return (
+            "413 Payload Too Large",
+            "application/json",
+            r#"{"ok":false,"error":"layout too large"}"#.into(),
+        );
+    }
+    // The blob lives on one line of the key=value config file, so a
+    // newline would corrupt the next parse. Compact JSON never has one.
+    if body.contains('\n') || body.contains('\r') {
+        return (
+            "400 Bad Request",
+            "application/json",
+            r#"{"ok":false,"error":"layout must be single-line json"}"#.into(),
+        );
+    }
+    let mut ns = settings.borrow().clone();
+    if body.is_empty() {
+        ns.docks.remove(&id); // empty body resets the slot to default
+    } else {
+        if !ns.docks.contains_key(&id) && ns.docks.len() >= config::MAX_DOCKS {
+            return (
+                "400 Bad Request",
+                "application/json",
+                r#"{"ok":false,"error":"too many saved docks"}"#.into(),
+            );
+        }
+        ns.docks.insert(id, body.to_string());
+    }
+    if let Err(e) = ns.save(cfg_path) {
+        return (
+            "500 Internal Server Error",
+            "application/json",
+            format!(r#"{{"ok":false,"error":"{}"}}"#, json_escape(&e.to_string())),
+        );
+    }
     let _ = settings.send(ns);
     ("200 OK", "application/json", r#"{"ok":true}"#.into())
 }
@@ -2897,6 +3071,11 @@ fn json_escape(s: &str) -> String {
 /// as the main dashboard so behavior stays identical. Source lives in
 /// `web/dock.html` - built-time minified + gzipped (see `build.rs`).
 static DOCK_HTML_GZ: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/dock.html.gz"));
+
+/// Dock logic (widget rendering, gear editor, state polling). Split out of
+/// `dock.html` so the page stays markup+CSS; source in `web/dock.js`,
+/// build-time gzipped (see `build.rs`).
+static DOCK_JS_GZ: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/dock.js.gz"));
 
 /// Main dashboard / first-run wizard. Source lives in `web/index.html`;
 /// build-time minified + gzipped (see `build.rs`).

--- a/web/dock.html
+++ b/web/dock.html
@@ -132,13 +132,28 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .pchip:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
 .pchip:active{transform:scale(.96)}
 .pchip .pv{font-size:10px;font-weight:700;color:var(--fg-3);font-variant-numeric:tabular-nums}
+/* Profiles list mode: full-width rows, name left / seconds right */
+.profiles.plist{flex-direction:column;flex-wrap:nowrap}
+.prow{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:7px 10px;
+  border:1px solid var(--line);border-radius:9px;background:var(--panel);color:var(--fg);
+  font-size:11.5px;font-weight:600;cursor:pointer;font-family:inherit;
+  transition:border-color .15s,background .15s,transform .12s cubic-bezier(.32,.72,0,1)}
+.prow:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
+.prow:active{transform:scale(.98)}
+.prow .pv{color:var(--fg-3);font-variant-numeric:tabular-nums;font-weight:700;font-size:10.5px}
 
-/* Health stats glance */
+/* Health stats glance: inline row, or a tile grid for glanceability */
 .stats{display:flex;flex-wrap:wrap;gap:5px 10px;justify-content:center;font-size:11px;color:var(--fg-3);
   font-variant-numeric:tabular-nums}
 .stats .st b{color:var(--fg-2);font-weight:700}
 .stats .st.bad{color:var(--warn);font-weight:600}
 .stats .st.muted{color:var(--fg-4)}
+.stats.tiles{display:grid;grid-template-columns:repeat(3,1fr);gap:5px}
+.stats.tiles .tile{display:flex;flex-direction:column;align-items:center;gap:1px;padding:7px 4px;
+  border:1px solid var(--line);border-radius:9px;background:var(--panel)}
+.stats.tiles .tile b{font-size:14px;color:var(--fg);font-weight:800;font-variant-numeric:tabular-nums}
+.stats.tiles .tile span{font-size:9px;text-transform:uppercase;letter-spacing:.6px;color:var(--fg-4)}
+.stats.tiles .st.bad{grid-column:1/-1;text-align:center;padding:4px}
 
 /* Auto behavior + settings toggle rows */
 .behavior,.settings{display:flex;flex-direction:column;gap:5px}
@@ -299,6 +314,8 @@ body:hover .gear{opacity:.5}
 .ed-actions{display:flex;gap:8px;margin-top:14px}
 .ed-actions .btn{font-size:12px;padding:10px;border-radius:10px}
 .ed-actions .btn.ghost{flex:1}
+.ed-actions .btn.reset{flex:0 0 auto;padding:10px 13px}
+.ed-actions .btn.reset.warn{color:var(--danger);border-color:color-mix(in srgb,var(--danger) 45%,var(--line))}
 .ed-actions .btn.primary{flex:0 0 auto;padding:10px 18px}
 
 #toast{position:fixed;left:50%;bottom:14px;transform:translateX(-50%) translateY(40px);

--- a/web/dock.html
+++ b/web/dock.html
@@ -173,6 +173,11 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .prow:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
 .prow:active{transform:scale(.96)}
 .prow .pv{color:var(--fg-3);font-variant-numeric:tabular-nums;font-weight:700;font-size:10.5px}
+/* Over buffer capacity: dimmed, struck, and inert (see currentCapMs). The
+   tooltip explains how much buffer the delay would need. */
+.pchip.toobig,.prow.toobig{opacity:.4;cursor:not-allowed;text-decoration:line-through;
+  text-decoration-color:color-mix(in srgb,var(--warn) 70%,transparent)}
+.pchip.toobig:hover,.prow.toobig:hover{border-color:var(--line);background:var(--panel);transform:none}
 
 /* Health stats glance: inline row, or a tile grid for glanceability */
 .stats{display:flex;flex-wrap:wrap;gap:5px 10px;justify-content:center;font-size:11px;color:var(--fg-3);

--- a/web/dock.html
+++ b/web/dock.html
@@ -63,6 +63,8 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .cur input::-webkit-outer-spin-button,.cur input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
 .cur .u{font-size:.4em;color:var(--fg-3);font-weight:600;margin-left:2px;letter-spacing:0}
 .cur.changing{color:var(--accent);transform:scale(1.04)}
+/* Accent-tinted readout: the number always wears the dock's accent hue. */
+.cur.tint{color:var(--accent)}
 /* Number size modes */
 .sz-sm .cur{font-size:clamp(18px,7vw,24px)}
 .sz-lg .cur{font-size:clamp(30px,14vw,48px)}
@@ -83,6 +85,10 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .bar .fill.active{background:linear-gradient(90deg,var(--live),color-mix(in srgb,var(--live) 55%,#fff))}
 .bar .pct{position:absolute;right:0;top:-14px;font-size:9.5px;color:var(--fg-3);font-variant-numeric:tabular-nums}
 .bar.thick{height:8px}
+/* Accent-only bar: one hue through fill/ready/active instead of the
+   amber -> cyan -> green state ramp - for single-color themed docks. */
+.bar.mono .fill,.bar.mono .fill.ready,.bar.mono .fill.active{
+  background:linear-gradient(90deg,var(--accent),color-mix(in srgb,var(--accent) 55%,#fff))}
 
 /* Egress glance (destinations + bitrate) */
 .eg{display:flex;align-items:center;justify-content:center;gap:7px;font-size:11px;color:var(--fg-3);
@@ -105,6 +111,11 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .dest .d-name{flex:1;font-weight:600;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .dest .d-plat{color:var(--fg-3);font-size:10px;text-transform:uppercase;letter-spacing:.5px}
 .dest .d-rate{color:var(--live);font-size:10.5px;font-weight:700;font-variant-numeric:tabular-nums}
+/* Platform-coded rows: label, live dot, and the on-switch take the brand hue
+   ("the little buttons colored" feedback). */
+.dest.pc .d-plat{color:color-mix(in srgb,var(--pc) 80%,var(--fg-3))}
+.dest.pc.alive .d-dot{background:var(--pc);box-shadow:0 0 0 3px color-mix(in srgb,var(--pc) 20%,transparent)}
+.dest.pc .sw.on{background:var(--pc)}
 /* iOS-style switch */
 .sw{width:34px;height:20px;flex:0 0 auto;border-radius:999px;border:0;background:var(--line-2);
   position:relative;cursor:pointer;transition:background-color .2s cubic-bezier(.32,.72,0,1)}
@@ -137,7 +148,12 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .dico.on{color:var(--fg);border-color:var(--line-2)}
 .dico.off{opacity:.4}
 .dico.alive{border-color:color-mix(in srgb,var(--live) 55%,var(--line));box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 16%,transparent)}
-.dico.arm{border-color:var(--warn);color:var(--warn);font-size:15px;animation:dico-pulse 1s ease-in-out infinite}
+/* Platform-coded badges (--pc set per element): letter + ring take the
+   platform's brand hue so a glance says WHICH service is live. */
+.dico.pc{color:color-mix(in srgb,var(--pc) 75%,var(--fg-3))}
+.dico.pc.on{color:var(--pc);border-color:color-mix(in srgb,var(--pc) 50%,var(--line))}
+.dico.pc.alive{border-color:color-mix(in srgb,var(--pc) 70%,var(--line));box-shadow:0 0 0 3px color-mix(in srgb,var(--pc) 20%,transparent)}
+.dico.arm,.dico.pc.arm{border-color:var(--warn);color:var(--warn);font-size:15px;animation:dico-pulse 1s ease-in-out infinite}
 @keyframes dico-pulse{0%,100%{box-shadow:0 0 0 2px color-mix(in srgb,var(--warn) 28%,transparent)}50%{box-shadow:0 0 0 6px color-mix(in srgb,var(--warn) 8%,transparent)}}
 
 /* Delay profile chips */

--- a/web/dock.html
+++ b/web/dock.html
@@ -11,13 +11,13 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
   font-family:-apple-system,Segoe UI,Roboto,sans-serif;
   overflow-x:hidden;overflow-y:auto;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
-/* Thin scrollbar only when a dock is genuinely too short for the controls. */
 body::-webkit-scrollbar{width:6px}
 body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .wrap{display:flex;flex-direction:column;min-height:100vh;padding:10px;gap:6px}
-/* Critical rows never shrink; only the tip/egress lines absorb a squeeze in
-   a short dock, so the big number + controls always render fully. */
-.top,.screen,.input-row,.cta-row{flex:0 0 auto}
+.top,.screen,.cta-row{flex:0 0 auto}
+/* Any widget can be switched off from the gear editor. */
+[hidden]{display:none!important}
+
 .top{display:flex;justify-content:space-between;align-items:center;gap:8px}
 
 /* Phase chip */
@@ -36,29 +36,48 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .pill.on{color:var(--fg)}
 .pill.on .dot{background:var(--live);box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 18%,transparent)}
 .pill.bad .dot{background:var(--fg-4)}
+/* Live-as-dot mode: collapse the pill to just its signal dot. */
+.pill.asdot{padding:4px;gap:0}
+.pill.asdot #src-lbl{display:none}
+.pill.asdot .dot{width:9px;height:9px}
 
-/* Big delay readout inside an inset "screen" */
+/* Big delay readout / setter inside an inset "screen" */
 .screen{background:var(--panel-2);border:1px solid color-mix(in srgb,var(--line) 70%,transparent);
-  border-radius:11px;padding:9px 11px;text-align:center;position:relative}
-/* Responsive so it never clips in a narrow/short dock; line-height leaves
-   room for the glyphs (line-height:1 was chopping the digits' top/bottom). */
+  border-radius:11px;padding:9px 11px;position:relative}
+.num-row{display:flex;align-items:center;justify-content:center;gap:6px}
 .cur{font-size:clamp(23px,11vw,34px);font-weight:800;letter-spacing:-1.5px;
-  font-variant-numeric:tabular-nums;line-height:1.08;transition:color .25s}
+  font-variant-numeric:tabular-nums;line-height:1.08;transition:color .25s;
+  display:inline-flex;align-items:baseline}
+/* The idle setter shares the readout's exact type so nothing jumps when the
+   dock crosses from passthrough into an armed delay. */
+.cur input{font:inherit;letter-spacing:inherit;color:inherit;background:transparent;border:0;
+  outline:none;text-align:center;width:2.7em;font-variant-numeric:tabular-nums;
+  -moz-appearance:textfield}
+.cur input::-webkit-outer-spin-button,.cur input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
 .cur .u{font-size:.4em;color:var(--fg-3);font-weight:600;margin-left:2px;letter-spacing:0}
 .cur.changing{color:var(--accent)}
+/* Number size modes */
+.sz-sm .cur{font-size:clamp(18px,7vw,24px)}
+.sz-lg .cur{font-size:clamp(30px,14vw,48px)}
+/* Round nudge buttons that flank the number; they retire once a delay is
+   engaged so the screen becomes a clean readout. */
+.np{width:30px;height:30px;flex:0 0 auto;border-radius:50%;border:1px solid var(--line);
+  background:var(--panel);color:var(--fg-2);font-size:18px;line-height:1;cursor:pointer;
+  transition:.15s cubic-bezier(.32,.72,0,1)}
+.np:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line));color:var(--fg)}
+.np:active{transform:scale(.9)}
 .bar{position:relative;height:4px;background:var(--panel);border-radius:999px;overflow:hidden;margin-top:8px}
 .bar .fill{position:absolute;inset:0 auto 0 0;width:0;border-radius:999px;
   background:linear-gradient(90deg,var(--warn),color-mix(in srgb,var(--warn) 60%,#fff));
   transition:width .35s cubic-bezier(.32,.72,0,1)}
 .bar .fill.ready {background:linear-gradient(90deg,var(--accent),color-mix(in srgb,var(--accent) 55%,#fff))}
 .bar .fill.active{background:linear-gradient(90deg,var(--live),color-mix(in srgb,var(--live) 55%,#fff))}
+.bar .pct{position:absolute;right:0;top:-14px;font-size:9.5px;color:var(--fg-3);font-variant-numeric:tabular-nums}
+.bar.thick{height:8px}
 
-/* Egress glance (destinations + bitrate), shown only while a source is live */
+/* Egress glance (destinations + bitrate) */
 .eg{display:flex;align-items:center;justify-content:center;gap:7px;font-size:11px;color:var(--fg-3);
   font-variant-numeric:tabular-nums}
-/* Fully removed from layout when offline (not just transparent) so the dock
-   stays compact and the controls sit higher. */
-.eg.hide{display:none}
 .eg b{color:var(--fg-2);font-weight:600}
 .eg .sep{color:var(--fg-4)}
 
@@ -67,19 +86,91 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
   transition:opacity .15s,transform .15s}
 .tip.fade{opacity:0;transform:translateY(2px)}
 
-/* Delay input */
-.input-row{display:flex;gap:4px;align-items:center;background:var(--panel);border:1px solid var(--line);
-  border-radius:10px;padding:3px;transition:.15s}
-.input-row:focus-within{border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
-.input-row.disabled{opacity:.4;pointer-events:none}
-.input-row input{flex:1;background:transparent;border:0;color:var(--fg);font-size:14px;font-weight:700;
-  text-align:center;font-variant-numeric:tabular-nums;outline:none;-moz-appearance:textfield;width:100%}
-.input-row input::-webkit-outer-spin-button,.input-row input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
-.input-row .step{background:transparent;border:0;color:var(--fg-3);font-size:16px;width:26px;height:26px;
-  border-radius:7px;cursor:pointer;transition:.15s;line-height:1}
-.input-row .step:hover{background:var(--line);color:var(--fg)}
-.input-row .step:active{transform:scale(.9)}
-.input-row .suf{color:var(--fg-3);font-size:11px;padding:0 6px}
+/* Destination quick-toggle strip */
+.dests{display:flex;flex-direction:column;gap:4px}
+.dest{display:flex;align-items:center;gap:8px;padding:6px 8px;border:1px solid var(--line);
+  border-radius:9px;background:var(--panel);font-size:11.5px}
+.dest .d-dot{width:7px;height:7px;border-radius:50%;background:var(--fg-4);flex:0 0 auto;transition:.2s}
+.dest.alive .d-dot{background:var(--live);box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 18%,transparent)}
+.dest .d-name{flex:1;font-weight:600;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dest .d-plat{color:var(--fg-3);font-size:10px;text-transform:uppercase;letter-spacing:.5px}
+.dest .d-rate{color:var(--live);font-size:10.5px;font-weight:700;font-variant-numeric:tabular-nums}
+/* iOS-style switch */
+.sw{width:34px;height:20px;flex:0 0 auto;border-radius:999px;border:0;background:var(--line-2);
+  position:relative;cursor:pointer;transition:.2s cubic-bezier(.32,.72,0,1)}
+.sw::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
+  background:#fff;transition:.2s cubic-bezier(.32,.72,0,1)}
+.sw.on{background:var(--live)}
+.sw.on::after{transform:translateX(14px)}
+/* Misclick guard: the row swaps to a Sure? / cancel pair for ~3s. */
+.dest .confirm{display:flex;align-items:center;gap:6px;flex:0 0 auto}
+.dest .confirm .q{color:var(--warn);font-weight:700;font-size:10.5px}
+.dest .cbtn{width:24px;height:22px;border-radius:6px;border:1px solid var(--line-2);
+  background:var(--panel-2);cursor:pointer;font-size:12px;line-height:1;color:var(--fg-2)}
+.dest .cbtn.yes{color:var(--live);border-color:color-mix(in srgb,var(--live) 45%,var(--line-2))}
+.dest .cbtn.no{color:var(--fg-3)}
+.dest .cbtn:active{transform:scale(.9)}
+.dests .empty{font-size:10.5px;color:var(--fg-3);text-align:center;padding:4px}
+/* Icons layout: destinations as compact circular badges (hover for name). */
+.dests.icons{flex-direction:row;flex-wrap:wrap;gap:7px;justify-content:center}
+.dico{width:34px;height:34px;border-radius:50%;border:1px solid var(--line);background:var(--panel);
+  display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;color:var(--fg-3);
+  cursor:pointer;transition:transform .12s cubic-bezier(.32,.72,0,1),border-color .15s,color .15s,box-shadow .2s,opacity .15s}
+.dico:hover{border-color:var(--line-2);color:var(--fg);transform:translateY(-1px)}
+.dico:active{transform:scale(.94)}
+.dico.on{color:var(--fg);border-color:var(--line-2)}
+.dico.off{opacity:.4}
+.dico.alive{border-color:color-mix(in srgb,var(--live) 55%,var(--line));box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 16%,transparent)}
+.dico.arm{border-color:var(--warn);color:var(--warn);font-size:15px;animation:dico-pulse 1s ease-in-out infinite}
+@keyframes dico-pulse{0%,100%{box-shadow:0 0 0 2px color-mix(in srgb,var(--warn) 28%,transparent)}50%{box-shadow:0 0 0 6px color-mix(in srgb,var(--warn) 8%,transparent)}}
+
+/* Delay profile chips */
+.profiles{display:flex;flex-wrap:wrap;gap:6px;justify-content:center}
+.pchip{display:inline-flex;align-items:center;gap:6px;padding:6px 11px;border-radius:9px;
+  border:1px solid var(--line);background:var(--panel);color:var(--fg);font-size:11.5px;font-weight:600;
+  cursor:pointer;transition:border-color .15s,color .15s,background .15s,transform .12s cubic-bezier(.32,.72,0,1)}
+.pchip:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
+.pchip:active{transform:scale(.96)}
+.pchip .pv{font-size:10px;font-weight:700;color:var(--fg-3);font-variant-numeric:tabular-nums}
+
+/* Health stats glance */
+.stats{display:flex;flex-wrap:wrap;gap:5px 10px;justify-content:center;font-size:11px;color:var(--fg-3);
+  font-variant-numeric:tabular-nums}
+.stats .st b{color:var(--fg-2);font-weight:700}
+.stats .st.bad{color:var(--warn);font-weight:600}
+.stats .st.muted{color:var(--fg-4)}
+
+/* Auto behavior + settings toggle rows */
+.behavior,.settings{display:flex;flex-direction:column;gap:5px}
+.brow{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:7px 9px;
+  border:1px solid var(--line);border-radius:9px;background:var(--panel);font-size:11.5px}
+.blbl{color:var(--fg-2);font-weight:600}
+.srow-btns{display:flex;gap:5px;flex:0 0 auto;align-items:center}
+.cq{font-size:10px;color:var(--warn);font-weight:600;margin-right:1px}
+
+/* Overlays list */
+.overlays{display:flex;flex-direction:column;gap:4px}
+.orow{display:flex;align-items:center;gap:8px;padding:6px 8px;border:1px solid var(--line);
+  border-radius:9px;background:var(--panel);font-size:11.5px}
+.o-name{flex:1;display:flex;align-items:center;gap:6px;font-weight:600;color:var(--fg);
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.o-tag{font-size:8.5px;text-transform:uppercase;letter-spacing:.5px;color:var(--accent);
+  border:1px solid color-mix(in srgb,var(--accent) 40%,var(--line));border-radius:999px;padding:1px 5px}
+.overlays .empty{font-size:10.5px;color:var(--fg-3);text-align:center;padding:4px}
+.osearch{width:100%;font:inherit;font-size:11.5px;color:var(--fg);background:var(--panel-2);
+  border:1px solid var(--line);border-radius:8px;padding:6px 9px;outline:none;margin-bottom:5px}
+.osearch::placeholder{color:var(--fg-4)}
+.osearch:focus{border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
+.olist{display:flex;flex-direction:column;gap:4px}
+.ogroup{font-size:9px;text-transform:uppercase;letter-spacing:1px;color:var(--fg-4);font-weight:700;margin:6px 2px 1px}
+
+/* Mini action buttons (settings + overlays) */
+.minibtn{flex:0 0 auto;padding:5px 9px;border-radius:7px;border:1px solid var(--line);background:var(--panel-2);
+  color:var(--fg-2);font-size:10.5px;font-weight:600;cursor:pointer;font-family:inherit;
+  transition:border-color .15s,color .15s,transform .12s}
+.minibtn:hover:not(:disabled){border-color:var(--line-2);color:var(--fg)}
+.minibtn:active:not(:disabled){transform:scale(.95)}
+.minibtn:disabled{opacity:.4;cursor:not-allowed}
 
 /* Buttons */
 .btn{padding:9px 10px;border-radius:9px;border:1px solid var(--line);background:var(--panel);color:var(--fg);
@@ -103,192 +194,150 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .cta-row .btn{flex:1}
 .cta-row .btn.disarm{flex:0 0 auto;padding:10px 13px}
 
+/* Status-as-dot mode: collapse the chip to a colored dot of the state hue. */
+.phase.asdot{width:14px;height:14px;min-width:14px;padding:0;font-size:0;border-radius:50%;
+  background:currentColor;box-shadow:none}
+
+/* Compact density: tighten spacing + type for gamers who want minimal chrome. */
+body.compact .wrap{padding:7px;gap:4px}
+body.compact .screen{padding:6px 9px}
+body.compact .cur{font-size:clamp(20px,9vw,28px)}
+body.compact .btn{padding:7px 9px;font-size:12px}
+body.compact .dest{padding:5px 7px}
+body.compact .eg,body.compact .tip{font-size:10px}
+
+/* Gear button - hidden until you mouse over the dock, so a live dock stays
+   clean and the control only surfaces when you go to configure it. */
+.gear{position:fixed;top:5px;right:5px;width:26px;height:26px;border-radius:8px;border:0;
+  background:transparent;color:var(--fg-3);cursor:pointer;font-size:15px;line-height:1;z-index:5;
+  opacity:0;transition:opacity .18s,color .15s,background .15s,transform .15s}
+body:hover .gear{opacity:.5}
+.gear:hover{opacity:1;color:var(--fg);background:var(--panel)}
+.gear:active{transform:scale(.92) rotate(35deg)}
+
+/* Editor: a bottom sheet that slides up over the dock */
+.editor{position:fixed;inset:0;z-index:10;display:flex;align-items:flex-end;justify-content:center;
+  background:color-mix(in srgb,#000 55%,transparent);backdrop-filter:blur(3px);
+  opacity:0;transition:opacity .22s cubic-bezier(.32,.72,0,1)}
+.editor.show{opacity:1}
+.sheet{width:100%;max-height:92vh;overflow-y:auto;background:var(--panel);
+  border:1px solid var(--line);border-bottom:0;border-radius:20px 20px 0 0;padding:8px 12px 14px;
+  box-shadow:0 -8px 40px -12px rgba(0,0,0,.6),0 -1px 0 color-mix(in srgb,#fff 6%,transparent) inset;
+  transform:translateY(16px);transition:transform .24s cubic-bezier(.32,.72,0,1)}
+.editor.show .sheet{transform:translateY(0)}
+.grabber{width:34px;height:4px;border-radius:999px;background:var(--line-2);margin:2px auto 10px}
+.ehead{display:flex;align-items:center;gap:8px;margin-bottom:2px}
+.ehead h3{margin:0;font-size:13px;font-weight:700;color:var(--fg);letter-spacing:.2px}
+.ehead .slot{font-size:10px;font-weight:600;color:var(--fg-3);background:var(--panel-2);
+  border:1px solid var(--line);border-radius:999px;padding:2px 7px}
+.eclose{margin-left:auto;width:28px;height:28px;border-radius:8px;border:1px solid var(--line);
+  background:var(--panel-2);color:var(--fg-3);font-size:16px;line-height:1;cursor:pointer;transition:.15s}
+.eclose:hover{color:var(--fg);border-color:var(--line-2)}
+.eclose:active{transform:scale(.92)}
+.lbl{font-size:9.5px;text-transform:uppercase;letter-spacing:1px;color:var(--fg-4);font-weight:700;margin:13px 2px 6px}
+.lbl.inline{margin:0}
+
+/* Preset chips */
+.chips{display:flex;flex-wrap:wrap;gap:6px}
+.chip{padding:7px 12px;border-radius:10px;border:1px solid var(--line);background:var(--panel-2);
+  color:var(--fg-2);font-size:12px;font-weight:600;cursor:pointer;
+  transition:border-color .15s,color .15s,background .15s,transform .12s}
+.chip:hover{border-color:var(--line-2);color:var(--fg)}
+.chip:active{transform:scale(.96)}
+.chip.sel{background:color-mix(in srgb,var(--accent) 18%,var(--panel));
+  border-color:color-mix(in srgb,var(--accent) 55%,var(--line));color:var(--accent)}
+.chip.add{color:var(--fg-3);border-style:dashed}
+.chip.add:hover{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
+.newdock{font:inherit;font-size:12px;font-weight:600;color:var(--fg);background:var(--panel-2);
+  border:1px solid color-mix(in srgb,var(--accent) 45%,var(--line));border-radius:10px;padding:6px 10px;outline:none;width:96px}
+.hint{font-size:10px;color:var(--fg-4);line-height:1.4;margin:7px 2px 0}
+
+/* Appearance rows: label + control on one line */
+.densrow{display:flex;align-items:center;justify-content:space-between;gap:10px;margin:9px 2px 2px}
+.swatches{display:flex;gap:7px}
+.swatch{width:22px;height:22px;border-radius:50%;border:2px solid transparent;background:var(--sw);
+  cursor:pointer;padding:0;box-shadow:0 0 0 1px var(--line) inset;transition:transform .12s cubic-bezier(.32,.72,0,1),border-color .15s}
+.swatch:hover{transform:scale(1.12)}
+.swatch:active{transform:scale(.94)}
+.swatch.sel{border-color:var(--fg)}
+
+/* Segmented "mode" control */
+.seg{display:inline-flex;background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:2px;gap:2px}
+.segb{border:0;background:transparent;color:var(--fg-3);font:inherit;font-size:11.5px;font-weight:600;
+  padding:5px 11px;border-radius:8px;cursor:pointer;font-variant-numeric:tabular-nums;
+  transition:color .15s,background .15s,box-shadow .15s,transform .12s}
+.segb:hover{color:var(--fg-2)}
+.segb:active{transform:scale(.96)}
+.segb.sel{background:var(--panel);color:var(--fg);box-shadow:0 1px 2px rgba(0,0,0,.25),0 0 0 1px var(--line)}
+
+/* Widget rows */
+.wlist{display:flex;flex-direction:column;gap:6px}
+.wrow{border:1px solid var(--line);border-radius:12px;background:var(--panel-2);
+  transition:border-color .15s,opacity .15s,box-shadow .15s}
+.wrow.off{opacity:.62}
+.wrow.dragging{opacity:.5;border-color:color-mix(in srgb,var(--accent) 50%,var(--line))}
+.wrow.drop{border-color:var(--accent);box-shadow:0 -2px 0 var(--accent)}
+.wrow .head{display:flex;align-items:center;gap:9px;padding:9px 10px}
+.grip{color:var(--fg-4);font-size:14px;line-height:1;letter-spacing:1px;cursor:grab;padding:6px 3px;user-select:none}
+.grip:hover{color:var(--fg-2)}
+.grip:active{cursor:grabbing}
+.wrow .nm{flex:1;font-size:12.5px;font-weight:600;color:var(--fg)}
+.wrow.off .nm{color:var(--fg-4)}
+.wrow .cv{color:var(--fg-4);font-size:16px;line-height:1;transition:transform .2s cubic-bezier(.32,.72,0,1)}
+.wrow.open .cv{transform:rotate(90deg)}
+.wrow .opts{display:none;flex-direction:column;gap:0;padding:0 10px 6px}
+.wrow.open .opts{display:flex}
+.optrow{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 0;
+  border-top:1px solid color-mix(in srgb,var(--line) 55%,transparent)}
+.optlbl{font-size:11.5px;color:var(--fg-2)}
+
+/* Switch size variant for option rows (base .sw defined in the dest section) */
+.sw.sm{width:30px;height:18px}
+.sw.sm::after{width:14px;height:14px}
+.sw.sm.on::after{transform:translateX(12px)}
+
+.ed-actions{display:flex;gap:8px;margin-top:14px}
+.ed-actions .btn{font-size:12px;padding:10px;border-radius:10px}
+.ed-actions .btn.ghost{flex:1}
+.ed-actions .btn.primary{flex:0 0 auto;padding:10px 18px}
+
 #toast{position:fixed;left:50%;bottom:14px;transform:translateX(-50%) translateY(40px);
   background:var(--panel);border:1px solid var(--line-2);color:var(--fg);font-size:11px;padding:6px 12px;
-  border-radius:9px;pointer-events:none;opacity:0;transition:.25s cubic-bezier(.32,.72,0,1);white-space:nowrap;max-width:90%}
+  border-radius:9px;pointer-events:none;opacity:0;transition:.25s cubic-bezier(.32,.72,0,1);white-space:nowrap;max-width:90%;z-index:20}
 #toast.show{transform:translateX(-50%) translateY(0);opacity:1}
 #toast.err{border-color:var(--danger);color:color-mix(in srgb,var(--danger) 60%,#fff)}
 #toast.ok{border-color:var(--live);color:color-mix(in srgb,var(--live) 55%,#fff)}
 </style></head><body>
+<button class="gear" id="gear" title="Customize dock" onclick="openEditor()">&#9881;</button>
 <div class="wrap">
-  <div class="top">
+  <div class="top" id="w-top">
     <span class="phase" id="ph">Idle</span>
     <span class="pill bad" id="src"><span class="dot"></span><span id="src-lbl">Offline</span></span>
   </div>
-  <div class="screen">
-    <div class="cur"><span id="v">0.0</span><span class="u">s</span></div>
-    <div class="bar"><div class="fill" id="bar"></div></div>
+  <div class="screen" id="w-screen">
+    <div class="num-row">
+      <button class="np" id="minus" onclick="bump(-1)" title="less delay">&minus;</button>
+      <span class="cur" id="cur">
+        <input id="d" type="number" min="0" max="600" value="0" inputmode="numeric">
+        <span id="v" hidden>0.0</span><span class="u">s</span>
+      </span>
+      <button class="np" id="plus" onclick="bump(1)" title="more delay">+</button>
+    </div>
+    <div class="bar" id="w-bar"><span class="pct" id="pct" hidden></span><div class="fill" id="bar"></div></div>
   </div>
-  <div class="eg hide" id="eg"></div>
-  <div class="tip" id="sub">Waiting for your encoder…</div>
-  <div class="input-row" id="d-row">
-    <button class="step" onclick="bump(-5)" title="-5s">−</button>
-    <input id="d" type="number" min="0" max="600" value="0" inputmode="numeric">
-    <span class="suf">s</span>
-    <button class="step" onclick="bump(5)" title="+5s">+</button>
-  </div>
-  <div class="cta-row">
+  <div class="eg" id="w-eg" hidden></div>
+  <div class="tip" id="w-tip">Waiting for your encoder&hellip;</div>
+  <div class="dests" id="w-dests" hidden></div>
+  <div class="profiles" id="w-profiles" hidden></div>
+  <div class="stats" id="w-stats" hidden></div>
+  <div class="behavior" id="w-behavior" hidden></div>
+  <div class="settings" id="w-settings" hidden></div>
+  <div class="overlays" id="w-overlays" hidden></div>
+  <div class="cta-row" id="w-cta">
     <button class="btn full" id="main" onclick="mainClick()" disabled>-</button>
-    <button class="btn ghost disarm" id="cancel" onclick="disarmClick()" hidden title="Cancel arming">✕</button>
+    <button class="btn ghost disarm" id="cancel" onclick="disarmClick()" hidden title="Cancel arming">&times;</button>
   </div>
 </div>
 <div id="toast"></div>
-<script>
-const $=id=>document.getElementById(id);
-const PHASE_TO_STATE={idle:'off',preparing:'arming',ready:'armed',active:'active'};
-let s=null, lastVal='0.0', pending=null;
-async function fetchJ(u,o){try{const r=await fetch(u,o);const j=r.headers.get('content-type')?.includes('json')?await r.json():null;return {ok:r.ok,status:r.status,j}}catch(_){return {ok:false,status:0,j:null}}}
-function bump(n){const i=$('d');i.value=Math.max(0,Math.min(600,(+i.value||0)+n));renderCta()}
-$('d').addEventListener('input',renderCta);
-function toast(msg,kind){const t=$('toast');t.className='show '+(kind||'');t.textContent=msg;clearTimeout(t._h);t._h=setTimeout(()=>t.className='',1800)}
-function setPending(p){pending=p;setTimeout(()=>pending=null,1500);tick()}
-function fmtRate(k){if(!k||k<=0)return '';return k>=1000?(k/1000).toFixed(2)+' Mbps':Math.round(k)+' kbps'}
-// Crossfade helper so the sub-tip swaps smoothly instead of snapping.
-function setTip(text){const el=$('sub');if(el.textContent===text)return;el.classList.add('fade');clearTimeout(el._t);el._t=setTimeout(()=>{el.textContent=text;el.classList.remove('fade')},140)}
-async function arm(ms){
-  setPending('arming');
-  const r=await fetchJ('/arm',{method:'POST',headers:{'content-type':'application/x-www-form-urlencoded'},body:'ms='+ms});
-  if(!r.ok){toast(r.j?.error||'Failed to arm','err');pending=null}
-  else toast(`Arming ${(ms/1000).toFixed(0)}s`,'ok');
-  tick();
-}
-async function activate(){
-  setPending('active');
-  const r=await fetchJ('/activate',{method:'POST'});
-  if(!r.ok){toast(r.j?.error||'Cannot activate yet','err');pending=null}
-  else toast('Delay active','ok');
-  tick();
-}
-async function stop(){
-  setPending('off');
-  await fetchJ('/stop',{method:'POST'});
-  toast('Back to live','ok');
-  tick();
-}
-async function disarm(){
-  setPending('off');
-  await fetchJ('/disarm',{method:'POST'});
-  toast('Disarmed','ok');
-  tick();
-}
-function mainClick(){
-  const m=$('main'); if(m._busy||m.disabled)return;
-  m._busy=true;setTimeout(()=>m._busy=false,300);
-  if(!s)return;
-  const ds=PHASE_TO_STATE[s.phase]||'off';
-  if(ds==='active')return stop();
-  if(ds==='armed') return activate();
-  if(ds==='arming')return disarm();   // double-click safety: arming primary disarms too
-  const ms=(+$('d').value||0)*1000;
-  if(ms>0)arm(ms); else toast('Enter a delay','err');
-}
-function disarmClick(){
-  const b=$('cancel'); if(b._busy)return;
-  b._busy=true;setTimeout(()=>b._busy=false,300);
-  disarm();
-}
-function fmt(ms){if(ms<100)return '0.0';const x=Math.round(ms/100)/10;return x<10?x.toFixed(1):Math.round(x).toString()}
-function renderCta(){
-  if(!s){return}
-  const m=$('main'),cancel=$('cancel');
-  const ds=pending||PHASE_TO_STATE[s.phase]||'off';
-  const ingest=s.ingest_alive;
-  m.className='btn full';m.disabled=false;cancel.hidden=true;
-  $('d-row').classList.toggle('disabled',ds==='arming'||ds==='armed'||ds==='active');
-  if(ds==='active'){
-    m.textContent='Cut delay';m.classList.add('danger');
-  } else if(ds==='armed'){
-    m.innerHTML='<span>▶</span> Activate';m.classList.add('go');
-    cancel.hidden=false;
-  } else if(ds==='arming'){
-    const tgt=s.armed_delay_ms||1;
-    const pct=Math.min(99,Math.round((s.buffer_fill_ms/tgt)*100));
-    m.innerHTML=`<span class="spin"></span> Buffering ${pct}%`;m.disabled=true;
-    cancel.hidden=false;
-  } else {
-    const ms=(+$('d').value||0)*1000;
-    if(!ingest){m.textContent='Waiting for encoder…';m.disabled=true}
-    else if(ms<=0){m.textContent='Set a delay above';m.disabled=true}
-    else {m.innerHTML=`<span>⏱</span> Arm ${(ms/1000).toFixed(0)}s`;m.classList.add('primary')}
-  }
-}
-function applyState(j){
-  s=j;
-  const ds=PHASE_TO_STATE[s.phase]||'off';
-  // Phase chip - distinguishes idle vs passthrough vs arming/armed/active
-  const phMap={off:s.ingest_alive?['live','Live']:['off','Idle'],arming:['arming','Buffering'],armed:['armed','Armed'],active:['active','Active']};
-  const [cls,txt]=phMap[ds];
-  $('ph').className='phase '+cls;
-  $('ph').textContent=txt;
-  // Source pill - encoder connected or not (any RTMP encoder, not just OBS)
-  $('src').className='pill '+(s.ingest_alive?'on':'bad');
-  $('src-lbl').textContent=s.ingest_alive?'Live':'Offline';
-  // Current delay - mirror the dashboard: show the armed target while a
-  // delay is engaged (or the fill while arming) and 0 in passthrough.
-  // Using current_delay_ms directly showed the pipeline's own ~1s
-  // transit latency as "1.0s" even in passthrough, a phantom delay.
-  const tgtSec=(s.armed_delay_ms||0)/1000, fillSec=(s.buffer_fill_ms||0)/1000;
-  const showSec = ds==='arming' ? Math.min(fillSec,tgtSec)
-                : (ds==='armed'||ds==='active') ? tgtSec : 0;
-  const nv=fmt(showSec*1000);
-  if(nv!==lastVal){$('v').textContent=nv;lastVal=nv;
-    $('v').parentElement.classList.add('changing');setTimeout(()=>$('v').parentElement.classList.remove('changing'),350);
-  }
-  // Progress bar
-  const target=s.armed_delay_ms||s.buffer_target_ms||0;
-  const fill=$('bar');
-  fill.classList.remove('ready','active');
-  if(ds==='active'){fill.style.width='100%';fill.classList.add('active')}
-  else if(target>0){
-    const pct=Math.min(100,(Math.min(s.buffer_fill_ms,target)/target)*100);
-    fill.style.width=pct+'%';
-    if(pct>=99)fill.classList.add('ready');
-  } else {fill.style.width='0%'}
-  // Egress glance: where the feed is going + live bitrate. Only meaningful
-  // once a source is connected.
-  const eg=$('eg');
-  if(s.ingest_alive){
-    const alive=s.destinations_alive||0, tot=s.destinations_total||0;
-    const rate=fmtRate(s.stats&&s.stats.bitrate_kbps);
-    let html=`<span>▲</span><b>${alive}/${tot||0}</b> live`;
-    if(rate) html+=`<span class="sep">·</span><b>${rate}</b> in`;
-    eg.innerHTML=html; eg.classList.remove('hide');
-  } else { eg.classList.add('hide'); }
-  // Sub-tip (crossfaded)
-  setTip(
-    !s.ingest_alive ? 'Point your encoder at rtmp://…/live' :
-    ds==='active'   ? `Live ${(s.current_delay_ms/1000).toFixed(1)}s behind real time.` :
-    ds==='armed'    ? 'Buffer full. Hit Activate to go live with delay.' :
-    ds==='arming'   ? 'Filling buffer… you can cancel any time.' :
-                      'Passthrough - no delay applied.');
-  renderCta();
-}
-async function tick(){
-  const r=await fetchJ('/state');
-  if(!r.ok||!r.j){$('src').className='pill bad';$('src-lbl').textContent='Offline';return}
-  applyState(r.j);
-}
-// Prefer Server-Sent Events for state updates - one long-lived connection
-// the server writes to only when something changes. Falls back to 500 ms
-// polling if EventSource is missing or the stream drops.
-let _pollTimer=null;
-function startPolling(){
-  if(_pollTimer)return;
-  tick();
-  _pollTimer=setInterval(tick,500);
-}
-function stopPolling(){
-  if(_pollTimer){clearInterval(_pollTimer);_pollTimer=null}
-}
-let _es=null;
-function startSSE(){
-  if(!window.EventSource){startPolling();return}
-  try{
-    _es=new EventSource('/events');
-    _es.onmessage=ev=>{try{applyState(JSON.parse(ev.data));stopPolling()}catch(_){}};
-    _es.onerror=()=>{try{_es.close()}catch(_){}_es=null;startPolling()};
-  }catch(_){startPolling()}
-}
-startSSE();
-window.addEventListener('focus',()=>{ if(!_es)tick(); });
-</script></body></html>
+<script src="/dock.js"></script>
+</body></html>

--- a/web/dock.html
+++ b/web/dock.html
@@ -23,7 +23,8 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 /* Phase chip */
 .phase{padding:3px 10px;border-radius:999px;font-size:10.5px;font-weight:700;
   text-transform:uppercase;letter-spacing:1.2px;border:1px solid var(--line);
-  background:var(--panel);color:var(--fg-3);transition:.25s cubic-bezier(.32,.72,0,1)}
+  background:var(--panel);color:var(--fg-3);
+  transition:color .25s,background-color .25s,border-color .25s,box-shadow .25s}
 .phase.live  {color:var(--live);  border-color:color-mix(in srgb,var(--live) 40%,var(--line));  background:color-mix(in srgb,var(--live) 12%,var(--panel))}
 .phase.arming{color:var(--warn);  border-color:color-mix(in srgb,var(--warn) 40%,var(--line));  background:color-mix(in srgb,var(--warn) 12%,var(--panel))}
 .phase.armed {color:var(--accent);border-color:color-mix(in srgb,var(--accent) 40%,var(--line));background:color-mix(in srgb,var(--accent) 12%,var(--panel))}
@@ -32,9 +33,14 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 /* Signal pill */
 .pill{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;
   font-size:11px;font-weight:500;border:1px solid var(--line);background:var(--panel);color:var(--fg-3)}
-.pill .dot{width:6px;height:6px;border-radius:50%;background:var(--fg-4);transition:.2s}
+.pill .dot{width:6px;height:6px;border-radius:50%;background:var(--fg-4);
+  transition:background-color .2s,box-shadow .2s}
 .pill.on{color:var(--fg)}
-.pill.on .dot{background:var(--live);box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 18%,transparent)}
+/* Gentle breathing on the live dot - the dock reads "alive" at a glance. */
+.pill.on .dot{background:var(--live);animation:breathe 2.4s ease-in-out infinite}
+@keyframes breathe{
+  0%,100%{box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 18%,transparent)}
+  50%{box-shadow:0 0 0 5px color-mix(in srgb,var(--live) 7%,transparent)}}
 .pill.bad .dot{background:var(--fg-4)}
 /* Live-as-dot mode: collapse the pill to just its signal dot. */
 .pill.asdot{padding:4px;gap:0}
@@ -46,7 +52,8 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
   border-radius:11px;padding:9px 11px;position:relative}
 .num-row{display:flex;align-items:center;justify-content:center;gap:6px}
 .cur{font-size:clamp(23px,11vw,34px);font-weight:800;letter-spacing:-1.5px;
-  font-variant-numeric:tabular-nums;line-height:1.08;transition:color .25s;
+  font-variant-numeric:tabular-nums;line-height:1.08;
+  transition:color .25s,transform .25s cubic-bezier(.32,.72,0,1);
   display:inline-flex;align-items:baseline}
 /* The idle setter shares the readout's exact type so nothing jumps when the
    dock crosses from passthrough into an armed delay. */
@@ -55,7 +62,7 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
   -moz-appearance:textfield}
 .cur input::-webkit-outer-spin-button,.cur input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
 .cur .u{font-size:.4em;color:var(--fg-3);font-weight:600;margin-left:2px;letter-spacing:0}
-.cur.changing{color:var(--accent)}
+.cur.changing{color:var(--accent);transform:scale(1.04)}
 /* Number size modes */
 .sz-sm .cur{font-size:clamp(18px,7vw,24px)}
 .sz-lg .cur{font-size:clamp(30px,14vw,48px)}
@@ -63,9 +70,11 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
    engaged so the screen becomes a clean readout. */
 .np{width:30px;height:30px;flex:0 0 auto;border-radius:50%;border:1px solid var(--line);
   background:var(--panel);color:var(--fg-2);font-size:18px;line-height:1;cursor:pointer;
-  transition:.15s cubic-bezier(.32,.72,0,1)}
-.np:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line));color:var(--fg)}
-.np:active{transform:scale(.9)}
+  transition:border-color .15s,background-color .15s,color .15s,opacity .15s,
+    transform .15s cubic-bezier(.32,.72,0,1)}
+.np:hover:not(:disabled){border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line));color:var(--fg)}
+.np:active:not(:disabled){transform:scale(.96)}
+.np:disabled{opacity:.3;cursor:default;pointer-events:none}
 .bar{position:relative;height:4px;background:var(--panel);border-radius:999px;overflow:hidden;margin-top:8px}
 .bar .fill{position:absolute;inset:0 auto 0 0;width:0;border-radius:999px;
   background:linear-gradient(90deg,var(--warn),color-mix(in srgb,var(--warn) 60%,#fff));
@@ -90,26 +99,33 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .dests{display:flex;flex-direction:column;gap:4px}
 .dest{display:flex;align-items:center;gap:8px;padding:6px 8px;border:1px solid var(--line);
   border-radius:9px;background:var(--panel);font-size:11.5px}
-.dest .d-dot{width:7px;height:7px;border-radius:50%;background:var(--fg-4);flex:0 0 auto;transition:.2s}
+.dest .d-dot{width:7px;height:7px;border-radius:50%;background:var(--fg-4);flex:0 0 auto;
+  transition:background-color .2s,box-shadow .2s}
 .dest.alive .d-dot{background:var(--live);box-shadow:0 0 0 3px color-mix(in srgb,var(--live) 18%,transparent)}
 .dest .d-name{flex:1;font-weight:600;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .dest .d-plat{color:var(--fg-3);font-size:10px;text-transform:uppercase;letter-spacing:.5px}
 .dest .d-rate{color:var(--live);font-size:10.5px;font-weight:700;font-variant-numeric:tabular-nums}
 /* iOS-style switch */
 .sw{width:34px;height:20px;flex:0 0 auto;border-radius:999px;border:0;background:var(--line-2);
-  position:relative;cursor:pointer;transition:.2s cubic-bezier(.32,.72,0,1)}
+  position:relative;cursor:pointer;transition:background-color .2s cubic-bezier(.32,.72,0,1)}
+/* Invisible halo so the small switch is comfortable to hit. */
+.sw::before{content:"";position:absolute;inset:-6px -5px}
 .sw::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
-  background:#fff;transition:.2s cubic-bezier(.32,.72,0,1)}
+  background:#fff;transition:transform .2s cubic-bezier(.32,.72,0,1)}
+.sw:active::after{transform:scale(.92)}
+.sw.on:active::after{transform:translateX(14px) scale(.92)}
 .sw.on{background:var(--live)}
 .sw.on::after{transform:translateX(14px)}
 /* Misclick guard: the row swaps to a Sure? / cancel pair for ~3s. */
 .dest .confirm{display:flex;align-items:center;gap:6px;flex:0 0 auto}
 .dest .confirm .q{color:var(--warn);font-weight:700;font-size:10.5px}
 .dest .cbtn{width:24px;height:22px;border-radius:6px;border:1px solid var(--line-2);
-  background:var(--panel-2);cursor:pointer;font-size:12px;line-height:1;color:var(--fg-2)}
+  background:var(--panel-2);cursor:pointer;font-size:12px;line-height:1;color:var(--fg-2);
+  position:relative;transition:transform .12s cubic-bezier(.32,.72,0,1)}
+.dest .cbtn::before{content:"";position:absolute;inset:-5px}
 .dest .cbtn.yes{color:var(--live);border-color:color-mix(in srgb,var(--live) 45%,var(--line-2))}
 .dest .cbtn.no{color:var(--fg-3)}
-.dest .cbtn:active{transform:scale(.9)}
+.dest .cbtn:active{transform:scale(.96)}
 .dests .empty{font-size:10.5px;color:var(--fg-3);text-align:center;padding:4px}
 /* Icons layout: destinations as compact circular badges (hover for name). */
 .dests.icons{flex-direction:row;flex-wrap:wrap;gap:7px;justify-content:center}
@@ -139,7 +155,7 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
   font-size:11.5px;font-weight:600;cursor:pointer;font-family:inherit;
   transition:border-color .15s,background .15s,transform .12s cubic-bezier(.32,.72,0,1)}
 .prow:hover{border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
-.prow:active{transform:scale(.98)}
+.prow:active{transform:scale(.96)}
 .prow .pv{color:var(--fg-3);font-variant-numeric:tabular-nums;font-weight:700;font-size:10.5px}
 
 /* Health stats glance: inline row, or a tile grid for glanceability */
@@ -184,19 +200,26 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
   color:var(--fg-2);font-size:10.5px;font-weight:600;cursor:pointer;font-family:inherit;
   transition:border-color .15s,color .15s,transform .12s}
 .minibtn:hover:not(:disabled){border-color:var(--line-2);color:var(--fg)}
-.minibtn:active:not(:disabled){transform:scale(.95)}
+.minibtn:active:not(:disabled){transform:scale(.96)}
 .minibtn:disabled{opacity:.4;cursor:not-allowed}
 
 /* Buttons */
 .btn{padding:9px 10px;border-radius:9px;border:1px solid var(--line);background:var(--panel);color:var(--fg);
-  font-size:13px;font-weight:600;cursor:pointer;transition:.15s cubic-bezier(.32,.72,0,1);font-family:inherit;
+  font-size:13px;font-weight:600;cursor:pointer;font-family:inherit;
+  transition:border-color .15s,background-color .15s,color .15s,box-shadow .2s,opacity .15s,
+    transform .15s cubic-bezier(.32,.72,0,1);
   display:flex;align-items:center;justify-content:center;gap:7px}
 .btn:hover:not(:disabled){border-color:var(--line-2);background:color-mix(in srgb,var(--panel) 70%,var(--line))}
-.btn:active:not(:disabled){transform:scale(.98)}
+.btn:active:not(:disabled){transform:scale(.96)}
 .btn.primary{background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 82%,#000));color:var(--accent-ink);border-color:transparent}
 .btn.primary:hover:not(:disabled){box-shadow:0 6px 18px -6px color-mix(in srgb,var(--accent) 70%,transparent)}
-.btn.go{background:linear-gradient(180deg,var(--live),color-mix(in srgb,var(--live) 82%,#000));color:#04140a;border-color:transparent}
+.btn.go{background:linear-gradient(180deg,var(--live),color-mix(in srgb,var(--live) 82%,#000));color:#04140a;border-color:transparent;
+  animation:readyglow 1.8s ease-in-out infinite}
 .btn.go:hover:not(:disabled){box-shadow:0 6px 18px -6px color-mix(in srgb,var(--live) 70%,transparent)}
+/* Buffer is full and waiting on the streamer - breathe so the eye lands here. */
+@keyframes readyglow{
+  0%,100%{box-shadow:0 2px 8px -4px color-mix(in srgb,var(--live) 30%,transparent)}
+  50%{box-shadow:0 6px 22px -6px color-mix(in srgb,var(--live) 60%,transparent)}}
 .btn.danger{background:linear-gradient(180deg,var(--danger),color-mix(in srgb,var(--danger) 82%,#000));color:#fff;border-color:transparent}
 .btn.danger:hover:not(:disabled){box-shadow:0 6px 18px -6px color-mix(in srgb,var(--danger) 70%,transparent)}
 .btn.ghost{background:transparent;border-color:var(--line);color:var(--fg-2)}
@@ -225,10 +248,12 @@ body.compact .eg,body.compact .tip{font-size:10px}
    clean and the control only surfaces when you go to configure it. */
 .gear{position:fixed;top:5px;right:5px;width:26px;height:26px;border-radius:8px;border:0;
   background:transparent;color:var(--fg-3);cursor:pointer;font-size:15px;line-height:1;z-index:5;
-  opacity:0;transition:opacity .18s,color .15s,background .15s,transform .15s}
+  opacity:0;transition:opacity .18s,color .15s,background-color .15s,transform .15s}
+/* Invisible halo: the gear is the dock's main entry point, keep it easy to hit. */
+.gear::before{content:"";position:absolute;inset:-8px}
 body:hover .gear{opacity:.5}
 .gear:hover{opacity:1;color:var(--fg);background:var(--panel)}
-.gear:active{transform:scale(.92) rotate(35deg)}
+.gear:active{transform:scale(.96) rotate(30deg)}
 
 /* Editor: a bottom sheet that slides up over the dock */
 .editor{position:fixed;inset:0;z-index:10;display:flex;align-items:flex-end;justify-content:center;
@@ -246,9 +271,10 @@ body:hover .gear{opacity:.5}
 .ehead .slot{font-size:10px;font-weight:600;color:var(--fg-3);background:var(--panel-2);
   border:1px solid var(--line);border-radius:999px;padding:2px 7px}
 .eclose{margin-left:auto;width:28px;height:28px;border-radius:8px;border:1px solid var(--line);
-  background:var(--panel-2);color:var(--fg-3);font-size:16px;line-height:1;cursor:pointer;transition:.15s}
+  background:var(--panel-2);color:var(--fg-3);font-size:16px;line-height:1;cursor:pointer;
+  transition:color .15s,border-color .15s,transform .15s}
 .eclose:hover{color:var(--fg);border-color:var(--line-2)}
-.eclose:active{transform:scale(.92)}
+.eclose:active{transform:scale(.96)}
 .lbl{font-size:9.5px;text-transform:uppercase;letter-spacing:1px;color:var(--fg-4);font-weight:700;margin:13px 2px 6px}
 .lbl.inline{margin:0}
 
@@ -273,7 +299,7 @@ body:hover .gear{opacity:.5}
 .swatch{width:22px;height:22px;border-radius:50%;border:2px solid transparent;background:var(--sw);
   cursor:pointer;padding:0;box-shadow:0 0 0 1px var(--line) inset;transition:transform .12s cubic-bezier(.32,.72,0,1),border-color .15s}
 .swatch:hover{transform:scale(1.12)}
-.swatch:active{transform:scale(.94)}
+.swatch:active{transform:scale(.96)}
 .swatch.sel{border-color:var(--fg)}
 
 /* Segmented "mode" control */
@@ -287,7 +313,7 @@ body:hover .gear{opacity:.5}
 
 /* Widget rows */
 .wlist{display:flex;flex-direction:column;gap:6px}
-.wrow{border:1px solid var(--line);border-radius:12px;background:var(--panel-2);
+.wrow{border:1px solid var(--line);border-radius:10px;background:var(--panel-2);
   transition:border-color .15s,opacity .15s,box-shadow .15s}
 .wrow.off{opacity:.62}
 .wrow.dragging{opacity:.5;border-color:color-mix(in srgb,var(--accent) 50%,var(--line))}
@@ -310,6 +336,7 @@ body:hover .gear{opacity:.5}
 .sw.sm{width:30px;height:18px}
 .sw.sm::after{width:14px;height:14px}
 .sw.sm.on::after{transform:translateX(12px)}
+.sw.sm.on:active::after{transform:translateX(12px) scale(.92)}
 
 .ed-actions{display:flex;gap:8px;margin-top:14px}
 .ed-actions .btn{font-size:12px;padding:10px;border-radius:10px}
@@ -320,10 +347,38 @@ body:hover .gear{opacity:.5}
 
 #toast{position:fixed;left:50%;bottom:14px;transform:translateX(-50%) translateY(40px);
   background:var(--panel);border:1px solid var(--line-2);color:var(--fg);font-size:11px;padding:6px 12px;
-  border-radius:9px;pointer-events:none;opacity:0;transition:.25s cubic-bezier(.32,.72,0,1);white-space:nowrap;max-width:90%;z-index:20}
+  border-radius:9px;pointer-events:none;opacity:0;white-space:nowrap;max-width:90%;z-index:20;
+  transition:transform .25s cubic-bezier(.32,.72,0,1),opacity .25s,border-color .25s,color .25s}
 #toast.show{transform:translateX(-50%) translateY(0);opacity:1}
 #toast.err{border-color:var(--danger);color:color-mix(in srgb,var(--danger) 60%,#fff)}
 #toast.ok{border-color:var(--live);color:color-mix(in srgb,var(--live) 55%,#fff)}
+
+/* First-paint entrance: widgets rise in with a small stagger. The `boot`
+   class comes off after one pass so saves/reorders never replay it. */
+body.boot .wrap>*{animation:rise .38s cubic-bezier(.32,.72,0,1) both}
+body.boot .wrap>*:nth-child(2){animation-delay:.04s}
+body.boot .wrap>*:nth-child(3){animation-delay:.08s}
+body.boot .wrap>*:nth-child(4){animation-delay:.12s}
+body.boot .wrap>*:nth-child(5){animation-delay:.16s}
+body.boot .wrap>*:nth-child(6){animation-delay:.20s}
+body.boot .wrap>*:nth-child(7){animation-delay:.24s}
+body.boot .wrap>*:nth-child(n+8){animation-delay:.28s}
+@keyframes rise{from{opacity:0;transform:translateY(6px)}}
+
+/* Keyboard focus ring, only for keyboard (not mouse) focus. */
+:where(button,input):focus-visible{outline:2px solid color-mix(in srgb,var(--accent) 70%,transparent);outline-offset:1px}
+
+/* Very narrow dock: shave the chrome so content keeps breathing room. */
+@media (max-width:220px){
+  .wrap{padding:7px;gap:5px}
+  .top,.eg{flex-wrap:wrap}
+  .btn{font-size:12px;padding:8px}
+}
+
+/* Respect the OS motion preference: kill entrances and looping pulses. */
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
+}
 </style></head><body>
 <button class="gear" id="gear" title="Customize dock" onclick="openEditor()">&#9881;</button>
 <div class="wrap">

--- a/web/dock.html
+++ b/web/dock.html
@@ -247,6 +247,14 @@ body::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:999px}
 .cta-row{display:flex;gap:6px}
 .cta-row .btn{flex:1}
 .cta-row .btn.disarm{flex:0 0 auto;padding:10px 13px}
+/* Safe cut ("cut after airs") secondary: text button; pending state counts
+   down in warn amber with a soft pulse so the armed auto-cut is unmissable. */
+.cta-row .btn.cutafter{flex:0 0 auto;padding:10px 11px;font-size:11.5px;white-space:nowrap}
+.cta-row .btn.cutafter.pending{border-color:color-mix(in srgb,var(--warn) 55%,var(--line));color:var(--warn);
+  font-variant-numeric:tabular-nums;animation:cutpulse 1.6s ease-in-out infinite}
+@keyframes cutpulse{
+  0%,100%{box-shadow:0 0 0 0 color-mix(in srgb,var(--warn) 22%,transparent)}
+  50%{box-shadow:0 0 0 4px color-mix(in srgb,var(--warn) 10%,transparent)}}
 
 /* Status-as-dot mode: collapse the chip to a colored dot of the state hue. */
 .phase.asdot{width:14px;height:14px;min-width:14px;padding:0;font-size:0;border-radius:50%;
@@ -423,7 +431,7 @@ body.boot .wrap>*:nth-child(n+8){animation-delay:.28s}
   <div class="overlays" id="w-overlays" hidden></div>
   <div class="cta-row" id="w-cta">
     <button class="btn full" id="main" onclick="mainClick()" disabled>-</button>
-    <button class="btn ghost disarm" id="cancel" onclick="disarmClick()" hidden title="Cancel arming">&times;</button>
+    <button class="btn ghost disarm" id="cancel" onclick="secondaryClick()" hidden title="Cancel arming">&times;</button>
   </div>
 </div>
 <div id="toast"></div>

--- a/web/dock.js
+++ b/web/dock.js
@@ -1,0 +1,846 @@
+// InstantClone OBS dock: a configurable stack of widgets driven by a saved
+// layout. The layout is per-slot (?dock=<id>), persisted server-side so it
+// survives OBS clearing its browser cache, with a localStorage mirror for
+// instant paint. dock.html holds the markup+CSS; this file is all behaviour.
+
+const $ = id => document.getElementById(id);
+const PHASE_TO_STATE = { idle: 'off', preparing: 'arming', ready: 'armed', active: 'active' };
+let s = null, lastVal = '0.0', pending = null;
+
+async function fetchJ(u, o) {
+  try {
+    const r = await fetch(u, o);
+    const j = r.headers.get('content-type')?.includes('json') ? await r.json() : null;
+    return { ok: r.ok, status: r.status, j };
+  } catch (_) { return { ok: false, status: 0, j: null }; }
+}
+function toast(msg, kind) {
+  const t = $('toast'); t.className = 'show ' + (kind || ''); t.textContent = msg;
+  clearTimeout(t._h); t._h = setTimeout(() => t.className = '', 1800);
+}
+function esc(v) {
+  return String(v).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+// ---------------------------------------------------------------- config ----
+
+// The dock slot this page is (?dock=<id>). Sanitised to match the server's
+// allowed key charset so a hand-typed slot can round-trip to storage.
+const SLOT = ((new URLSearchParams(location.search).get('dock') || 'default')
+  .replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40)) || 'default';
+
+// Widget catalog: id -> label + default options (on + per-widget knobs).
+const WIDGETS = {
+  status:   { label: 'Status bar',    def: { on: true } },
+  phase:    { label: 'Phase chip',    def: { on: true, style: 'chip' } },
+  source:   { label: 'Live pill',     def: { on: true, style: 'pill' } },
+  number:   { label: 'Delay number',  def: { on: true, units: true, step: 5, controls: true, size: 'md' } },
+  bar:      { label: 'Buffer bar',    def: { on: true, pct: false, thick: false } },
+  egress:   { label: 'Egress glance', def: { on: true, dests: true, bitrate: true, codec: false } },
+  tips:     { label: 'Hint text',     def: { on: true, errorsOnly: false } },
+  dest:     { label: 'Destinations',  def: { on: false, confirm: true, view: 'rows', active: false, stats: false } },
+  profiles: { label: 'Delay profiles',def: { on: false, arm: false, value: true } },
+  stats:    { label: 'Health stats',  def: { on: false, cpu: true, mem: true, recon: true, bitrate: false, cuts: false } },
+  behavior: { label: 'Auto behavior', def: { on: false } },
+  settings: { label: 'Settings',      def: { on: false } },
+  overlays: { label: 'Overlays',      def: { on: false, autohide: false, search: true, group: true } },
+  activate: { label: 'Action button', def: { on: true, confirmcut: false } },
+};
+// Every widget that has stored options. phase + source are sub-widgets of the
+// status bar; bar rides along with the number screen it lives in.
+const ALL = ['status', 'phase', 'source', 'number', 'bar', 'egress', 'tips', 'dest', 'profiles', 'stats', 'behavior', 'settings', 'overlays', 'activate'];
+// Reorderable rows = the top-level containers the user can drag around.
+const ROWS = ['status', 'number', 'profiles', 'egress', 'tips', 'dest', 'stats', 'behavior', 'settings', 'overlays', 'activate'];
+// DOM container per row.
+const WEL = {
+  status: 'w-top', number: 'w-screen', profiles: 'w-profiles', egress: 'w-eg', tips: 'w-tip', dest: 'w-dests',
+  stats: 'w-stats', behavior: 'w-behavior', settings: 'w-settings', overlays: 'w-overlays', activate: 'w-cta',
+};
+// Presets = which widgets are on. Options keep their defaults / last tweak.
+const ALL_ON = ['status', 'phase', 'source', 'number', 'bar', 'egress', 'tips', 'dest', 'profiles', 'stats', 'behavior', 'settings', 'overlays', 'activate'];
+const PRESETS = {
+  full:      { label: 'Full',         on: ['status', 'phase', 'source', 'number', 'bar', 'egress', 'tips', 'dest', 'activate'] },
+  minimal:   { label: 'Minimal',      on: ['status', 'phase', 'source', 'number', 'activate'] },
+  delay:     { label: 'Delay only',   on: ['number', 'activate'] },
+  dest:      { label: 'Destinations', on: ['status', 'phase', 'source', 'dest'] },
+  control:   { label: 'Control',      on: ['status', 'source', 'behavior', 'settings', 'overlays'] },
+  dashboard: { label: 'Dashboard',    on: ALL_ON },
+};
+// Editable options per row. An option targets another widget's store via `w`
+// (phase/source live under the status bar; bar under the number screen),
+// renders as a segmented mode picker via `modes`/`sel`, else a switch.
+const OPTS = {
+  status: [
+    { k: 'on', label: 'Phase chip', w: 'phase' },
+    { k: 'style', label: 'Phase', w: 'phase', modes: [['chip', 'Chip'], ['dot', 'Dot']] },
+    { k: 'on', label: 'Live pill', w: 'source' },
+    { k: 'style', label: 'Live', w: 'source', modes: [['pill', 'Pill'], ['dot', 'Dot']] },
+  ],
+  number: [
+    { k: 'size', label: 'Size', modes: [['sm', 'S'], ['md', 'M'], ['lg', 'L']] },
+    { k: 'step', label: 'Step', sel: [1, 5, 10] },
+    { k: 'controls', label: '+/- buttons' }, { k: 'units', label: 'Unit' },
+    { k: 'on', label: 'Buffer bar', w: 'bar' }, { k: 'pct', label: 'Show %', w: 'bar' }, { k: 'thick', label: 'Thick bar', w: 'bar' },
+  ],
+  egress: [{ k: 'dests', label: 'Dest count' }, { k: 'bitrate', label: 'Bitrate' }, { k: 'codec', label: 'Codec' }],
+  tips:   [{ k: 'errorsOnly', label: 'Errors only' }],
+  dest:   [
+    { k: 'view', label: 'Layout', modes: [['rows', 'Rows'], ['icons', 'Icons']] },
+    { k: 'confirm', label: 'Confirm tap' }, { k: 'stats', label: 'Show bitrate' }, { k: 'active', label: 'Active only' },
+  ],
+  profiles: [{ k: 'arm', label: 'Arm on tap' }, { k: 'value', label: 'Show seconds' }],
+  stats:  [
+    { k: 'cpu', label: 'CPU' }, { k: 'mem', label: 'RAM' }, { k: 'recon', label: 'Reconnects' },
+    { k: 'bitrate', label: 'Bitrate' }, { k: 'cuts', label: 'Cuts' },
+  ],
+  overlays: [
+    { k: 'search', label: 'Search bar' }, { k: 'group', label: 'Folders' }, { k: 'autohide', label: 'Copy with autohide off' },
+  ],
+  activate: [{ k: 'confirmcut', label: 'Confirm cut' }],
+};
+
+function defaultCfg() {
+  const w = {};
+  for (const id of ALL) w[id] = { ...WIDGETS[id].def };
+  return { v: 1, preset: 'full', density: 'comfy', accent: 'cyan', order: [...ROWS], w };
+}
+// Accent presets: [--accent, --accent-ink]. Ink is the dark text drawn on
+// filled accent buttons, tuned per hue so it stays legible.
+const ACCENTS = {
+  cyan:   ['#5ac8fa', '#04121c'],
+  green:  ['#34d06a', '#04140a'],
+  purple: ['#a78bfa', '#140a24'],
+  amber:  ['#e0a33a', '#1c1204'],
+  pink:   ['#f472b6', '#24040f'],
+  blue:   ['#6aa8ff', '#04101c'],
+};
+// Keep only known row ids, drop dupes, and append any rows a newer version
+// added so an old saved order still renders every widget.
+function sanitizeOrder(raw) {
+  const seen = new Set();
+  const out = [];
+  if (Array.isArray(raw)) for (const id of raw) if (ROWS.includes(id) && !seen.has(id)) { seen.add(id); out.push(id); }
+  for (const id of ROWS) if (!seen.has(id)) out.push(id);
+  return out;
+}
+// Merge a stored (possibly older) layout onto current defaults so widgets or
+// options added in a later version get sane values on an old saved dock.
+function mergeCfg(raw) {
+  const base = defaultCfg();
+  if (!raw || typeof raw !== 'object') return base;
+  if (raw.preset) base.preset = raw.preset;
+  if (raw.density === 'compact' || raw.density === 'comfy') base.density = raw.density;
+  if (ACCENTS[raw.accent]) base.accent = raw.accent;
+  base.order = sanitizeOrder(raw.order);
+  if (raw.w && typeof raw.w === 'object') {
+    for (const id of ALL) {
+      if (raw.w[id] && typeof raw.w[id] === 'object') base.w[id] = { ...base.w[id], ...raw.w[id] };
+    }
+  }
+  return base;
+}
+let cfg = defaultCfg();
+
+// ---------------------------------------------------------- delay controls --
+
+function bump(n) {
+  const step = cfg.w.number.step || 1;
+  const i = $('d');
+  i.value = Math.max(0, Math.min(600, (+i.value || 0) + n * step));
+  renderCta();
+}
+function setPending(p) { pending = p; setTimeout(() => pending = null, 1500); tick(); }
+function fmtRate(k) { if (!k || k <= 0) return ''; return k >= 1000 ? (k / 1000).toFixed(2) + ' Mbps' : Math.round(k) + ' kbps'; }
+function fmt(ms) { if (ms < 100) return '0.0'; const x = Math.round(ms / 100) / 10; return x < 10 ? x.toFixed(1) : Math.round(x).toString(); }
+// Crossfade helper so the sub-tip swaps smoothly instead of snapping.
+function setTip(text) {
+  const el = $('w-tip'); if (el.textContent === text) return;
+  el.classList.add('fade'); clearTimeout(el._t);
+  el._t = setTimeout(() => { el.textContent = text; el.classList.remove('fade'); }, 140);
+}
+
+async function arm(ms) {
+  setPending('arming');
+  const r = await fetchJ('/arm', { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: 'ms=' + ms });
+  if (!r.ok) { toast(r.j?.error || 'Failed to arm', 'err'); pending = null; }
+  else toast(`Arming ${(ms / 1000).toFixed(0)}s`, 'ok');
+  tick();
+}
+async function activate() {
+  setPending('active');
+  const r = await fetchJ('/activate', { method: 'POST' });
+  if (!r.ok) { toast(r.j?.error || 'Cannot activate yet', 'err'); pending = null; }
+  else toast('Delay active', 'ok');
+  tick();
+}
+async function stop() { setPending('off'); await fetchJ('/stop', { method: 'POST' }); toast('Back to live', 'ok'); tick(); }
+async function disarm() { setPending('off'); await fetchJ('/disarm', { method: 'POST' }); toast('Disarmed', 'ok'); tick(); }
+
+function mainClick() {
+  const m = $('main'); if (m._busy || m.disabled) return;
+  m._busy = true; setTimeout(() => m._busy = false, 300);
+  if (!s) return;
+  const ds = PHASE_TO_STATE[s.phase] || 'off';
+  if (ds === 'active') {
+    // Cutting a live delay drops you back to real time instantly - guard it
+    // behind a two-tap confirm when the option is on.
+    if (cfg.w.activate.confirmcut && !m._cutArm) {
+      m._cutArm = true; renderCta();
+      clearTimeout(m._cutT); m._cutT = setTimeout(() => { m._cutArm = false; renderCta(); }, 3000);
+      return;
+    }
+    m._cutArm = false; return stop();
+  }
+  if (ds === 'armed') return activate();
+  if (ds === 'arming') return disarm();   // double-click safety: arming primary disarms too
+  const ms = (+$('d').value || 0) * 1000;
+  if (ms > 0) arm(ms); else toast('Enter a delay', 'err');
+}
+function disarmClick() {
+  const b = $('cancel'); if (b._busy) return;
+  b._busy = true; setTimeout(() => b._busy = false, 300);
+  disarm();
+}
+
+// The big number is an editable setter while idle and a readout once a delay
+// is engaged - the +/- retire so the screen reads clean (the feedback ask).
+function setNumberMode(ds) {
+  const engaged = ds === 'arming' || ds === 'armed' || ds === 'active';
+  const controls = cfg.w.number.controls && !engaged;
+  $('d').hidden = engaged;
+  $('v').hidden = !engaged;
+  $('minus').hidden = !controls;
+  $('plus').hidden = !controls;
+}
+
+// ------------------------------------------------------------- state paint --
+
+function renderCta() {
+  if (!s) return;
+  const m = $('main'), cancel = $('cancel');
+  const ds = pending || PHASE_TO_STATE[s.phase] || 'off';
+  const ingest = s.ingest_alive;
+  // Drop a pending cut-confirm if we left the active state by any route, so a
+  // stale arm can't skip the guard next time.
+  if (ds !== 'active' && m._cutArm) { m._cutArm = false; clearTimeout(m._cutT); }
+  m.className = 'btn full'; m.disabled = false; cancel.hidden = true;
+  if (ds === 'active') {
+    m.textContent = m._cutArm ? 'Tap again to cut' : 'Cut delay'; m.classList.add('danger');
+  } else if (ds === 'armed') {
+    m.innerHTML = '<span>&#9654;</span> Activate'; m.classList.add('go'); cancel.hidden = false;
+  } else if (ds === 'arming') {
+    const tgt = s.armed_delay_ms || 1;
+    const pct = Math.min(99, Math.round((s.buffer_fill_ms / tgt) * 100));
+    m.innerHTML = `<span class="spin"></span> Buffering ${pct}%`; m.disabled = true; cancel.hidden = false;
+  } else {
+    const ms = (+$('d').value || 0) * 1000;
+    if (!ingest) { m.textContent = 'Waiting for encoder…'; m.disabled = true; }
+    else if (ms <= 0) { m.textContent = 'Set a delay above'; m.disabled = true; }
+    else { m.innerHTML = `<span>&#9201;</span> Arm ${(ms / 1000).toFixed(0)}s`; m.classList.add('primary'); }
+  }
+}
+
+function applyState(j) {
+  s = j;
+  const ds = PHASE_TO_STATE[s.phase] || 'off';
+  setNumberMode(ds);
+  // Phase chip: idle vs passthrough vs arming/armed/active.
+  const phMap = { off: s.ingest_alive ? ['live', 'Live'] : ['off', 'Idle'], arming: ['arming', 'Buffering'], armed: ['armed', 'Armed'], active: ['active', 'Active'] };
+  const [cls, txt] = phMap[ds];
+  $('ph').className = 'phase ' + cls + (cfg.w.phase.style === 'dot' ? ' asdot' : '');
+  $('ph').textContent = txt; $('ph').title = txt;
+  $('src').className = 'pill ' + (s.ingest_alive ? 'on' : 'bad') + (cfg.w.source.style === 'dot' ? ' asdot' : '');
+  $('src-lbl').textContent = s.ingest_alive ? 'Live' : 'Offline';
+  $('src').title = s.ingest_alive ? 'Live' : 'Offline';
+  // Readout: mirror the dashboard - show the armed target while engaged (or
+  // the fill while arming) and 0 in passthrough. current_delay_ms includes
+  // the pipeline's own ~1s transit, which would read as a phantom delay.
+  const tgtSec = (s.armed_delay_ms || 0) / 1000, fillSec = (s.buffer_fill_ms || 0) / 1000;
+  const showSec = ds === 'arming' ? Math.min(fillSec, tgtSec) : (ds === 'armed' || ds === 'active') ? tgtSec : 0;
+  const nv = fmt(showSec * 1000);
+  if (nv !== lastVal) {
+    $('v').textContent = nv; lastVal = nv;
+    const cur = $('v').parentElement; cur.classList.add('changing'); setTimeout(() => cur.classList.remove('changing'), 350);
+  }
+  // Progress bar (+ optional %).
+  const target = s.armed_delay_ms || s.buffer_target_ms || 0;
+  const fill = $('bar'); fill.classList.remove('ready', 'active');
+  let pct = 0;
+  if (ds === 'active') { fill.style.width = '100%'; fill.classList.add('active'); pct = 100; }
+  else if (target > 0) {
+    pct = Math.min(100, (Math.min(s.buffer_fill_ms, target) / target) * 100);
+    fill.style.width = pct + '%'; if (pct >= 99) fill.classList.add('ready');
+  } else fill.style.width = '0%';
+  const pctEl = $('pct'); pctEl.hidden = !cfg.w.bar.pct; if (cfg.w.bar.pct) pctEl.textContent = Math.round(pct) + '%';
+  // Egress glance, honouring its per-part options.
+  const eg = $('w-eg');
+  if (s.ingest_alive && cfg.w.egress.on) {
+    const parts = [];
+    if (cfg.w.egress.dests) parts.push(`<span>&#9650;</span><b>${s.destinations_alive || 0}/${s.destinations_total || 0}</b> live`);
+    if (cfg.w.egress.bitrate) { const rate = fmtRate(s.stats && s.stats.bitrate_kbps); if (rate) parts.push(`<b>${rate}</b> in`); }
+    if (cfg.w.egress.codec && s.video_codec) parts.push(`<b>${esc(s.video_codec)}</b>${s.multitrack_video ? ' &middot; MT' : ''}`);
+    if (parts.length) { eg.innerHTML = parts.join('<span class="sep">&middot;</span>'); eg.hidden = false; } else eg.hidden = true;
+  } else eg.hidden = true;
+  // Hint text: full sentences, or errors-only (encoder offline) if opted.
+  const tip = !s.ingest_alive ? 'Point your encoder at rtmp://…/live'
+    : ds === 'active' ? `Live ${(s.current_delay_ms / 1000).toFixed(1)}s behind real time.`
+    : ds === 'armed' ? 'Buffer full. Hit Activate to go live with delay.'
+    : ds === 'arming' ? 'Filling buffer… you can cancel any time.'
+    : 'Passthrough - no delay applied.';
+  const showTip = cfg.w.tips.on && (!cfg.w.tips.errorsOnly || !s.ingest_alive);
+  $('w-tip').hidden = !showTip; if (showTip) setTip(tip);
+  renderStats();
+  renderCta();
+}
+
+async function tick() {
+  const r = await fetchJ('/state');
+  if (!r.ok || !r.j) { $('src').className = 'pill bad'; $('src-lbl').textContent = 'Offline'; return; }
+  applyState(r.j);
+}
+
+// ---------------------------------------------------------- destination strip --
+
+let _destTimer = null;
+let destCache = [];   // last /destinations payload, for instant re-render on option change
+function startDests() { if (_destTimer) return; fetchDests(); _destTimer = setInterval(fetchDests, 4000); }
+function stopDests() { if (_destTimer) { clearInterval(_destTimer); _destTimer = null; } }
+async function fetchDests() {
+  if ($('w-dests').hidden) return;
+  const r = await fetchJ('/destinations');
+  if (r.ok && Array.isArray(r.j)) { destCache = r.j; renderDests(r.j); }
+}
+function renderDests(list) {
+  const box = $('w-dests'); if (box.hidden) return;
+  const icons = cfg.w.dest.view === 'icons';
+  // Show every configured destination by default so a disabled one can be
+  // toggled back on. "Active only" is the opt-in filter for a clean look.
+  const show = cfg.w.dest.active ? list.filter(d => d.enabled || d.alive) : list;
+  box.className = 'dests' + (icons ? ' icons' : '');
+  if (!show.length) { box.innerHTML = '<div class="empty">No destinations yet. Add them in the dashboard.</div>'; return; }
+  box.innerHTML = '';
+  for (const d of show) box.appendChild(icons ? destIcon(d) : destRow(d));
+}
+function destRow(d) {
+  const row = document.createElement('div');
+  row.className = 'dest' + (d.alive ? ' alive' : '');
+  const rate = cfg.w.dest.stats && d.alive ? fmtRate(d.bitrate_kbps) : '';
+  const meta = rate ? `<span class="d-rate">${rate}</span>` : `<span class="d-plat">${esc(d.platform || '')}</span>`;
+  row.innerHTML = `<span class="d-dot"></span><span class="d-name">${esc(d.name || 'Destination')}</span>${meta}`;
+  const sw = document.createElement('button');
+  sw.className = 'sw' + (d.enabled ? ' on' : '');
+  sw.title = d.enabled ? 'Turn off' : 'Turn on';
+  sw.onclick = () => onDestToggle(d, row, sw);
+  row.appendChild(sw);
+  return row;
+}
+// Compact circular badge: platform initial, live-glow ring, hover shows the
+// name (native title). Tap arms it (confirm), tap again commits.
+function destIcon(d) {
+  const b = document.createElement('button');
+  b.className = 'dico' + (d.enabled ? ' on' : ' off') + (d.alive ? ' alive' : '');
+  b.textContent = (d.platform || d.name || '?').slice(0, 1).toUpperCase();
+  b.title = `${d.name || 'Destination'} · ${d.enabled ? 'on' : 'off'}`;
+  b.onclick = () => onDestIcon(d, b);
+  return b;
+}
+function onDestIcon(d, b) {
+  if (!cfg.w.dest.confirm) { commitDest(d, !d.enabled); return; }
+  if (b._armed) { clearTimeout(b._t); commitDest(d, !d.enabled); return; }   // 2nd tap commits; the re-render clears the armed look
+  // Arm: pulse an amber ring and swap the badge to a check so the "tap again
+  // to confirm" intent is unmistakable, not just a colour change.
+  b._armed = true; b._letter = b.textContent; b.textContent = '✓';
+  b.classList.add('arm');
+  b.title = d.enabled ? 'Tap again to turn OFF' : 'Tap again to go LIVE';
+  clearTimeout(b._t);
+  b._t = setTimeout(() => {
+    b._armed = false; b.classList.remove('arm'); b.textContent = b._letter;
+    b.title = `${d.name || 'Destination'} · ${d.enabled ? 'on' : 'off'}`;
+  }, 3000);
+}
+// Misclick guard: the row swaps its switch for a Sure? / cancel pair that
+// auto-dismisses after 3s. Toggling a live platform either way matters, so
+// both directions are guarded.
+function onDestToggle(d, row, sw) {
+  if (!cfg.w.dest.confirm) { commitDest(d, !d.enabled); return; }
+  if (row._confirm) return;
+  const next = !d.enabled;
+  const box = document.createElement('span'); box.className = 'confirm';
+  box.innerHTML = `<span class="q">${next ? 'Go live?' : 'Turn off?'}</span>`;
+  const yes = document.createElement('button'); yes.className = 'cbtn yes'; yes.innerHTML = '&#10003;';
+  const no = document.createElement('button'); no.className = 'cbtn no'; no.innerHTML = '&times;';
+  const cancel = () => { clearTimeout(row._ct); row._confirm = false; box.replaceWith(sw); };
+  yes.onclick = () => { cancel(); commitDest(d, next); };
+  no.onclick = cancel;
+  box.append(yes, no);
+  sw.replaceWith(box); row._confirm = true; row._ct = setTimeout(cancel, 3000);
+}
+async function commitDest(d, enabled) {
+  const r = await fetchJ('/destinations/toggle', {
+    method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: `id=${encodeURIComponent(d.id)}&enabled=${enabled ? 'on' : 'off'}`,
+  });
+  if (!r.ok) toast(r.j?.error || 'Toggle failed', 'err');
+  else toast(`${d.name || 'Destination'} ${enabled ? 'on' : 'off'}`, 'ok');
+  fetchDests();
+}
+
+// --------------------------------------------------------- extra widgets ----
+
+// Delay profiles: one-tap chips from the user's saved profiles (same list as
+// the dashboard). Tapping fills the delay and optionally arms it.
+let profileCache = [];
+async function fetchProfiles() {
+  const r = await fetchJ('/profiles');
+  if (r.ok && Array.isArray(r.j)) { profileCache = r.j; renderProfiles(); }
+}
+function renderProfiles() {
+  const box = $('w-profiles'); if (box.hidden) return;
+  if (!profileCache.length) { box.innerHTML = '<div class="empty">No profiles yet. Add them in the dashboard.</div>'; return; }
+  box.innerHTML = '';
+  for (const p of profileCache) {
+    const sec = Math.round((p.delay_ms || 0) / 1000);
+    const b = document.createElement('button'); b.className = 'pchip';
+    b.innerHTML = esc(p.name || sec + 's') + (cfg.w.profiles.value ? `<span class="pv">${sec}s</span>` : '');
+    b.onclick = () => profileSet(sec);
+    box.appendChild(b);
+  }
+}
+function profileSet(sec) {
+  $('d').value = sec; renderCta();
+  const ds = s ? (PHASE_TO_STATE[s.phase] || 'off') : 'off';
+  if (cfg.w.profiles.arm && ds === 'off' && sec > 0) arm(sec * 1000);
+}
+
+// Health stats: CPU / RAM / reconnects, plus a backpressure warning. All read
+// from the state stream, so no extra polling.
+function renderStats() {
+  const box = $('w-stats'); if (box.hidden || !s) return;
+  const o = cfg.w.stats, st = s.stats || {}, parts = [];
+  if (o.cpu) parts.push(`<span class="st"><b>${(s.cpu_pct || 0).toFixed(0)}</b>% cpu</span>`);
+  if (o.mem) parts.push(`<span class="st"><b>${Math.round((s.rss_bytes || 0) / 1048576)}</b> MB</span>`);
+  if (o.bitrate) { const rate = fmtRate(st.bitrate_kbps); if (rate) parts.push(`<span class="st"><b>${rate}</b></span>`); }
+  if (o.recon) parts.push(`<span class="st"><b>${(st.egress_reconnects || 0) + (st.ingest_disconnects || 0)}</b> recon</span>`);
+  if (o.cuts) parts.push(`<span class="st"><b>${st.cuts || 0}</b> cuts</span>`);
+  if (s.backpressure) parts.push('<span class="st bad">&#9888; buffer lag</span>');
+  box.innerHTML = parts.join('') || '<span class="st muted">no metrics selected</span>';
+}
+
+// Server settings mirrored on the dock (Auto behavior + Settings widgets).
+// Read from /config; each boolean flip is a safe partial POST /config.
+let srvCfg = { auto_arm_on_connect: false, auto_activate_when_ready: false, tracing_enabled: true, webhook_set: false };
+async function fetchServerCfg() {
+  const r = await fetchJ('/config');
+  if (!r.ok || !r.j) return;
+  srvCfg.auto_arm_on_connect = !!r.j.auto_arm_on_connect;
+  srvCfg.auto_activate_when_ready = !!r.j.auto_activate_when_ready;
+  srvCfg.tracing_enabled = !!r.j.tracing_enabled;
+  srvCfg.webhook_set = !!r.j.webhook_set;
+  renderBehavior(); renderSettings();
+}
+// A label + switch row bound to a boolean server-config key.
+function toggleRow(label, key) {
+  const row = document.createElement('div'); row.className = 'brow';
+  const lb = document.createElement('span'); lb.className = 'blbl'; lb.textContent = label;
+  const sw = document.createElement('button'); sw.type = 'button'; sw.className = 'sw sm' + (srvCfg[key] ? ' on' : '');
+  sw.onclick = () => setServer(key, !srvCfg[key], sw);
+  row.append(lb, sw);
+  return row;
+}
+async function setServer(key, val, sw) {
+  srvCfg[key] = val; if (sw) sw.className = 'sw sm' + (val ? ' on' : '');
+  const r = await fetchJ('/config', {
+    method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: `${key}=${val ? 'true' : 'false'}`,
+  });
+  if (!r.ok) { toast('Save failed', 'err'); fetchServerCfg(); }
+  else toast(val ? 'On' : 'Off', 'ok');
+}
+function renderBehavior() {
+  const box = $('w-behavior'); if (box.hidden) return;
+  box.innerHTML = '';
+  box.appendChild(toggleRow('Auto-arm on connect', 'auto_arm_on_connect'));
+  box.appendChild(toggleRow('Auto-activate when full', 'auto_activate_when_ready'));
+}
+
+// Settings: the live-safe knobs (things that don't need a restart). Buffer /
+// ports stay in the dashboard because changing them restarts the pipeline.
+function renderSettings() {
+  const box = $('w-settings'); if (box.hidden) return;
+  box.innerHTML = '';
+  box.appendChild(toggleRow('Wire trace log', 'tracing_enabled'));
+  const wh = document.createElement('div'); wh.className = 'brow';
+  const lb = document.createElement('span'); lb.className = 'blbl'; lb.textContent = srvCfg.webhook_set ? 'Discord webhook set' : 'No Discord webhook';
+  const btns = document.createElement('span'); btns.className = 'srow-btns';
+  if (srvCfg.webhook_set) {
+    const test = document.createElement('button'); test.className = 'minibtn'; test.textContent = 'Test'; test.onclick = testWebhook;
+    const clr = document.createElement('button'); clr.className = 'minibtn'; clr.textContent = 'Clear'; clr.onclick = clearWebhook;
+    btns.append(test, clr);
+  } else {
+    // Setting a webhook means pasting a secret URL - awkward on a dock, so
+    // "Set" bounces to the dashboard (behind a confirm).
+    const set = document.createElement('button'); set.className = 'minibtn'; set.textContent = 'Set'; set.onclick = () => confirmOpenDashboard(btns);
+    btns.append(set);
+  }
+  wh.append(lb, btns); box.appendChild(wh);
+}
+function confirmOpenDashboard(btns) {
+  btns.innerHTML = '';
+  const q = document.createElement('span'); q.className = 'cq'; q.textContent = 'Open dashboard?';
+  q.title = 'This opens the InstantClone dashboard in a new tab so you can paste the webhook URL.';
+  const yes = document.createElement('button'); yes.className = 'minibtn'; yes.textContent = 'Yes';
+  yes.onclick = () => { window.open(location.origin + '/', '_blank'); toast('Opening dashboard…', 'ok'); renderSettings(); };
+  const no = document.createElement('button'); no.className = 'minibtn'; no.textContent = 'No'; no.onclick = renderSettings;
+  btns.append(q, yes, no);
+}
+async function testWebhook() {
+  const r = await fetchJ('/test-webhook', { method: 'POST' });
+  // The endpoint answers 200 even when Discord rejects, so trust the JSON ok.
+  const ok = r.ok && (!r.j || r.j.ok !== false);
+  toast(ok ? 'Test event sent' : (r.j?.error || 'Test failed'), ok ? 'ok' : 'err');
+}
+async function clearWebhook() {
+  const r = await fetchJ('/config', { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: 'webhook_clear=1' });
+  if (r.ok) { srvCfg.webhook_set = false; renderSettings(); toast('Webhook cleared', 'ok'); }
+  else toast('Failed', 'err');
+}
+
+// Overlays: list the OBS browser-source overlays and copy their URLs, so a
+// dock can double as an overlay picker.
+let overlayCache = [];
+let overlayQuery = '';
+async function fetchOverlays() {
+  const r = await fetchJ('/overlays');
+  if (r.ok && Array.isArray(r.j)) { overlayCache = r.j; renderOverlays(); }
+}
+function renderOverlays() {
+  const box = $('w-overlays'); if (box.hidden) return;
+  box.innerHTML = '';
+  if (!overlayCache.length) { box.innerHTML = '<div class="empty">No overlays yet. Open the dashboard once to seed the presets.</div>'; return; }
+  // The search field is built once and left in place; only the list below it
+  // re-renders on keystroke, so the input keeps focus + caret.
+  if (cfg.w.overlays.search) {
+    const inp = document.createElement('input'); inp.className = 'osearch'; inp.placeholder = 'Search overlays…'; inp.value = overlayQuery;
+    inp.oninput = () => { overlayQuery = inp.value; renderOverlayList(); };
+    box.appendChild(inp);
+  }
+  const list = document.createElement('div'); list.className = 'olist'; list.id = 'olist';
+  box.appendChild(list);
+  renderOverlayList();
+}
+function renderOverlayList() {
+  const list = $('olist'); if (!list) return;
+  list.innerHTML = '';
+  let items = overlayCache;
+  if (cfg.w.overlays.search && overlayQuery) {
+    const q = overlayQuery.toLowerCase();
+    items = items.filter(o => (o.name || o.slug).toLowerCase().includes(q));
+  }
+  if (!items.length) { list.innerHTML = '<div class="empty">No overlays match.</div>'; return; }
+  if (cfg.w.overlays.group) {
+    const studio = items.filter(o => o.studio), presets = items.filter(o => !o.studio);
+    if (studio.length) { list.appendChild(overlayGroup('Studio')); for (const o of studio) list.appendChild(overlayRow(o)); }
+    if (presets.length) { list.appendChild(overlayGroup('Presets')); for (const o of presets) list.appendChild(overlayRow(o)); }
+  } else {
+    for (const o of items) list.appendChild(overlayRow(o));
+  }
+}
+function overlayGroup(text) { const h = document.createElement('div'); h.className = 'ogroup'; h.textContent = text; return h; }
+function overlayRow(o) {
+  const row = document.createElement('div'); row.className = 'orow';
+  const nm = document.createElement('span'); nm.className = 'o-name'; nm.textContent = o.name || o.slug;
+  if (o.studio && !cfg.w.overlays.group) { const tag = document.createElement('span'); tag.className = 'o-tag'; tag.textContent = 'studio'; nm.appendChild(tag); }
+  const open = document.createElement('button'); open.className = 'minibtn'; open.textContent = 'Open'; open.title = 'Preview in a new tab'; open.onclick = () => openOverlay(o.slug);
+  const copy = document.createElement('button'); copy.className = 'minibtn'; copy.innerHTML = '&#128279;'; copy.title = 'Copy browser-source URL'; copy.onclick = () => copyOverlay(o.slug);
+  row.append(nm, open, copy);
+  return row;
+}
+function overlayUrl(slug) {
+  // The overlay files are served at /overlay/<slug>.html (matches the
+  // dashboard). ?autohide=off keeps the overlay up even while live (some
+  // presets otherwise fade out); opt-in via the widget option.
+  const q = cfg.w.overlays.autohide ? '?autohide=off' : '';
+  return `${location.origin}/overlay/${encodeURIComponent(slug)}.html${q}`;
+}
+function openOverlay(slug) { window.open(overlayUrl(slug), '_blank'); }
+async function copyOverlay(slug) {
+  const url = overlayUrl(slug);
+  try { await navigator.clipboard.writeText(url); toast('Overlay URL copied', 'ok'); }
+  catch (_) { toast(url, 'ok'); }
+}
+
+// -------------------------------------------------------------- layout apply --
+
+function applyCfg(c) {
+  cfg = c;
+  const on = id => c.w[id].on;
+  document.body.classList.toggle('compact', c.density === 'compact');
+  // Accent hue (CSS custom properties drive every accent-colored surface).
+  const [accent, ink] = ACCENTS[c.accent] || ACCENTS.cyan;
+  document.documentElement.style.setProperty('--accent', accent);
+  document.documentElement.style.setProperty('--accent-ink', ink);
+  // Status bar: hidden if switched off, or if both of its parts are off (no
+  // empty bar left taking space).
+  $('w-top').hidden = !(on('status') && (on('phase') || on('source')));
+  $('ph').hidden = !on('phase');       // phase chip within it
+  $('src').hidden = !on('source');     // live pill within it
+  // The number screen wraps the readout and the bar. The bar is a child of
+  // the number (its toggle lives under the Number row), so turning the number
+  // off hides the whole screen, bar included.
+  $('w-screen').hidden = !on('number');
+  $('w-screen').className = 'screen sz-' + (c.w.number.size || 'md');
+  $('w-bar').hidden = !on('bar');
+  $('w-bar').classList.toggle('thick', !!c.w.bar.thick);
+  for (const id of ['egress', 'tips', 'dest', 'profiles', 'stats', 'behavior', 'settings', 'overlays', 'activate']) $(WEL[id]).hidden = !on(id);
+  document.querySelectorAll('.cur .u').forEach(u => u.hidden = !c.w.number.units);
+  // Apply the saved drag order by re-appending containers in sequence.
+  const wrap = document.querySelector('.wrap');
+  for (const id of c.order) { const el = $(WEL[id]); if (el) wrap.appendChild(el); }
+  if (on('dest')) { startDests(); if (destCache.length) renderDests(destCache); } else stopDests();
+  if (on('profiles')) fetchProfiles();
+  if (on('behavior') || on('settings')) { renderBehavior(); renderSettings(); fetchServerCfg(); }
+  if (on('overlays')) fetchOverlays();
+  if (s) applyState(s); else renderCta();   // re-render with the new options
+}
+
+function persist() {
+  const json = JSON.stringify(cfg);
+  try { localStorage.setItem('ic.dock.' + SLOT, json); } catch (_) {}
+  fetchJ('/docks/' + encodeURIComponent(SLOT), { method: 'POST', headers: { 'content-type': 'application/json' }, body: json });
+}
+function saveAndApply() { applyCfg(cfg); persist(); }
+
+async function loadCfg() {
+  // 1) A ?cfg= blob (shared / imported URL) wins and is saved to this slot.
+  const p = new URLSearchParams(location.search).get('cfg');
+  if (p) {
+    try {
+      cfg = mergeCfg(JSON.parse(decodeURIComponent(escape(atob(p)))));
+      applyCfg(cfg); persist();
+      const u = new URL(location.href); u.searchParams.delete('cfg'); history.replaceState(null, '', u);
+      return;
+    } catch (_) {}
+  }
+  // 2) localStorage mirror: instant paint before the server answers.
+  try { const ls = localStorage.getItem('ic.dock.' + SLOT); if (ls) { cfg = mergeCfg(JSON.parse(ls)); applyCfg(cfg); } } catch (_) {}
+  // 3) Server copy is the durable source of truth; reconcile when it lands.
+  const r = await fetchJ('/docks/' + encodeURIComponent(SLOT));
+  if (r.ok && r.j && typeof r.j === 'object') {
+    cfg = mergeCfg(r.j); applyCfg(cfg);
+    try { localStorage.setItem('ic.dock.' + SLOT, JSON.stringify(cfg)); } catch (_) {}
+  }
+}
+
+// -------------------------------------------------------------- gear editor --
+
+let dragId = null;
+// Which widget rows are expanded. Kept across the frequent buildEditor()
+// rebuilds so flipping an option doesn't snap its panel shut.
+const openRows = new Set();
+// Saved dock slots the server knows about (for the Docks switcher).
+let knownSlots = [];
+
+async function fetchSlots() {
+  const r = await fetchJ('/docks');
+  if (r.ok && Array.isArray(r.j)) { knownSlots = r.j; if (!$('editor').hidden) buildEditor(); }
+}
+
+function ensureEditorRoot() {
+  let el = $('editor');
+  if (!el) {
+    el = document.createElement('div'); el.id = 'editor'; el.className = 'editor'; el.hidden = true;
+    el.innerHTML = '<div class="sheet"><div class="grabber"></div><div class="sheet-body" id="sheet-body"></div></div>';
+    el.onclick = e => { if (e.target === el) closeEditor(); };
+    document.body.appendChild(el);
+  }
+  return el;
+}
+function openEditor() {
+  const root = ensureEditorRoot(); buildEditor(); root.hidden = false;
+  requestAnimationFrame(() => root.classList.add('show'));
+  fetchSlots();   // populate the Docks switcher
+}
+function closeEditor() {
+  const root = ensureEditorRoot(); root.classList.remove('show');
+  setTimeout(() => root.hidden = true, 220);   // let the slide-out finish
+}
+
+// A row of segmented buttons (the "mode" control). `current` is the selected
+// value; `items` is [value, label] pairs; `onPick(val)` applies the choice.
+function segControl(current, items, onPick) {
+  const seg = document.createElement('div'); seg.className = 'seg';
+  for (const [val, lab] of items) {
+    const b = document.createElement('button'); b.type = 'button';
+    b.className = 'segb' + (String(current) === String(val) ? ' sel' : ''); b.textContent = lab;
+    b.onclick = () => onPick(val);
+    seg.appendChild(b);
+  }
+  return seg;
+}
+function optionEls(id) {
+  const specs = OPTS[id]; if (!specs) return null;
+  const box = document.createElement('div'); box.className = 'opts';
+  for (const sp of specs) {
+    const t = sp.w || id;
+    const row = document.createElement('div'); row.className = 'optrow';
+    const lb = document.createElement('span'); lb.className = 'optlbl'; lb.textContent = sp.label; row.appendChild(lb);
+    if (sp.modes || sp.sel) {
+      const items = sp.modes || sp.sel.map(v => [v, String(v)]);
+      row.appendChild(segControl(cfg.w[t][sp.k], items, val => { cfg.w[t][sp.k] = val; cfg.preset = 'custom'; saveAndApply(); buildEditor(); }));
+    } else {
+      const sw = document.createElement('button'); sw.type = 'button'; sw.className = 'sw sm' + (cfg.w[t][sp.k] ? ' on' : '');
+      sw.onclick = () => { cfg.w[t][sp.k] = !cfg.w[t][sp.k]; cfg.preset = 'custom'; saveAndApply(); buildEditor(); };
+      row.appendChild(sw);
+    }
+    box.appendChild(row);
+  }
+  return box;
+}
+function widgetRow(id) {
+  const w = cfg.w[id];
+  const row = document.createElement('div'); row.className = 'wrow' + (w.on ? '' : ' off'); row.dataset.id = id;
+  const head = document.createElement('div'); head.className = 'head';
+  // Drag starts only from the grip, so tapping the row still expands options.
+  const grip = document.createElement('span'); grip.className = 'grip'; grip.innerHTML = '&#8942;&#8942;'; grip.title = 'Drag to reorder';
+  grip.onmousedown = () => { row.draggable = true; };
+  row.ondragstart = e => { dragId = id; row.classList.add('dragging'); e.dataTransfer.effectAllowed = 'move'; try { e.dataTransfer.setData('text/plain', id); } catch (_) {} };
+  row.ondragend = () => { row.draggable = false; row.classList.remove('dragging'); document.querySelectorAll('.wrow.drop').forEach(x => x.classList.remove('drop')); };
+  row.ondragover = e => { if (dragId && dragId !== id) { e.preventDefault(); row.classList.add('drop'); } };
+  row.ondragleave = () => row.classList.remove('drop');
+  row.ondrop = e => { e.preventDefault(); row.classList.remove('drop'); if (dragId) reorder(dragId, id); };
+  const nm = document.createElement('span'); nm.className = 'nm'; nm.textContent = WIDGETS[id].label;
+  const sw = document.createElement('button'); sw.type = 'button'; sw.className = 'sw' + (w.on ? ' on' : '');
+  sw.onclick = e => { e.stopPropagation(); w.on = !w.on; cfg.preset = 'custom'; saveAndApply(); buildEditor(); };
+  const opts = optionEls(id);
+  head.append(grip, nm);
+  if (opts) {
+    const cv = document.createElement('span'); cv.className = 'cv'; cv.innerHTML = '&#8250;'; head.appendChild(cv);
+    if (openRows.has(id)) row.classList.add('open');
+    head.onclick = e => {
+      if (e.target === sw || e.target === grip) return;
+      if (openRows.has(id)) openRows.delete(id); else openRows.add(id);
+      row.classList.toggle('open');
+    };
+  }
+  head.appendChild(sw);
+  row.appendChild(head); if (opts) row.appendChild(opts);
+  return row;
+}
+function sectionLabel(text, inline) {
+  const el = document.createElement('div'); el.className = 'lbl' + (inline ? ' inline' : ''); el.textContent = text; return el;
+}
+function buildEditor() {
+  const body = $('sheet-body'); body.innerHTML = '';
+  const head = document.createElement('div'); head.className = 'ehead';
+  head.innerHTML = `<h3>Customize dock</h3><span class="slot">${esc(SLOT)}</span>`;
+  const x = document.createElement('button'); x.className = 'eclose'; x.innerHTML = '&times;'; x.title = 'Done'; x.onclick = closeEditor;
+  head.appendChild(x); body.appendChild(head);
+
+  body.appendChild(sectionLabel('Preset'));
+  const chips = document.createElement('div'); chips.className = 'chips';
+  for (const [k, p] of Object.entries(PRESETS)) {
+    const c = document.createElement('button'); c.type = 'button'; c.className = 'chip' + (cfg.preset === k ? ' sel' : ''); c.textContent = p.label;
+    c.onclick = () => applyPreset(k); chips.appendChild(c);
+  }
+  body.appendChild(chips);
+
+  body.appendChild(sectionLabel('Appearance'));
+  const densRow = document.createElement('div'); densRow.className = 'densrow';
+  densRow.appendChild(sectionLabel('Density', true));
+  // Density + accent are orthogonal to the preset, so they don't mark it custom.
+  densRow.appendChild(segControl(cfg.density, [['comfy', 'Comfy'], ['compact', 'Compact']], val => { cfg.density = val; saveAndApply(); buildEditor(); }));
+  body.appendChild(densRow);
+  const accRow = document.createElement('div'); accRow.className = 'densrow';
+  accRow.appendChild(sectionLabel('Accent', true));
+  const sw = document.createElement('div'); sw.className = 'swatches';
+  for (const key of Object.keys(ACCENTS)) {
+    const b = document.createElement('button'); b.type = 'button'; b.className = 'swatch' + (cfg.accent === key ? ' sel' : '');
+    b.style.setProperty('--sw', ACCENTS[key][0]); b.title = key;
+    b.onclick = () => { cfg.accent = key; saveAndApply(); buildEditor(); };
+    sw.appendChild(b);
+  }
+  accRow.appendChild(sw); body.appendChild(accRow);
+
+  body.appendChild(sectionLabel('Widgets · drag to reorder'));
+  const list = document.createElement('div'); list.className = 'wlist';
+  for (const id of cfg.order) list.appendChild(widgetRow(id));
+  body.appendChild(list);
+
+  // Docks switcher: surface that multiple docks exist (?dock=<id>) and let
+  // the user copy a URL to paste into another OBS browser dock.
+  body.appendChild(sectionLabel('Docks'));
+  const slots = document.createElement('div'); slots.className = 'chips';
+  for (const id of Array.from(new Set([SLOT, ...knownSlots]))) {
+    const c = document.createElement('button'); c.type = 'button';
+    c.className = 'chip' + (id === SLOT ? ' sel' : ''); c.textContent = id;
+    c.title = 'Copy this dock’s URL';
+    c.onclick = () => copySlotUrl(id);
+    slots.appendChild(c);
+  }
+  const add = document.createElement('button'); add.type = 'button'; add.className = 'chip add'; add.innerHTML = '&#43; New';
+  add.onclick = () => newDock(add);
+  slots.appendChild(add);
+  body.appendChild(slots);
+  const hint = document.createElement('div'); hint.className = 'hint';
+  hint.textContent = 'Each OBS browser dock loads a layout by URL. Copy one, then add a new browser dock in OBS to run a second.';
+  body.appendChild(hint);
+
+  const act = document.createElement('div'); act.className = 'ed-actions';
+  const copy = document.createElement('button'); copy.className = 'btn ghost'; copy.innerHTML = '<span>&#128279;</span> Copy dock URL'; copy.onclick = copyDockUrl;
+  const done = document.createElement('button'); done.className = 'btn primary'; done.textContent = 'Done'; done.onclick = closeEditor;
+  act.append(copy, done); body.appendChild(act);
+}
+function applyPreset(k) {
+  const p = PRESETS[k]; if (!p) return;
+  for (const id of ALL) cfg.w[id].on = p.on.includes(id);
+  cfg.preset = k; saveAndApply(); buildEditor();
+}
+// Move `from` to just before `to` in the row order.
+function reorder(from, to) {
+  if (from === to) return;
+  const o = cfg.order.filter(x => x !== from);
+  o.splice(o.indexOf(to), 0, from);
+  cfg.order = o; cfg.preset = 'custom'; saveAndApply(); buildEditor();
+}
+async function copyDockUrl() {
+  const b64 = btoa(unescape(encodeURIComponent(JSON.stringify(cfg))));
+  const url = `${location.origin}/dock?dock=${encodeURIComponent(SLOT)}&cfg=${b64}`;
+  try { await navigator.clipboard.writeText(url); toast('Dock URL copied', 'ok'); }
+  catch (_) { toast(url, 'ok'); }
+}
+// A slot's plain URL - it loads that slot's own saved layout on open.
+async function copySlotUrl(id) {
+  const url = `${location.origin}/dock?dock=${encodeURIComponent(id)}`;
+  try { await navigator.clipboard.writeText(url); toast(id === SLOT ? 'This dock URL copied' : `Dock "${id}" URL copied`, 'ok'); }
+  catch (_) { toast(url, 'ok'); }
+}
+// Inline name entry (prompt() is unreliable inside OBS's browser dock).
+function newDock(addChip) {
+  const inp = document.createElement('input'); inp.className = 'newdock'; inp.placeholder = 'name…'; inp.maxLength = 40;
+  const commit = () => { const id = inp.value.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40); if (id) copySlotUrl(id); buildEditor(); };
+  inp.onkeydown = e => { if (e.key === 'Enter') commit(); else if (e.key === 'Escape') buildEditor(); };
+  inp.onblur = () => setTimeout(() => { if (!$('editor').hidden) buildEditor(); }, 150);
+  addChip.replaceWith(inp); inp.focus();
+}
+
+// -------------------------------------------------------------------- boot --
+
+$('d').addEventListener('input', renderCta);
+applyCfg(cfg);   // paint defaults immediately
+loadCfg();       // then hydrate from url / localStorage / server
+
+// Prefer SSE for state; fall back to 500ms polling if it is missing or drops.
+let _pollTimer = null;
+function startPolling() { if (_pollTimer) return; tick(); _pollTimer = setInterval(tick, 500); }
+function stopPolling() { if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; } }
+let _es = null;
+function startSSE() {
+  if (!window.EventSource) { startPolling(); return; }
+  try {
+    _es = new EventSource('/events');
+    _es.onmessage = ev => { try { applyState(JSON.parse(ev.data)); stopPolling(); } catch (_) {} };
+    _es.onerror = () => { try { _es.close(); } catch (_) {} _es = null; startPolling(); };
+  } catch (_) { startPolling(); }
+}
+startSSE();
+window.addEventListener('focus', () => { if (!_es) tick(); });

--- a/web/dock.js
+++ b/web/dock.js
@@ -678,9 +678,10 @@ function overlayRow(o) {
   const row = document.createElement('div'); row.className = 'orow';
   const nm = document.createElement('span'); nm.className = 'o-name'; nm.textContent = o.name || o.slug;
   if (o.studio && !cfg.w.overlays.group) { const tag = document.createElement('span'); tag.className = 'o-tag'; tag.textContent = 'studio'; nm.appendChild(tag); }
-  const open = document.createElement('button'); open.className = 'minibtn'; open.textContent = 'Open'; open.title = 'Preview in a new tab'; open.onclick = () => openOverlay(o.slug);
+  //const open = document.createElement('button'); open.className = 'minibtn'; open.textContent = 'Open'; open.title = 'Preview in a new tab'; open.onclick = () => openOverlay(o.slug);
   const copy = document.createElement('button'); copy.className = 'minibtn'; copy.innerHTML = '&#128279;'; copy.title = 'Copy browser-source URL'; copy.onclick = () => copyOverlay(o.slug);
-  row.append(nm, open, copy);
+  //row.append(nm, open, copy);
+  row.append(nm, copy);
   return row;
 }
 function overlayUrl(slug) {

--- a/web/dock.js
+++ b/web/dock.js
@@ -237,10 +237,13 @@ function renderCta() {
     const pct = Math.min(99, Math.round((s.buffer_fill_ms / tgt) * 100));
     m.innerHTML = `<span class="spin"></span> Buffering ${pct}%`; m.disabled = true; cancel.hidden = false;
   } else {
-    const ms = (+$('d').value || 0) * 1000;
+    const sec = +$('d').value || 0;
     if (!ingest) { m.textContent = 'Waiting for encoder…'; m.disabled = true; }
-    else if (ms <= 0) { m.textContent = 'Set a delay above'; m.disabled = true; }
-    else { m.innerHTML = `<span>&#9201;</span> Arm ${(ms / 1000).toFixed(0)}s`; m.classList.add('primary'); }
+    else if (sec <= 0) { m.textContent = 'Set a delay above'; m.disabled = true; }
+    else { m.innerHTML = `<span>&#9201;</span> Arm ${sec.toFixed(0)}s`; m.classList.add('primary'); }
+    // Dead-end nudges read as disabled: can't go below 0 or above the cap.
+    $('minus').disabled = sec <= 0;
+    $('plus').disabled = sec >= 600;
   }
 }
 
@@ -856,6 +859,12 @@ function newDock(addChip) {
 // -------------------------------------------------------------------- boot --
 
 $('d').addEventListener('input', renderCta);
+// Enter in the delay field = press the main button (arm). Keyboard-first flow.
+$('d').addEventListener('keydown', e => { if (e.key === 'Enter') mainClick(); });
+// Staggered first paint (see body.boot CSS); the class comes off after one
+// pass so later saves/reorders never replay the entrance.
+document.body.classList.add('boot');
+setTimeout(() => document.body.classList.remove('boot'), 800);
 applyCfg(cfg);   // paint defaults immediately
 loadCfg();       // then hydrate from url / localStorage / server
 

--- a/web/dock.js
+++ b/web/dock.js
@@ -147,6 +147,45 @@ function mergeCfg(raw) {
 }
 let cfg = defaultCfg();
 
+// -------------------------------------------------------- capacity gate ----
+// The disk ring holds a finite amount of video. A delay bigger than it can
+// fill at the current bitrate silently stalls in "arming" forever, which
+// reads as a bug. Mirror the dashboard's estimate so the dock greys out (and
+// refuses to arm) delays the buffer can't hold. Soft estimate: ~160 kbps
+// audio, ~5% RTMP framing, a little headroom, and a peak-hold on bitrate so
+// the gate doesn't flicker a chip in/out on a momentary dip. The server
+// enforces the same wall on /arm, so this is UX, not the last line of defence.
+const BUF_AUDIO_KBPS = 160, BUF_OVERHEAD_PCT = 5, BUF_HEADROOM_PCT = 3, BUF_REF_KBPS = 10000;
+let bufferMB = 0;          // persisted buffer size, from /config
+let bitrateHoldKbps = 0;   // worst-case recent bitrate (peak-hold, slow decay)
+function updateBitrateHold() {
+  const m = s && s.stats && s.stats.bitrate_kbps;
+  if (!m || m <= 1000) return;                         // no signal - keep last hold
+  bitrateHoldKbps = Math.max(m, (bitrateHoldKbps || m) * 0.985);
+}
+function planningKbps() {
+  if (bitrateHoldKbps > 1000) return bitrateHoldKbps;
+  const m = s && s.stats && s.stats.bitrate_kbps;
+  return (m && m > 1000) ? m : BUF_REF_KBPS;           // plan for 10 Mbps before we know
+}
+function capMsFor(mb, kbps) {
+  if (!mb || mb <= 0) return 0;
+  const total = (Math.max(1, kbps) + BUF_AUDIO_KBPS) * (1 + BUF_OVERHEAD_PCT / 100);
+  return Math.floor((mb * 8192) / total * (1 - BUF_HEADROOM_PCT / 100)) * 1000;
+}
+function currentCapMs() { return bufferMB > 0 ? capMsFor(bufferMB, planningKbps()) : 0; }
+function requiredMB(ms) {
+  if (!ms || ms <= 0) return 0;
+  const total = (planningKbps() + BUF_AUDIO_KBPS) * (1 + BUF_OVERHEAD_PCT / 100);
+  return Math.ceil((ms / 1000) * total / (1 - BUF_HEADROOM_PCT / 100) / 8192);
+}
+function overCap(ms) { const c = currentCapMs(); return c > 0 && ms > c; }
+async function fetchBufferMB() {
+  const r = await fetchJ('/config');
+  if (r.ok && r.j && typeof r.j.buffer_mb === 'number') bufferMB = r.j.buffer_mb;
+  renderProfiles();   // re-gate chips now that capacity is known
+}
+
 // ---------------------------------------------------------- delay controls --
 
 function bump(n) {
@@ -166,6 +205,12 @@ function setTip(text) {
 }
 
 async function arm(ms) {
+  // Capacity guard, matched by the server's own /arm check. Skip for ms===0
+  // (disarm). The toast names the buffer size the delay actually needs.
+  if (ms > 0 && overCap(ms)) {
+    toast(`Buffer too small - ${(ms / 1000).toFixed(0)}s needs about ${requiredMB(ms)} MB. Raise it in the dashboard.`, 'err');
+    return;
+  }
   setPending('arming');
   const r = await fetchJ('/arm', { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: 'ms=' + ms });
   if (!r.ok) { toast(r.j?.error || 'Failed to arm', 'err'); pending = null; }
@@ -281,6 +326,7 @@ function renderCta() {
 
 function applyState(j) {
   s = j;
+  updateBitrateHold();   // feed the capacity peak-hold before anything reads it
   const ds = PHASE_TO_STATE[s.phase] || 'off';
   setNumberMode(ds);
   // Phase chip: idle vs passthrough vs arming/armed/active.
@@ -463,9 +509,14 @@ function renderProfiles() {
   if (!profileCache.length) { box.innerHTML = '<div class="empty">No profiles yet. Add them in the dashboard.</div>'; return; }
   box.innerHTML = '';
   for (const p of profileCache) {
-    const sec = Math.round((p.delay_ms || 0) / 1000);
+    const ms = p.delay_ms || 0, sec = Math.round(ms / 1000);
+    // Too big for the buffer at the current bitrate: greyed + disabled, with
+    // a tooltip naming the size it needs. Same wall the arm path enforces.
+    const tooBig = overCap(ms);
     const b = document.createElement('button');
-    b.className = list ? 'prow' : 'pchip';
+    b.className = (list ? 'prow' : 'pchip') + (tooBig ? ' toobig' : '');
+    b.disabled = tooBig;
+    b.title = tooBig ? `Buffer too small - needs about ${requiredMB(ms)} MB. Raise it in the dashboard.` : `Set ${sec}s delay`;
     b.innerHTML = list
       ? `<span>${esc(p.name || sec + 's')}</span><span class="pv">${sec}s</span>`
       : esc(p.name || sec + 's') + (cfg.w.profiles.value ? `<span class="pv">${sec}s</span>` : '');
@@ -474,6 +525,10 @@ function renderProfiles() {
   }
 }
 function profileSet(sec) {
+  if (overCap(sec * 1000)) {
+    toast(`Buffer too small for ${sec}s - raise it in the dashboard.`, 'err');
+    return;
+  }
   $('d').value = sec; renderCta();
   const ds = s ? (PHASE_TO_STATE[s.phase] || 'off') : 'off';
   if (cfg.w.profiles.arm && ds === 'off' && sec > 0) arm(sec * 1000);
@@ -508,6 +563,7 @@ async function fetchServerCfg() {
   srvCfg.auto_activate_when_ready = !!r.j.auto_activate_when_ready;
   srvCfg.tracing_enabled = !!r.j.tracing_enabled;
   srvCfg.webhook_set = !!r.j.webhook_set;
+  if (typeof r.j.buffer_mb === 'number') { bufferMB = r.j.buffer_mb; renderProfiles(); }
   renderBehavior(); renderSettings();
 }
 // A label + switch row bound to a boolean server-config key.
@@ -671,7 +727,7 @@ function applyCfg(c) {
   const wrap = document.querySelector('.wrap');
   for (const id of c.order) { const el = $(WEL[id]); if (el) wrap.appendChild(el); }
   if (on('dest')) { startDests(); if (destCache.length) renderDests(destCache); } else stopDests();
-  if (on('profiles')) fetchProfiles();
+  if (on('profiles')) { fetchProfiles(); if (!bufferMB) fetchBufferMB(); }   // capacity gate needs buffer size
   if (on('behavior') || on('settings')) { renderBehavior(); renderSettings(); fetchServerCfg(); }
   if (on('overlays')) fetchOverlays();
   if (s) applyState(s); else renderCta();   // re-render with the new options
@@ -949,7 +1005,7 @@ window.addEventListener('storage', e => {
 // channel, so refresh it whenever the dock regains focus or visibility -
 // e.g. after editing profiles in the dashboard and clicking back into OBS.
 function refreshAux() {
-  if (cfg.w.profiles.on) fetchProfiles();
+  if (cfg.w.profiles.on) { fetchProfiles(); fetchBufferMB(); }   // buffer size may have changed in the dashboard
   if (cfg.w.overlays.on) fetchOverlays();
   if (cfg.w.behavior.on || cfg.w.settings.on) fetchServerCfg();
   if (cfg.w.dest.on) fetchDests();

--- a/web/dock.js
+++ b/web/dock.js
@@ -474,7 +474,7 @@ function onDestToggle(d, row, sw) {
   if (row._confirm) return;
   const next = !d.enabled;
   const box = document.createElement('span'); box.className = 'confirm';
-  box.innerHTML = `<span class="q">${next ? 'Go live?' : 'Turn off?'}</span>`;
+  box.innerHTML = `<span class="q">${next ? 'Turn on?' : 'Turn off?'}</span>`;
   const yes = document.createElement('button'); yes.className = 'cbtn yes'; yes.innerHTML = '&#10003;';
   const no = document.createElement('button'); no.className = 'cbtn no'; no.innerHTML = '&times;';
   const cancel = () => { clearTimeout(row._ct); row._confirm = false; box.replaceWith(sw); };

--- a/web/dock.js
+++ b/web/dock.js
@@ -44,7 +44,7 @@ const WIDGETS = {
   behavior: { label: 'Auto behavior', def: { on: false } },
   settings: { label: 'Settings',      def: { on: false } },
   overlays: { label: 'Overlays',      def: { on: false, autohide: false, search: true, group: true } },
-  activate: { label: 'Action button', def: { on: true, confirmcut: false } },
+  activate: { label: 'Action button', def: { on: true, confirmcut: false, safecut: true } },
 };
 // Every widget that has stored options. phase + source are sub-widgets of the
 // status bar; bar rides along with the number screen it lives in.
@@ -102,7 +102,7 @@ const OPTS = {
   overlays: [
     { k: 'search', label: 'Search bar' }, { k: 'group', label: 'Folders' }, { k: 'autohide', label: 'Copy with autohide off' },
   ],
-  activate: [{ k: 'confirmcut', label: 'Confirm cut' }],
+  activate: [{ k: 'safecut', label: 'Cut after airs' }, { k: 'confirmcut', label: 'Confirm cut' }],
 };
 
 function defaultCfg() {
@@ -202,9 +202,27 @@ function mainClick() {
   const ms = (+$('d').value || 0) * 1000;
   if (ms > 0) arm(ms); else toast('Enter a delay', 'err');
 }
-function disarmClick() {
-  const b = $('cancel'); if (b._busy) return;
+// Scheduled safe cut ("cut after this airs"): mark now, keep forwarding the
+// buffered footage, auto-cut to live once the mark has aired everywhere.
+// Same endpoints as the dashboard's Cut-after; state carries the countdown.
+async function cutAfter() {
+  const r = await fetchJ('/cut-after', { method: 'POST' });
+  if (!r.ok) toast(r.j?.error || 'Cannot schedule cut', 'err');
+  else toast('Mark set - cuts once this airs', 'ok');
+  tick();
+}
+async function cutAfterCancel() {
+  await fetchJ('/cut-after/cancel', { method: 'POST' });
+  toast('Auto-cut cancelled', 'ok');
+  tick();
+}
+// The secondary button next to the main CTA: cancels arming while the buffer
+// fills, and schedules / cancels the safe cut while the delay is active.
+function secondaryClick() {
+  const b = $('cancel'); if (b._busy || !s) return;
   b._busy = true; setTimeout(() => b._busy = false, 300);
+  const ds = PHASE_TO_STATE[s.phase] || 'off';
+  if (ds === 'active') { if (s.safe_cut_pending) cutAfterCancel(); else cutAfter(); return; }
   disarm();
 }
 
@@ -229,9 +247,21 @@ function renderCta() {
   // Drop a pending cut-confirm if we left the active state by any route, so a
   // stale arm can't skip the guard next time.
   if (ds !== 'active' && m._cutArm) { m._cutArm = false; clearTimeout(m._cutT); }
-  m.className = 'btn full'; m.disabled = false; cancel.hidden = true;
+  m.className = 'btn full'; m.disabled = false;
+  cancel.hidden = true; cancel.className = 'btn ghost disarm'; cancel.innerHTML = '&times;'; cancel.title = 'Cancel arming';
   if (ds === 'active') {
     m.textContent = m._cutArm ? 'Tap again to cut' : 'Cut delay'; m.classList.add('danger');
+    // Secondary becomes the safe cut: schedule, then a live countdown a second
+    // tap cancels. A pending cut always shows even with the option off - it
+    // may have been scheduled from the dashboard, and hiding it would lie.
+    if (s.safe_cut_pending) {
+      const cd = Math.max(0, Math.round((s.safe_cut_remaining_ms || 0) / 1000));
+      cancel.hidden = false; cancel.className = 'btn ghost cutafter pending';
+      cancel.textContent = `⏱ ~${cd}s ✕`; cancel.title = 'Auto-cut armed - tap to cancel';
+    } else if (cfg.w.activate.safecut) {
+      cancel.hidden = false; cancel.className = 'btn ghost cutafter';
+      cancel.textContent = '⏱ Cut after'; cancel.title = 'Cut to live after everything buffered has aired';
+    }
   } else if (ds === 'armed') {
     m.innerHTML = '<span>&#9654;</span> Activate'; m.classList.add('go'); cancel.hidden = false;
   } else if (ds === 'arming') {
@@ -292,6 +322,7 @@ function applyState(j) {
   } else eg.hidden = true;
   // Hint text: full sentences, or errors-only (encoder offline) if opted.
   const tip = !s.ingest_alive ? 'Point your encoder at rtmp://…/live'
+    : ds === 'active' && s.safe_cut_pending ? `Auto-cut in ~${Math.max(0, Math.round((s.safe_cut_remaining_ms || 0) / 1000))}s - marked footage still airs.`
     : ds === 'active' ? `Live ${(s.current_delay_ms / 1000).toFixed(1)}s behind real time.`
     : ds === 'armed' ? 'Buffer full. Hit Activate to go live with delay.'
     : ds === 'arming' ? 'Filling buffer… you can cancel any time.'
@@ -343,7 +374,10 @@ function renderDests(list) {
   // toggled back on. "Active only" is the opt-in filter for a clean look.
   const show = cfg.w.dest.active ? list.filter(d => d.enabled || d.alive) : list;
   box.className = 'dests' + (icons ? ' icons' : '');
-  if (!show.length) { box.innerHTML = '<div class="empty">No destinations yet. Add them in the dashboard.</div>'; return; }
+  if (!show.length) {
+    box.innerHTML = `<div class="empty">${list.length ? 'No active destinations right now.' : 'No destinations yet. Add them in the dashboard.'}</div>`;
+    return;
+  }
   box.innerHTML = '';
   for (const d of show) box.appendChild(icons ? destIcon(d) : destRow(d));
 }

--- a/web/dock.js
+++ b/web/dock.js
@@ -39,8 +39,8 @@ const WIDGETS = {
   egress:   { label: 'Egress glance', def: { on: true, dests: true, bitrate: true, codec: false } },
   tips:     { label: 'Hint text',     def: { on: true, errorsOnly: false } },
   dest:     { label: 'Destinations',  def: { on: false, confirm: true, view: 'rows', active: false, stats: false } },
-  profiles: { label: 'Delay profiles',def: { on: false, arm: false, value: true } },
-  stats:    { label: 'Health stats',  def: { on: false, cpu: true, mem: true, recon: true, bitrate: false, cuts: false } },
+  profiles: { label: 'Delay profiles',def: { on: false, arm: false, value: true, view: 'chips' } },
+  stats:    { label: 'Health stats',  def: { on: false, cpu: true, mem: true, recon: true, bitrate: false, cuts: false, view: 'row' } },
   behavior: { label: 'Auto behavior', def: { on: false } },
   settings: { label: 'Settings',      def: { on: false } },
   overlays: { label: 'Overlays',      def: { on: false, autohide: false, search: true, group: true } },
@@ -88,8 +88,12 @@ const OPTS = {
     { k: 'view', label: 'Layout', modes: [['rows', 'Rows'], ['icons', 'Icons']] },
     { k: 'confirm', label: 'Confirm tap' }, { k: 'stats', label: 'Show bitrate' }, { k: 'active', label: 'Active only' },
   ],
-  profiles: [{ k: 'arm', label: 'Arm on tap' }, { k: 'value', label: 'Show seconds' }],
+  profiles: [
+    { k: 'view', label: 'Layout', modes: [['chips', 'Chips'], ['list', 'List']] },
+    { k: 'arm', label: 'Arm on tap' }, { k: 'value', label: 'Show seconds' },
+  ],
   stats:  [
+    { k: 'view', label: 'Layout', modes: [['row', 'Row'], ['tiles', 'Tiles']] },
     { k: 'cpu', label: 'CPU' }, { k: 'mem', label: 'RAM' }, { k: 'recon', label: 'Reconnects' },
     { k: 'bitrate', label: 'Bitrate' }, { k: 'cuts', label: 'Cuts' },
   ],
@@ -289,6 +293,11 @@ function applyState(j) {
     : 'Passthrough - no delay applied.';
   const showTip = cfg.w.tips.on && (!cfg.w.tips.errorsOnly || !s.ingest_alive);
   $('w-tip').hidden = !showTip; if (showTip) setTip(tip);
+  // Cross-dock sync: the state stream carries per-dest enabled/alive, so a
+  // toggle made anywhere (dashboard or another dock) refreshes the strip
+  // immediately instead of waiting out the 4 s poll.
+  const dsig = (s.destinations || []).map(d => `${d.id}:${+d.enabled}:${+d.alive}`).join();
+  if (dsig !== _destSig) { _destSig = dsig; if (cfg.w.dest.on) fetchDests(); }
   renderStats();
   renderCta();
 }
@@ -303,6 +312,7 @@ async function tick() {
 
 let _destTimer = null;
 let destCache = [];   // last /destinations payload, for instant re-render on option change
+let _destSig = '';    // enabled/alive fingerprint from the state stream (sync trigger)
 function startDests() { if (_destTimer) return; fetchDests(); _destTimer = setInterval(fetchDests, 4000); }
 function stopDests() { if (_destTimer) { clearInterval(_destTimer); _destTimer = null; } }
 async function fetchDests() {
@@ -396,12 +406,17 @@ async function fetchProfiles() {
 }
 function renderProfiles() {
   const box = $('w-profiles'); if (box.hidden) return;
+  const list = cfg.w.profiles.view === 'list';
+  box.className = 'profiles' + (list ? ' plist' : '');
   if (!profileCache.length) { box.innerHTML = '<div class="empty">No profiles yet. Add them in the dashboard.</div>'; return; }
   box.innerHTML = '';
   for (const p of profileCache) {
     const sec = Math.round((p.delay_ms || 0) / 1000);
-    const b = document.createElement('button'); b.className = 'pchip';
-    b.innerHTML = esc(p.name || sec + 's') + (cfg.w.profiles.value ? `<span class="pv">${sec}s</span>` : '');
+    const b = document.createElement('button');
+    b.className = list ? 'prow' : 'pchip';
+    b.innerHTML = list
+      ? `<span>${esc(p.name || sec + 's')}</span><span class="pv">${sec}s</span>`
+      : esc(p.name || sec + 's') + (cfg.w.profiles.value ? `<span class="pv">${sec}s</span>` : '');
     b.onclick = () => profileSet(sec);
     box.appendChild(b);
   }
@@ -416,14 +431,19 @@ function profileSet(sec) {
 // from the state stream, so no extra polling.
 function renderStats() {
   const box = $('w-stats'); if (box.hidden || !s) return;
-  const o = cfg.w.stats, st = s.stats || {}, parts = [];
-  if (o.cpu) parts.push(`<span class="st"><b>${(s.cpu_pct || 0).toFixed(0)}</b>% cpu</span>`);
-  if (o.mem) parts.push(`<span class="st"><b>${Math.round((s.rss_bytes || 0) / 1048576)}</b> MB</span>`);
-  if (o.bitrate) { const rate = fmtRate(st.bitrate_kbps); if (rate) parts.push(`<span class="st"><b>${rate}</b></span>`); }
-  if (o.recon) parts.push(`<span class="st"><b>${(st.egress_reconnects || 0) + (st.ingest_disconnects || 0)}</b> recon</span>`);
-  if (o.cuts) parts.push(`<span class="st"><b>${st.cuts || 0}</b> cuts</span>`);
-  if (s.backpressure) parts.push('<span class="st bad">&#9888; buffer lag</span>');
-  box.innerHTML = parts.join('') || '<span class="st muted">no metrics selected</span>';
+  const o = cfg.w.stats, st = s.stats || {}, tiles = o.view === 'tiles';
+  box.className = 'stats' + (tiles ? ' tiles' : '');
+  const items = [];
+  if (o.cpu) items.push([(s.cpu_pct || 0).toFixed(0) + '%', 'cpu']);
+  if (o.mem) items.push([Math.round((s.rss_bytes || 0) / 1048576), 'MB']);
+  if (o.bitrate) { const rate = fmtRate(st.bitrate_kbps); if (rate) items.push([rate, 'in']); }
+  if (o.recon) items.push([(st.egress_reconnects || 0) + (st.ingest_disconnects || 0), 'recon']);
+  if (o.cuts) items.push([st.cuts || 0, 'cuts']);
+  let html = items.map(([v, l]) => tiles
+    ? `<span class="tile"><b>${v}</b><span>${l}</span></span>`
+    : `<span class="st"><b>${v}</b> ${l}</span>`).join('');
+  if (s.backpressure) html += '<span class="st bad">&#9888; buffer lag</span>';
+  box.innerHTML = html || '<span class="st muted">no metrics selected</span>';
 }
 
 // Server settings mirrored on the dock (Auto behavior + Settings widgets).
@@ -786,9 +806,19 @@ function buildEditor() {
   body.appendChild(hint);
 
   const act = document.createElement('div'); act.className = 'ed-actions';
+  // Escape hatch for a messed-up layout: two-tap reset back to defaults.
+  const reset = document.createElement('button'); reset.className = 'btn ghost reset'; reset.textContent = 'Reset';
+  reset.onclick = () => {
+    if (!reset._arm) {
+      reset._arm = true; reset.textContent = 'Sure?'; reset.classList.add('warn');
+      setTimeout(() => { reset._arm = false; reset.textContent = 'Reset'; reset.classList.remove('warn'); }, 3000);
+      return;
+    }
+    openRows.clear(); cfg = defaultCfg(); saveAndApply(); buildEditor(); toast('Dock reset to defaults', 'ok');
+  };
   const copy = document.createElement('button'); copy.className = 'btn ghost'; copy.innerHTML = '<span>&#128279;</span> Copy dock URL'; copy.onclick = copyDockUrl;
   const done = document.createElement('button'); done.className = 'btn primary'; done.textContent = 'Done'; done.onclick = closeEditor;
-  act.append(copy, done); body.appendChild(act);
+  act.append(reset, copy, done); body.appendChild(act);
 }
 function applyPreset(k) {
   const p = PRESETS[k]; if (!p) return;
@@ -843,4 +873,26 @@ function startSSE() {
   } catch (_) { startPolling(); }
 }
 startSSE();
-window.addEventListener('focus', () => { if (!_es) tick(); });
+
+// Same-slot layout sync: OBS docks share one browser profile, so when
+// another instance of this slot saves (persist writes localStorage), the
+// storage event fires here and we adopt the new layout live - no reload.
+window.addEventListener('storage', e => {
+  if (e.key !== 'ic.dock.' + SLOT || !e.newValue) return;
+  try {
+    const next = mergeCfg(JSON.parse(e.newValue));
+    if (JSON.stringify(next) !== JSON.stringify(cfg)) applyCfg(next);
+  } catch (_) {}
+});
+
+// Aux data (profiles, overlays, server config, destinations) has no push
+// channel, so refresh it whenever the dock regains focus or visibility -
+// e.g. after editing profiles in the dashboard and clicking back into OBS.
+function refreshAux() {
+  if (cfg.w.profiles.on) fetchProfiles();
+  if (cfg.w.overlays.on) fetchOverlays();
+  if (cfg.w.behavior.on || cfg.w.settings.on) fetchServerCfg();
+  if (cfg.w.dest.on) fetchDests();
+}
+window.addEventListener('focus', () => { if (!_es) tick(); refreshAux(); });
+document.addEventListener('visibilitychange', () => { if (!document.hidden) refreshAux(); });

--- a/web/dock.js
+++ b/web/dock.js
@@ -34,11 +34,11 @@ const WIDGETS = {
   status:   { label: 'Status bar',    def: { on: true } },
   phase:    { label: 'Phase chip',    def: { on: true, style: 'chip' } },
   source:   { label: 'Live pill',     def: { on: true, style: 'pill' } },
-  number:   { label: 'Delay number',  def: { on: true, units: true, step: 5, controls: true, size: 'md' } },
-  bar:      { label: 'Buffer bar',    def: { on: true, pct: false, thick: false } },
+  number:   { label: 'Delay number',  def: { on: true, units: true, step: 5, controls: true, size: 'md', tint: false } },
+  bar:      { label: 'Buffer bar',    def: { on: true, pct: false, thick: false, mono: false } },
   egress:   { label: 'Egress glance', def: { on: true, dests: true, bitrate: true, codec: false } },
   tips:     { label: 'Hint text',     def: { on: true, errorsOnly: false } },
-  dest:     { label: 'Destinations',  def: { on: false, confirm: true, view: 'rows', active: false, stats: false } },
+  dest:     { label: 'Destinations',  def: { on: false, confirm: true, view: 'rows', active: false, stats: false, brand: true } },
   profiles: { label: 'Delay profiles',def: { on: false, arm: false, value: true, view: 'chips' } },
   stats:    { label: 'Health stats',  def: { on: false, cpu: true, mem: true, recon: true, bitrate: false, cuts: false, view: 'row' } },
   behavior: { label: 'Auto behavior', def: { on: false } },
@@ -79,13 +79,15 @@ const OPTS = {
   number: [
     { k: 'size', label: 'Size', modes: [['sm', 'S'], ['md', 'M'], ['lg', 'L']] },
     { k: 'step', label: 'Step', sel: [1, 5, 10] },
-    { k: 'controls', label: '+/- buttons' }, { k: 'units', label: 'Unit' },
-    { k: 'on', label: 'Buffer bar', w: 'bar' }, { k: 'pct', label: 'Show %', w: 'bar' }, { k: 'thick', label: 'Thick bar', w: 'bar' },
+    { k: 'controls', label: '+/- buttons' }, { k: 'units', label: 'Unit' }, { k: 'tint', label: 'Accent number' },
+    { k: 'on', label: 'Buffer bar', w: 'bar' }, { k: 'pct', label: 'Show %', w: 'bar' },
+    { k: 'thick', label: 'Thick bar', w: 'bar' }, { k: 'mono', label: 'Accent bar', w: 'bar' },
   ],
   egress: [{ k: 'dests', label: 'Dest count' }, { k: 'bitrate', label: 'Bitrate' }, { k: 'codec', label: 'Codec' }],
   tips:   [{ k: 'errorsOnly', label: 'Errors only' }],
   dest:   [
     { k: 'view', label: 'Layout', modes: [['rows', 'Rows'], ['icons', 'Icons']] },
+    { k: 'brand', label: 'Platform colors' },
     { k: 'confirm', label: 'Confirm tap' }, { k: 'stats', label: 'Show bitrate' }, { k: 'active', label: 'Active only' },
   ],
   profiles: [
@@ -316,6 +318,17 @@ async function tick() {
 let _destTimer = null;
 let destCache = [];   // last /destinations payload, for instant re-render on option change
 let _destSig = '';    // enabled/alive fingerprint from the state stream (sync trigger)
+
+// Brand hues so a glance says WHICH platform is live (user feedback: "color
+// coded by platform"). Reds/greens tuned for the dark panel; custom/sink
+// stay neutral. Applied via a --pc custom property + .pc class.
+const PLATFORM_COLORS = {
+  twitch: '#9146ff', youtube: '#ff4d4d', kick: '#53fc18', trovo: '#21c26d', restream: '#f27a3f',
+};
+function brandColor(el, platform) {
+  const pc = cfg.w.dest.brand && PLATFORM_COLORS[platform];
+  if (pc) { el.style.setProperty('--pc', pc); el.classList.add('pc'); }
+}
 function startDests() { if (_destTimer) return; fetchDests(); _destTimer = setInterval(fetchDests, 4000); }
 function stopDests() { if (_destTimer) { clearInterval(_destTimer); _destTimer = null; } }
 async function fetchDests() {
@@ -340,6 +353,7 @@ function destRow(d) {
   const rate = cfg.w.dest.stats && d.alive ? fmtRate(d.bitrate_kbps) : '';
   const meta = rate ? `<span class="d-rate">${rate}</span>` : `<span class="d-plat">${esc(d.platform || '')}</span>`;
   row.innerHTML = `<span class="d-dot"></span><span class="d-name">${esc(d.name || 'Destination')}</span>${meta}`;
+  brandColor(row, d.platform);
   const sw = document.createElement('button');
   sw.className = 'sw' + (d.enabled ? ' on' : '');
   sw.title = d.enabled ? 'Turn off' : 'Turn on';
@@ -354,6 +368,7 @@ function destIcon(d) {
   b.className = 'dico' + (d.enabled ? ' on' : ' off') + (d.alive ? ' alive' : '');
   b.textContent = (d.platform || d.name || '?').slice(0, 1).toUpperCase();
   b.title = `${d.name || 'Destination'} · ${d.enabled ? 'on' : 'off'}`;
+  brandColor(b, d.platform);
   b.onclick = () => onDestIcon(d, b);
   return b;
 }
@@ -612,8 +627,10 @@ function applyCfg(c) {
   // off hides the whole screen, bar included.
   $('w-screen').hidden = !on('number');
   $('w-screen').className = 'screen sz-' + (c.w.number.size || 'md');
+  $('cur').classList.toggle('tint', !!c.w.number.tint);
   $('w-bar').hidden = !on('bar');
   $('w-bar').classList.toggle('thick', !!c.w.bar.thick);
+  $('w-bar').classList.toggle('mono', !!c.w.bar.mono);
   for (const id of ['egress', 'tips', 'dest', 'profiles', 'stats', 'behavior', 'settings', 'overlays', 'activate']) $(WEL[id]).hidden = !on(id);
   document.querySelectorAll('.cur .u').forEach(u => u.hidden = !c.w.number.units);
   // Apply the saved drag order by re-appending containers in sequence.

--- a/web/index.html
+++ b/web/index.html
@@ -2581,7 +2581,16 @@ async function arm(ms){
       return;
     }
   }
-  await fetch('/arm',{method:'POST',headers:{'content-type':'application/x-www-form-urlencoded'},body:'ms='+ms});
+  const r = await fetch('/arm',{method:'POST',headers:{'content-type':'application/x-www-form-urlencoded'},body:'ms='+ms});
+  // The server enforces the same capacity wall (defence in depth); surface
+  // its message if bitrate rose between our check above and the request.
+  if (!r.ok){
+    let msg = 'Could not arm';
+    try { const j = await r.json(); if (j && j.error) msg = j.error; } catch(_){}
+    toast(msg, 'err');
+    tick();
+    return;
+  }
   toast(ms > 0 ? `Arming ${fmtDelay(ms)}…` : 'Disarmed', 'ok');
   tick();
 }


### PR DESCRIPTION
## Customizable OBS browser dock

A composable, per-slot OBS browser dock for driving InstantClone from inside OBS without opening the full dashboard, so competitive streamers can keep the CPU free. Everything is a widget you can toggle, reorder, and restyle; layouts are saved server-side and survive restarts.

### What's in it
- **Widget system** with presets (Full / Minimal / Delay only / Destinations / Control / Dashboard) and an in-dock bottom-sheet editor (drag to reorder, per-widget options, density, six accent themes).
- **Multiple docks** via `?dock=<id>` slots, each with its own saved layout. Copy-URL flows to spin up a second dock in OBS.
- **Durable persistence**: layout saved to the config file (`dock.<id>=<json>`), mirrored in localStorage for instant paint, reconciled from the server as source of truth.
- **Live sync** on par with the dashboard: SSE state stream, instant destination refresh on a state fingerprint, cross-dock layout sync via storage events, focus/visibility aux refresh.
- **Widgets**: status bar (phase chip + live pill), delay number (editable setter that retires to a clean readout when engaged), buffer bar, egress glance, hint text, destinations (rows/icons, platform-coded colors, two-tap misclick guard), delay profiles, health stats (CPU/RAM/reconnects/backpressure), auto-behavior toggles, live-safe settings, overlays picker with search + folders, and the action button.
- **Safe cut ("cut after this airs")** parity with the dashboard: schedule from the dock, live countdown, cancellable; a cut scheduled anywhere shows on every dock.
- **Buffer-capacity gate**: profiles/delays too big for the ring at the current bitrate are greyed out and refused, with a tooltip naming the buffer size needed. Enforced client-side on both dock and dashboard, and server-side on `/arm` (defence in depth).

### Server changes
- `/docks/<id>` GET/POST/list with size + charset validation; `dock.<id>` config lines (`MAX_DOCKS`, `MAX_DOCK_LAYOUT_LEN`).
- `/destinations/toggle` endpoint that flips `enabled` only, without the field-rebuild the upsert path does.
- `/arm` capacity guard returning 409 with a plain message when a delay can't fill.
- `/dock.js` served as an embedded gzip asset.

### Verification
- `node --check web/dock.js` clean, `cargo build` clean, **236 tests pass** (including a dock-layout round-trip through save/load).
- Live smoke tests: restart-durable layout persistence, destination toggle field preservation, safe-cut 409-when-idle, and the capacity guard (a 50 MB buffer arms 100s but rejects 300s with a clear message).

### Not yet done
- Opened as **draft** pending an in-OBS verification pass (platform colors on the dark panel, safe-cut countdown, cross-dock sync, capacity gating). Promote to Ready once that checks out.
