### PR TITLE
fix: first-run wizard reappears after setup (configured latch + serialized settings writes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ the CPU free and only show what they need.
 
 ### Fixes
 
+- The first-run wizard could reappear after setup was already done (thanks
+  **fashionxd** for the report). Two causes: (1) `configured` was recomputed
+  live on every destination toggle/delete, so turning off or removing your
+  last destination flipped it back to false and reopened the wizard - it is
+  now a one-way first-run latch that only an explicit full reset clears;
+  (2) every settings write did an unsynchronized clone -> mutate -> `send()`
+  of the whole struct, so two overlapping POSTs lost one update (which could
+  resurrect a stale `configured=false`). All settings mutations now
+  serialize through a single process-wide write lock, closing the
+  lost-update race for every field, not just this flag.
 - The OBS dock showed a phantom **1.0s** delay in passthrough. It fed
   the big number from `current_delay_ms`, which includes the pipeline's
   own transit latency (encoder → ingest → ring → egress) even with no

--- a/README.es.md
+++ b/README.es.md
@@ -49,7 +49,7 @@ Cuando ya lo tenía hecho, las piezas que de verdad quería eran: una activació
 <tr><td><b>RSS inactivo</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Hilos</b></td><td align="right"><code>1 tokio + 1 bandeja</code></td></tr>
 <tr><td><b>Deps en runtime</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>236 / 236</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>238 / 238</code></td></tr>
 </table>
 
 </td>
@@ -289,7 +289,7 @@ Sin npm, sin submódulos, sin SDK de plataforma. El HTML del panel se minifica y
 
 ## Estado
 
-**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 236 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
+**Listo para uso diario en Windows.** Lo uso en mis propios directos. CI corre fmt + clippy (con `-D warnings`) + 238 tests en cada push, y un tag dispara la build + publicación automática de la release con su `SHA256SUMS.txt` al lado (todavía no hay certificado de firma de código, así que el sistema operativo puede avisar en el primer lanzamiento).
 
 **Lo que está sólido**
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once it existed, the parts I'd actually wanted ended up in: a real two-phase arm
 <tr><td><b>Idle RSS</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Threads</b></td><td align="right"><code>1 tokio + 1 tray</code></td></tr>
 <tr><td><b>Runtime deps</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>236 / 236</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>238 / 238</code></td></tr>
 </table>
 
 </td>
@@ -289,7 +289,7 @@ No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzippe
 
 ## Status
 
-**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 236 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
+**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 238 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
 
 **What's solid**
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -26,6 +26,40 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 
+/// Serializes read-modify-write cycles on the single per-process settings
+/// channel. Each mutating handler does `settings.borrow().clone()` -> mutate
+/// -> `settings.send(whole_struct)`; a connection runs per task, so without
+/// this lock two overlapping POSTs each start from the same snapshot and the
+/// later `send()` clobbers the other's change. That lost update used to
+/// silently reset the `configured` flag and bounce users into the first-run
+/// wizard. A plain `std::sync::Mutex` is correct here because the critical
+/// section never `.await`s (its `!Send` guard makes that a compile error), so
+/// it can also be taken from the sync persist/overlay handlers.
+static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take the settings write lock for a full read-modify-write-send cycle. Hold
+/// the guard from just before `settings.borrow().clone()` until after
+/// `settings.send(..)`. Recovers from a poisoned mutex - a panic mid-save must
+/// not wedge every later config write.
+fn settings_write_guard() -> std::sync::MutexGuard<'static, ()> {
+    SETTINGS_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+/// True when at least one destination is enabled and fully addressable (a
+/// resolvable egress URL with a stream key). This is the "ready to stream"
+/// condition first-run setup waits for, and the only thing that raises the
+/// `configured` latch. It never lowers it: once setup is complete, turning
+/// the last destination off or deleting it keeps the user on the dashboard
+/// rather than reopening the wizard - only an explicit full reset clears the
+/// flag. See `post_destination_toggle` / `post_destination_delete`.
+fn has_streamable_dest(s: &Settings) -> bool {
+    s.destinations
+        .iter()
+        .any(|d| d.enabled && d.is_well_formed())
+}
+
 pub async fn run(
     addr: String,
     ctrl: Arc<Controller>,
@@ -1487,6 +1521,9 @@ async fn post_config(
     cfg_path: &Path,
 ) -> (&'static str, &'static str, String) {
     let form = config::parse_form(body);
+    // Held across the whole clone -> mutate -> save -> send below so a
+    // concurrent POST can't clobber this write. See SETTINGS_WRITE_LOCK.
+    let _wl = settings_write_guard();
     let mut new_settings = settings.borrow().clone();
 
     // Network + buffer + overlay-dir + webhook URL are applied directly.
@@ -1576,11 +1613,7 @@ async fn post_config(
         old.buffer_mb != new_settings.buffer_mb || old.buffer_path != new_settings.buffer_path;
 
     // Mark as configured the moment we have at least one usable destination.
-    if new_settings
-        .destinations
-        .iter()
-        .any(|d| d.enabled && d.is_well_formed())
-    {
+    if has_streamable_dest(&new_settings) {
         new_settings.configured = true;
     }
 
@@ -1638,6 +1671,7 @@ async fn post_config_reset(
         .get("scope")
         .cloned()
         .unwrap_or_else(|| "settings".to_string());
+    let _wl = settings_write_guard();
     let mut next = Settings::defaults();
     if scope == "settings" {
         // Carry over the user's stream destinations and profiles -
@@ -1863,6 +1897,7 @@ fn persist_delay_state(
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
 ) {
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     let armed = ctrl.armed_delay_ms();
     let target = ctrl.target_delay_ms();
@@ -1923,6 +1958,7 @@ async fn post_profile_add(
             r#"{"ok":false,"error":"name required"}"#.into(),
         );
     }
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     // Replace existing by name, else append.
     if let Some(p) = ns.profiles.iter_mut().find(|p| p.name == name) {
@@ -1942,6 +1978,7 @@ async fn post_profile_del(
 ) -> (&'static str, &'static str, String) {
     let form = config::parse_form(body);
     let name = form.get("name").cloned().unwrap_or_default();
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     ns.profiles.retain(|p| p.name != name);
     let _ = ns.save(cfg_path);
@@ -2072,6 +2109,7 @@ async fn post_destination_upsert(
         );
     }
 
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     if let Some(existing) = ns.destinations.iter_mut().find(|d| d.id == id) {
         existing.name = name;
@@ -2115,11 +2153,7 @@ async fn post_destination_upsert(
             ),
         );
     }
-    if ns
-        .destinations
-        .iter()
-        .any(|d| d.enabled && d.is_well_formed())
-    {
+    if has_streamable_dest(&ns) {
         ns.configured = true;
     }
     if let Err(e) = ns.save(cfg_path) {
@@ -2196,6 +2230,7 @@ async fn post_destination_toggle(
         Some("on" | "true" | "1")
     );
 
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     let Some(dest) = ns.destinations.iter_mut().find(|d| d.id == id) else {
         return (
@@ -2206,10 +2241,13 @@ async fn post_destination_toggle(
     };
     dest.enabled = enabled;
 
-    ns.configured = ns
-        .destinations
-        .iter()
-        .any(|d| d.enabled && d.is_well_formed());
+    // `configured` is a first-run setup latch, not a live "has an active
+    // destination" flag. Toggling your last destination off must not bounce
+    // you back into the wizard - only an explicit full reset clears it. So
+    // this only ever raises the latch, never lowers it.
+    if has_streamable_dest(&ns) {
+        ns.configured = true;
+    }
     if let Err(e) = ns.save(cfg_path) {
         return (
             "500 Internal Server Error",
@@ -2233,6 +2271,7 @@ async fn post_destination_delete(
 ) -> (&'static str, &'static str, String) {
     let form = config::parse_form(body);
     let id = form.get("id").cloned().unwrap_or_default();
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     let before = ns.destinations.len();
     ns.destinations.retain(|d| d.id != id);
@@ -2243,13 +2282,10 @@ async fn post_destination_delete(
             r#"{"ok":false,"error":"no such destination"}"#.into(),
         );
     }
-    if !ns
-        .destinations
-        .iter()
-        .any(|d| d.enabled && d.is_well_formed())
-    {
-        ns.configured = false;
-    }
+    // Deleting the last destination leaves `configured` alone: setup was
+    // already completed once, so we keep the user on the dashboard (empty
+    // Destinations tab) rather than reopening the first-run wizard. Only an
+    // explicit `scope=all` reset returns them to the wizard.
     let _ = ns.save(cfg_path);
     reconcile_obs_vod_files(&ns, ctrl);
     let _ = settings.send(ns);
@@ -2340,6 +2376,7 @@ async fn dock_layout_save(
             r#"{"ok":false,"error":"layout must be single-line json"}"#.into(),
         );
     }
+    let _wl = settings_write_guard();
     let mut ns = settings.borrow().clone();
     if body.is_empty() {
         ns.docks.remove(&id); // empty body resets the slot to default
@@ -2731,6 +2768,7 @@ fn overlays_mark_seeded(
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
 ) -> (&'static str, &'static str, String) {
+    let _wl = settings_write_guard();
     let mut next = settings.borrow().clone();
     if !next.overlays_seeded {
         next.overlays_seeded = true;
@@ -2755,6 +2793,7 @@ fn overlays_reset(
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
 ) -> (&'static str, &'static str, String) {
+    let _wl = settings_write_guard();
     let mut next = settings.borrow().clone();
     wipe_studio_overlays(&next.overlays_dir);
     next.overlays_seeded = false;
@@ -3858,6 +3897,73 @@ mod tests {
     #[test]
     fn find_subslice_returns_none_when_absent() {
         assert!(find_subslice(b"abc", b"xy").is_none());
+    }
+
+    // ── `configured` first-run latch ─────────────────────────────────
+    //
+    // `has_streamable_dest` is the sole condition that raises the
+    // `configured` latch. If it ever counted a disabled or key-less
+    // destination as streamable - or missed a real one - the toggle/upsert
+    // handlers would flip `configured` wrongly and bounce users into (or out
+    // of) the first-run wizard. This pins the exact contract.
+
+    fn twitch_dest(enabled: bool, stream_key: &str) -> crate::config::Destination {
+        crate::config::Destination {
+            id: "d1".into(),
+            name: "Main".into(),
+            enabled,
+            platform: "twitch".into(),
+            stream_key: stream_key.into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: String::new(),
+        }
+    }
+
+    fn settings_with_dests(dests: Vec<crate::config::Destination>) -> Settings {
+        let mut s = Settings::defaults();
+        s.destinations = dests;
+        s
+    }
+
+    #[test]
+    fn has_streamable_dest_requires_enabled_and_addressable() {
+        // No destinations at all: not streamable.
+        assert!(!has_streamable_dest(&settings_with_dests(vec![])));
+        // Enabled + real stream key: streamable.
+        assert!(has_streamable_dest(&settings_with_dests(vec![
+            twitch_dest(true, "livekey123")
+        ])));
+        // Disabled, even with a key: does NOT count - toggling the last
+        // destination off must not make setup look incomplete.
+        assert!(!has_streamable_dest(&settings_with_dests(vec![
+            twitch_dest(false, "livekey123")
+        ])));
+        // Enabled but no key: not addressable yet, so not streamable.
+        assert!(!has_streamable_dest(&settings_with_dests(vec![
+            twitch_dest(true, "")
+        ])));
+    }
+
+    #[test]
+    fn configured_latch_only_rises() {
+        // Mirror the handler's latch step - `if has_streamable_dest { =true }`
+        // starting from an already-configured install whose last destination
+        // is now disabled. The flag must stay true (no wizard reopen); only a
+        // full reset clears it.
+        let s = settings_with_dests(vec![twitch_dest(false, "livekey123")]);
+        assert!(!has_streamable_dest(&s), "precondition: not streamable");
+        let mut configured = true; // setup completed earlier
+        if has_streamable_dest(&s) {
+            configured = true;
+        }
+        assert!(
+            configured,
+            "a completed setup must never re-open the wizard"
+        );
     }
 
     // ── Overlay Studio CRUD ──────────────────────────────────────


### PR DESCRIPTION
## Summary

The first-run wizard could reappear after setup was already complete. Reported by **fashionxd**. Two independent root causes, both fixed:

1. **Semantic (the reproducible one).** `configured` was recomputed live on every destination toggle/delete as "is any destination streamable right now." So disabling or deleting your last enabled + well-formed destination flipped `configured=false` and reopened the wizard on next load. The 0.1.10 dock's one-tap destination toggle made this easy to hit for single-destination users. It is now a **one-way first-run latch**, cleared only by an explicit full reset (`scope=all`). The "ready to stream" condition is extracted into a tested `has_streamable_dest`.

2. **Race (secondary).** Every settings handler did an unsynchronized `settings.borrow().clone()` -> mutate -> `send(whole_struct)`, one task per connection. Two overlapping POSTs lost one update, which could resurrect a stale `configured=false`. All 12 settings mutators now serialize through a single process-wide `SETTINGS_WRITE_LOCK` (a `std::sync::Mutex`; the critical section never `.await`s, and its `!Send` guard makes that a compile-time guarantee). This closes the lost-update race for **every** settings field, not just this flag.

## Behavior change

Removing/disabling your last destination now leaves you on the dashboard (empty Destinations state) instead of reopening the wizard. "Reset everything" still returns to the wizard.

## Verification

- `cargo fmt`, `cargo clippy --release` clean, `cargo test --release` **238 passed** (+2 regression tests pinning the latch contract).
- Working tree was byte-identical to the released v0.1.10, so no integration drift.