### PR TITLE
feat: encoder compat warnings, Start with Windows, adaptive re-cut + UX polish (0.1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,79 @@ All notable changes will land here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow
 [SemVer](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.11] - Encoder compatibility warnings, Start with Windows, adaptive re-cut, and UX polish
+
+### Encoder compatibility warnings
+
+InstantClone now measures what OBS is actually sending and says something
+only when it will bite one of your **enabled** destinations.
+
+- **Keyframe interval** is measured from the IDR index (mean of the first
+  5 gaps, then frozen for the session) and flagged above 2.6 s. OBS's
+  "auto" typically lands at 4 s, which causes rebuffering on Kick and
+  YouTube. The 0.6 s of headroom means a correctly-set 2 s stream, which
+  measures ~2.0-2.1 s in practice, never trips it.
+- **Resolution** is decoded from the SPS and checked against Kick's 1080p
+  ceiling.
+- **Codec** is flagged when HEVC/AV1/VP9 is heading for Kick's H.264-only
+  ingest. Twitch and YouTube are deliberately excluded - Twitch negotiates
+  codecs under Enhanced Broadcasting and YouTube has HEVC ingest paths, so
+  warning about either would risk a false positive.
+
+The design constraint was not adding clutter: **nothing renders when the
+stream is healthy**, every problem collapses into a single line naming the
+affected platforms (never per-check badges), disabled destinations and the
+local sink are ignored, and the line is dismissible. Dismissal is keyed by
+the message, so fixing one problem and hitting a different one brings the
+strip back on its own. Custom RTMP gets no opinion at all - we have no idea
+what a user's own ingest wants.
+
+The measurement freezes once its sample budget is spent, on purpose. A
+value that keeps drifting is what made the buffer-capacity gate strobe in
+0.1.10, and a warning that flickers mid-stream is worse than no warning.
+
+### Start with Windows
+
+**System → Behavior → Start with Windows** registers InstantClone under the
+per-user `Run` key (HKCU, so no elevation) with `--no-browser`, so it waits
+in the tray at login instead of throwing a dashboard tab at you.
+
+The registry entry is its own source of truth rather than a mirrored
+setting: Windows gives users their own switches for startup entries (Task
+Manager's Startup tab), and a stored copy of the flag would sit there
+claiming "on" after someone turned it off elsewhere. Enabling always
+rewrites the command, so an entry left behind by a previous install
+location gets corrected instead of pointing at a missing executable.
+
+### LAN exposure warning
+
+The **LAN access** toggles now say what they actually do. The control API
+has no authentication - the CSRF guard blocks cross-origin browser POSTs,
+but a direct request (curl, Stream Deck) carries no `Origin` header and is
+allowed through by design so CLI integrations keep working. On loopback,
+the default, that is exactly right. Exposed to a LAN it means anyone on the
+network can change the delay, cut, and edit destinations, and the ingest
+port accepts any stream key. Both toggles remain off by default; the
+warning appears only while one is ticked.
+
+### Fixes
+
+- The keyframe-interval sampler discarded the real first keyframe of every
+  session. It used `first_idr_ts_ms == 0` as its "not started yet"
+  sentinel, but an RTMP session normally starts at timestamp 0, so the
+  window re-opened on the *second* keyframe and every subsequent mean was
+  computed from the wrong origin. Caught by its own regression test before
+  shipping; the window now has an explicit flag.
+- The compatibility strip's dismissal is scoped to the publishing session:
+  it clears when the stream stops, so a new session that hits the same
+  problem warns again instead of inheriting a stale dismissal.
+- The one-click updater now confirms before restarting while OBS is
+  publishing, matching the tray Quit guard - an update tears down every
+  egress the same way a quit does.
+
+### Dependencies
+
+- `tokio` 1.52.3 -> 1.53.0, `bytes` 1.12.0 -> 1.12.1.
 
 ## [0.1.10] - Improving visuals, adding "sink" test mode as destination, UX improvements and OBS dock
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "instantclone"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bytes",
  "flate2",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instantclone"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["s1moscs"]
 license = "GPL-3.0-only"
@@ -48,8 +48,10 @@ windows-sys = { version = "0.61", features = [
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Console",
+    "Win32_System_Registry",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",

--- a/README.es.md
+++ b/README.es.md
@@ -17,11 +17,7 @@
 <br/>
 <br/>
 
-<a href="https://youtu.be/y3aj88gTAOs"><img src="https://img.shields.io/badge/-%E2%96%B6%20Tutorial%20en%20v%C3%ADdeo-ff3b30?style=for-the-badge&labelColor=11141a"/></a>
-
-<br/>
-
-<sub>Tutorial de instalación y demostración de uso · audio en español, subtítulos en inglés</sub>
+<sub><a href="https://youtu.be/y3aj88gTAOs"><b>▶ Ver el tutorial</b></a> &nbsp;·&nbsp; audio en español, subtítulos en inglés</sub>
 
 <br/>
 <br/>

--- a/README.es.md
+++ b/README.es.md
@@ -17,6 +17,15 @@
 <br/>
 <br/>
 
+<a href="https://youtu.be/y3aj88gTAOs"><img src="https://img.shields.io/badge/-%E2%96%B6%20Tutorial%20en%20v%C3%ADdeo-ff3b30?style=for-the-badge&labelColor=11141a"/></a>
+
+<br/>
+
+<sub>Tutorial de instalación y demostración de uso · audio en español, subtítulos en inglés</sub>
+
+<br/>
+<br/>
+
 <a href="https://github.com/Soulhackzlol/InstantClone/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Soulhackzlol/InstantClone/ci.yml?branch=main&style=flat-square&label=ci&color=34c759&labelColor=11141a"/></a>
 <a href="https://github.com/Soulhackzlol/InstantClone/releases"><img alt="release" src="https://img.shields.io/github/v/release/Soulhackzlol/InstantClone?include_prereleases&style=flat-square&color=5ac8fa&labelColor=11141a&display_name=tag&sort=semver"/></a>
 <a href="LICENSE"><img alt="GPL-3.0" src="https://img.shields.io/badge/licencia-GPL--3.0-d4d8e1?style=flat-square&labelColor=11141a"/></a>

--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@
 <br/>
 <br/>
 
-<a href="https://youtu.be/y3aj88gTAOs"><img src="https://img.shields.io/badge/-%E2%96%B6%20Video%20tutorial-ff3b30?style=for-the-badge&labelColor=11141a"/></a>
-
-<br/>
-
-<sub>Setup tutorial and usage showcase · Spanish audio, English subtitles</sub>
+<sub><a href="https://youtu.be/y3aj88gTAOs"><b>▶ Watch the setup tutorial</b></a> &nbsp;·&nbsp; Spanish audio, English subtitles</sub>
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once it existed, the parts I'd actually wanted ended up in: a real two-phase arm
 <tr><td><b>Idle RSS</b></td><td align="right"><code>~9 MB</code></td></tr>
 <tr><td><b>Threads</b></td><td align="right"><code>1 tokio + 1 tray</code></td></tr>
 <tr><td><b>Runtime deps</b></td><td align="right"><code>tokio, bytes, ureq</code></td></tr>
-<tr><td><b>Tests</b></td><td align="right"><code>238 / 238</code></td></tr>
+<tr><td><b>Tests</b></td><td align="right"><code>269 / 269</code></td></tr>
 </table>
 
 </td>
@@ -289,7 +289,7 @@ No npm. No submodules. No platform SDKs. The dashboard HTML is minified + gzippe
 
 ## Status
 
-**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 238 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
+**Daily-driver ready on Windows.** I use it on my own streams. CI runs fmt + clippy (with `-D warnings`) + 269 tests on every push, and a tagged commit auto-builds + publishes a release artifact with a `SHA256SUMS.txt` checksum file alongside (no code-signing certificate yet, so the OS may warn on first launch).
 
 **What's solid**
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@
 <br/>
 <br/>
 
+<a href="https://youtu.be/y3aj88gTAOs"><img src="https://img.shields.io/badge/-%E2%96%B6%20Video%20tutorial-ff3b30?style=for-the-badge&labelColor=11141a"/></a>
+
+<br/>
+
+<sub>Setup tutorial and usage showcase · Spanish audio, English subtitles</sub>
+
+<br/>
+<br/>
+
 <a href="https://github.com/Soulhackzlol/InstantClone/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Soulhackzlol/InstantClone/ci.yml?branch=main&style=flat-square&label=ci&color=34c759&labelColor=11141a"/></a>
 <a href="https://github.com/Soulhackzlol/InstantClone/releases"><img alt="release" src="https://img.shields.io/github/v/release/Soulhackzlol/InstantClone?include_prereleases&style=flat-square&color=5ac8fa&labelColor=11141a&display_name=tag&sort=semver"/></a>
 <a href="LICENSE"><img alt="GPL-3.0" src="https://img.shields.io/badge/license-GPL--3.0-d4d8e1?style=flat-square&labelColor=11141a"/></a>

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -1,0 +1,166 @@
+//! "Start with Windows" - one value under the per-user Run key.
+//!
+//! The registry is the source of truth here, deliberately: it is not
+//! mirrored into `Settings`. Windows gives users their own switches for
+//! startup entries (Task Manager's Startup tab, Settings → Apps → Startup),
+//! and a copy of the flag on our side would sit there claiming "on" after
+//! someone turned it off somewhere else. Reading the key costs one call, so
+//! the dashboard just asks it directly and can never disagree with reality.
+//!
+//! HKCU rather than HKLM: no elevation needed, and autostart is a per-user
+//! preference. The command is registered with `--no-browser` so logging in
+//! doesn't throw a dashboard tab in the user's face.
+
+use std::io;
+
+/// Value name under the Run key. Stable - renaming it would strand the old
+/// entry and silently start InstantClone twice.
+#[cfg(windows)]
+const VALUE_NAME: &str = "InstantClone";
+
+#[cfg(windows)]
+const RUN_KEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+
+/// UTF-16, null-terminated - every `*W` registry API expects this.
+#[cfg(windows)]
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// The exact command line the Run key should hold. Quoted because
+/// `C:\Program Files\…` and friends contain spaces, and an unquoted path
+/// would have Windows try to launch `C:\Program`.
+#[cfg(windows)]
+fn run_command() -> io::Result<String> {
+    let exe = std::env::current_exe()?;
+    Ok(format!("\"{}\" --no-browser", exe.display()))
+}
+
+/// Whether InstantClone is currently registered to start at login.
+///
+/// Any failure reads as "not enabled": the value being absent is itself
+/// the common failure, and a missing Run key on an exotic Windows install
+/// means the same thing to the user either way.
+#[cfg(windows)]
+pub fn is_enabled() -> bool {
+    use windows_sys::Win32::System::Registry::{RegGetValueW, HKEY_CURRENT_USER, RRF_RT_REG_SZ};
+    let subkey = wide(RUN_KEY);
+    let name = wide(VALUE_NAME);
+    // Null output buffer + null size: asks only "does this value exist,
+    // and is it a string?" without reading the data back.
+    let rc = unsafe {
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            subkey.as_ptr(),
+            name.as_ptr(),
+            RRF_RT_REG_SZ,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    rc == 0
+}
+
+/// Add or remove the Run-key entry.
+///
+/// Enabling always rewrites the command rather than checking first, so an
+/// entry left behind by a previous install location is corrected instead
+/// of pointing at an executable that no longer exists.
+#[cfg(windows)]
+pub fn set(enabled: bool) -> io::Result<()> {
+    use windows_sys::Win32::System::Registry::{
+        RegDeleteKeyValueW, RegSetKeyValueW, HKEY_CURRENT_USER, REG_SZ,
+    };
+    let subkey = wide(RUN_KEY);
+    let name = wide(VALUE_NAME);
+
+    let rc = if enabled {
+        let value = wide(&run_command()?);
+        // Length is in BYTES and must include the terminating null.
+        let bytes = (value.len() * std::mem::size_of::<u16>()) as u32;
+        unsafe {
+            RegSetKeyValueW(
+                HKEY_CURRENT_USER,
+                subkey.as_ptr(),
+                name.as_ptr(),
+                REG_SZ,
+                value.as_ptr() as *const std::ffi::c_void,
+                bytes,
+            )
+        }
+    } else {
+        let rc = unsafe { RegDeleteKeyValueW(HKEY_CURRENT_USER, subkey.as_ptr(), name.as_ptr()) };
+        // ERROR_FILE_NOT_FOUND - already absent, which is the state the
+        // caller asked for. Disabling twice is not an error.
+        const ERROR_FILE_NOT_FOUND: u32 = 2;
+        if rc == ERROR_FILE_NOT_FOUND {
+            0
+        } else {
+            rc
+        }
+    };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(rc as i32))
+    }
+}
+
+#[cfg(not(windows))]
+pub fn is_enabled() -> bool {
+    false
+}
+
+#[cfg(not(windows))]
+pub fn set(_enabled: bool) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "start with Windows is only available on Windows",
+    ))
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_command_is_quoted_and_headless() {
+        let cmd = run_command().expect("current_exe");
+        assert!(
+            cmd.starts_with('"'),
+            "path must be quoted or a spaced install directory breaks the entry: {cmd}"
+        );
+        assert!(
+            cmd.contains("\" --no-browser"),
+            "autostart must not pop a browser tab at login: {cmd}"
+        );
+    }
+
+    /// Round-trip against the real registry. Writes under HKCU, which
+    /// needs no elevation, and restores whatever state the machine was in
+    /// so running the suite never changes the developer's own startup.
+    #[test]
+    fn enable_disable_round_trip() {
+        let original = is_enabled();
+
+        set(true).expect("enable");
+        assert!(is_enabled(), "value must exist after enabling");
+
+        set(false).expect("disable");
+        assert!(!is_enabled(), "value must be gone after disabling");
+
+        // Disabling an already-absent value is a no-op, not an error.
+        set(false).expect("disable twice");
+
+        if original {
+            set(true).expect("restore");
+        }
+        assert_eq!(
+            is_enabled(),
+            original,
+            "test must leave startup state as found"
+        );
+    }
+}

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,0 +1,356 @@
+//! Encoder-compatibility checks: compare what OBS is actually sending
+//! against what the *enabled* destinations accept.
+//!
+//! Design rule: silence when healthy. This module returns `None` far more
+//! often than it returns a warning, and when it does warn it produces ONE
+//! line naming the affected platforms - never a per-check badge. A wrong
+//! or noisy warning is worse than no warning, so every rule here is
+//! deliberately conservative: it fires only on settings that genuinely
+//! break an ingest, with enough tolerance that a correctly-configured
+//! stream never trips it.
+//!
+//! Everything is a pure function of (measured params, destinations), so
+//! the rules are unit-testable without a live stream.
+
+use crate::config::{platform_label, Destination};
+use crate::h264::VideoCodec;
+
+/// Measured parameters of the current publisher session. Zeroed between
+/// sessions by `Controller::reset_codec_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamParams {
+    /// Primary-track pixel dimensions, 0 when not decoded yet (non-AVC
+    /// codecs and multi-track sequence headers are not parsed).
+    pub width: u32,
+    pub height: u32,
+    /// Mean IDR spacing in ms, 0 until enough keyframes have been seen.
+    pub keyframe_interval_ms: u32,
+    pub codec: VideoCodec,
+}
+
+/// Warn above this measured IDR spacing. Every ingest we support asks for
+/// a 2 s keyframe interval; the 0.6 s of headroom absorbs encoder jitter
+/// and the occasional long GOP so a correctly-configured 2 s stream (which
+/// measures ~2.0-2.1 s in practice) never trips the check. OBS's "auto"
+/// setting typically lands at 4 s, which is what this is here to catch.
+const KEYFRAME_WARN_MS: u32 = 2_600;
+
+/// Platforms that document a 2 s keyframe interval. "custom" is absent on
+/// purpose - we have no idea what a user's own ingest wants, and guessing
+/// would produce exactly the false positive this module is built to avoid.
+const WANTS_2S_KEYFRAME: &[&str] = &["twitch", "youtube", "kick", "trovo", "restream"];
+
+/// Kick's ingest ladder tops out at 1080p. Sending a taller canvas is
+/// accepted but downscaled server-side at best, rejected at worst.
+const KICK_MAX_HEIGHT: u32 = 1080;
+
+/// Produce at most one line describing every compatibility problem with
+/// the current stream, or `None` when there is nothing worth saying.
+///
+/// Only *enabled* destinations are considered - there is no reason to warn
+/// about Kick's resolution cap for someone who does not stream to Kick.
+/// The local test sink is skipped: it accepts anything by design.
+pub fn compat_warning(params: &StreamParams, destinations: &[Destination]) -> Option<String> {
+    let live: Vec<&Destination> = destinations
+        .iter()
+        .filter(|d| d.enabled && d.platform != "sink")
+        .collect();
+    if live.is_empty() {
+        return None;
+    }
+
+    let issues: Vec<String> = [
+        keyframe_issue(params, &live),
+        resolution_issue(params, &live),
+        codec_issue(params, &live),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    if issues.is_empty() {
+        None
+    } else {
+        Some(issues.join(" · "))
+    }
+}
+
+/// IDR spacing well past the 2 s every platform asks for. This is the
+/// check that earns its keep: a 4 s interval causes visible rebuffering
+/// on the viewer side and breaks low-latency modes, and OBS ships it by
+/// default under "auto".
+fn keyframe_issue(params: &StreamParams, live: &[&Destination]) -> Option<String> {
+    if params.keyframe_interval_ms == 0 || params.keyframe_interval_ms <= KEYFRAME_WARN_MS {
+        return None;
+    }
+    let names = labels_matching(live, |slug| WANTS_2S_KEYFRAME.contains(&slug));
+    if names.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "Keyframe interval measures {}. {} {} 2s.",
+        format_seconds(params.keyframe_interval_ms),
+        join_names(&names),
+        verb_for(names.len(), "expects", "expect"),
+    ))
+}
+
+/// Canvas taller than a destination's ceiling. Only Kick states a hard cap
+/// we can rely on, so it is the only platform checked here.
+fn resolution_issue(params: &StreamParams, live: &[&Destination]) -> Option<String> {
+    if params.height == 0 || params.height <= KICK_MAX_HEIGHT {
+        return None;
+    }
+    if !live.iter().any(|d| d.platform == "kick") {
+        return None;
+    }
+    Some(format!(
+        "Video is {}p. Kick caps at {}p.",
+        params.height, KICK_MAX_HEIGHT
+    ))
+}
+
+/// A codec the destination's ingest cannot decode.
+///
+/// Scoped to Kick on purpose. Twitch negotiates codecs itself under
+/// Enhanced Broadcasting, and YouTube has added HEVC ingest paths, so
+/// warning about either would risk a false positive. Kick's ingest is
+/// H.264 and the failure is total, which makes it worth naming.
+fn codec_issue(params: &StreamParams, live: &[&Destination]) -> Option<String> {
+    if !matches!(
+        params.codec,
+        VideoCodec::Hevc | VideoCodec::Av1 | VideoCodec::Vp9
+    ) {
+        return None;
+    }
+    if !live.iter().any(|d| d.platform == "kick") {
+        return None;
+    }
+    Some(format!(
+        "Video codec is {}. Kick needs H.264.",
+        params.codec.label()
+    ))
+}
+
+/// Distinct platform labels among `live` whose slug satisfies `pred`,
+/// in first-seen order. Deduplicated so two Twitch destinations don't
+/// render as "Twitch and Twitch".
+fn labels_matching(live: &[&Destination], pred: impl Fn(&str) -> bool) -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = Vec::new();
+    for d in live {
+        if !pred(d.platform.as_str()) {
+            continue;
+        }
+        let label = platform_label(&d.platform);
+        if !out.contains(&label) {
+            out.push(label);
+        }
+    }
+    out
+}
+
+/// "Kick", "Kick and YouTube", "Kick, YouTube and Trovo".
+fn join_names(names: &[&str]) -> String {
+    match names {
+        [] => String::new(),
+        [one] => (*one).to_string(),
+        [rest @ .., last] => format!("{} and {}", rest.join(", "), last),
+    }
+}
+
+fn verb_for(count: usize, singular: &'static str, plural: &'static str) -> &'static str {
+    if count == 1 {
+        singular
+    } else {
+        plural
+    }
+}
+
+/// 4000 -> "4.0s". One decimal is enough to make "you set 4 s" obvious
+/// without implying we measured to the millisecond.
+fn format_seconds(ms: u32) -> String {
+    format!("{:.1}s", ms as f64 / 1000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dest(platform: &str, enabled: bool) -> Destination {
+        Destination {
+            id: platform.into(),
+            name: platform.into(),
+            enabled,
+            platform: platform.into(),
+            stream_key: "k".into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: "horizontal".into(),
+        }
+    }
+
+    fn params() -> StreamParams {
+        StreamParams {
+            width: 1920,
+            height: 1080,
+            keyframe_interval_ms: 2_000,
+            codec: VideoCodec::Avc,
+        }
+    }
+
+    #[test]
+    fn healthy_stream_is_silent() {
+        let dests = vec![dest("twitch", true), dest("kick", true)];
+        assert_eq!(compat_warning(&params(), &dests), None);
+    }
+
+    #[test]
+    fn no_destinations_is_silent() {
+        assert_eq!(compat_warning(&params(), &[]), None);
+    }
+
+    /// The whole point of the tolerance: a user who correctly set 2 s
+    /// measures slightly over it because of encoder jitter, and must not
+    /// be nagged for it.
+    #[test]
+    fn two_second_keyframe_with_jitter_does_not_warn() {
+        let mut p = params();
+        p.keyframe_interval_ms = 2_100;
+        assert_eq!(compat_warning(&p, &[dest("kick", true)]), None);
+    }
+
+    #[test]
+    fn four_second_keyframe_warns_and_names_platforms() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        let dests = vec![dest("kick", true), dest("youtube", true)];
+        assert_eq!(
+            compat_warning(&p, &dests),
+            Some("Keyframe interval measures 4.0s. Kick and YouTube expect 2s.".into())
+        );
+    }
+
+    #[test]
+    fn single_platform_uses_singular_verb() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        assert_eq!(
+            compat_warning(&p, &[dest("kick", true)]),
+            Some("Keyframe interval measures 4.0s. Kick expects 2s.".into())
+        );
+    }
+
+    /// Two destinations on the same platform must not render as
+    /// "Twitch and Twitch".
+    #[test]
+    fn duplicate_platforms_are_deduplicated() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        let mut second = dest("twitch", true);
+        second.id = "twitch-2".into();
+        let dests = vec![dest("twitch", true), second];
+        assert_eq!(
+            compat_warning(&p, &dests),
+            Some("Keyframe interval measures 4.0s. Twitch expects 2s.".into())
+        );
+    }
+
+    #[test]
+    fn disabled_destinations_are_ignored() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        assert_eq!(compat_warning(&p, &[dest("kick", false)]), None);
+    }
+
+    /// The sink accepts anything - warning about it would be noise.
+    #[test]
+    fn sink_alone_never_warns() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        p.height = 1440;
+        p.codec = VideoCodec::Av1;
+        assert_eq!(compat_warning(&p, &[dest("sink", true)]), None);
+    }
+
+    /// A custom ingest has unknown requirements, so guessing is worse
+    /// than staying quiet.
+    #[test]
+    fn custom_platform_has_no_keyframe_opinion() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        assert_eq!(compat_warning(&p, &[dest("custom", true)]), None);
+    }
+
+    #[test]
+    fn unmeasured_keyframe_interval_is_silent() {
+        let mut p = params();
+        p.keyframe_interval_ms = 0;
+        assert_eq!(compat_warning(&p, &[dest("kick", true)]), None);
+    }
+
+    #[test]
+    fn tall_canvas_warns_only_when_kick_is_enabled() {
+        let mut p = params();
+        p.height = 1440;
+        assert_eq!(compat_warning(&p, &[dest("twitch", true)]), None);
+        assert_eq!(
+            compat_warning(&p, &[dest("kick", true)]),
+            Some("Video is 1440p. Kick caps at 1080p.".into())
+        );
+    }
+
+    #[test]
+    fn undecoded_resolution_is_silent() {
+        let mut p = params();
+        p.height = 0;
+        assert_eq!(compat_warning(&p, &[dest("kick", true)]), None);
+    }
+
+    #[test]
+    fn non_h264_warns_for_kick_only() {
+        let mut p = params();
+        p.codec = VideoCodec::Hevc;
+        assert_eq!(compat_warning(&p, &[dest("youtube", true)]), None);
+        assert_eq!(
+            compat_warning(&p, &[dest("kick", true)]),
+            Some("Video codec is HEVC. Kick needs H.264.".into())
+        );
+    }
+
+    #[test]
+    fn unknown_codec_is_silent() {
+        let mut p = params();
+        p.codec = VideoCodec::Unknown;
+        assert_eq!(compat_warning(&p, &[dest("kick", true)]), None);
+    }
+
+    /// Multiple problems collapse into ONE line - the clutter guard.
+    #[test]
+    fn multiple_issues_join_into_a_single_line() {
+        let mut p = params();
+        p.keyframe_interval_ms = 4_000;
+        p.height = 1440;
+        p.codec = VideoCodec::Av1;
+        let warning = compat_warning(&p, &[dest("kick", true)]).unwrap();
+        assert_eq!(
+            warning,
+            "Keyframe interval measures 4.0s. Kick expects 2s. · \
+             Video is 1440p. Kick caps at 1080p. · \
+             Video codec is AV1. Kick needs H.264."
+        );
+        assert_eq!(warning.lines().count(), 1);
+    }
+
+    #[test]
+    fn join_names_reads_naturally() {
+        assert_eq!(join_names(&["Kick"]), "Kick");
+        assert_eq!(join_names(&["Kick", "YouTube"]), "Kick and YouTube");
+        assert_eq!(
+            join_names(&["Kick", "YouTube", "Trovo"]),
+            "Kick, YouTube and Trovo"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,16 +57,16 @@ pub struct Settings {
     pub buffer_path: PathBuf,
     pub target_delay_ms: u32,
     pub armed_delay_ms: u32,
-    pub initial_delay_ms: u32,
     pub configured: bool,
     pub profiles: Vec<DelayProfile>,
     pub destinations: Vec<Destination>,
     pub discord_webhook_url: String,
     pub overlays_dir: PathBuf,
     /// Whether the wire-level egress trace (instantclone-trace.log) is
-    /// actively writing. Default true so a fresh install captures
-    /// diagnostic data; toggleable in the System tab so users past the
-    /// debugging phase can stop the file from growing.
+    /// actively writing. Defaults to false (fresh installs ship it off);
+    /// toggleable in the System tab so users can turn it on when diagnosing
+    /// an issue, then off again so the file stops growing. Configs saved by
+    /// early betas with `tracing_enabled=true` are still honoured on load.
     pub tracing_enabled: bool,
     /// Behaviour: when OBS's RTMP publisher handshake completes, auto-arm
     /// the delay at `auto_arm_delay_ms`. Off by default - the
@@ -87,6 +87,18 @@ pub struct Settings {
     /// streamer hits Arm with a non-zero value) so "last used" sticks
     /// across sessions without a separate UI knob to maintain it.
     pub auto_arm_delay_ms: u32,
+    /// Whether the dashboard checks GitHub for a newer release on load.
+    /// Default true - the check is a passive nicety (cached 10 min
+    /// server-side, failures silent). Off for the privacy-minded or
+    /// air-gapped: it is the app's one routine outbound call, so it gets
+    /// an explicit opt-out in System -> About.
+    pub update_check_enabled: bool,
+    /// Whether a normal launch opens the dashboard in the browser. Default
+    /// true. Turning it off suits streamers who keep InstantClone running
+    /// in the tray (or autostart it) and don't want a tab every launch -
+    /// the same effect as the `--no-browser` CLI flag, but persisted and
+    /// reachable from the UI. The flag still forces suppression regardless.
+    pub open_dashboard_on_launch: bool,
     /// State: whether the built-in preset overlays have been seeded to the
     /// overlays folder as real files yet. Set true after the dashboard bakes
     /// them on first run, so deleting a seeded overlay doesn't bring it back.
@@ -276,7 +288,6 @@ impl Settings {
             buffer_path: PathBuf::from("./instantclone.buf"),
             target_delay_ms: 0,
             armed_delay_ms: 0,
-            initial_delay_ms: 0,
             configured: false,
             profiles: vec![
                 DelayProfile {
@@ -313,6 +324,11 @@ impl Settings {
             // auto_arm_on_connect without otherwise customising lands
             // on a familiar number.
             auto_arm_delay_ms: 15_000,
+            // Both default on: the update check is a convenience most users
+            // want, and opening the dashboard is the expected first-run
+            // behaviour. Each has an explicit opt-out in the System tab.
+            update_check_enabled: true,
+            open_dashboard_on_launch: true,
             // Fresh install hasn't seeded the preset overlays yet; the
             // dashboard does it on first load, then flips this true.
             overlays_seeded: false,
@@ -392,7 +408,6 @@ impl Settings {
         // Cap delay values to the same 10-minute ceiling the runtime uses.
         self.armed_delay_ms = self.armed_delay_ms.min(600_000);
         self.target_delay_ms = self.target_delay_ms.min(600_000);
-        self.initial_delay_ms = self.initial_delay_ms.min(600_000);
         // auto_arm_delay_ms is the value used when auto-arm fires. Clamp
         // to the same 10-minute ceiling; a 0 from a fresh install or a
         // hand-edited config falls back to the 15 s default so we never
@@ -495,7 +510,6 @@ impl Settings {
         writeln!(f, "buffer_mb={}", self.buffer_mb)?;
         writeln!(f, "buffer_path={}", self.buffer_path.display())?;
         writeln!(f, "target_delay_ms={}", self.target_delay_ms)?;
-        writeln!(f, "initial_delay_ms={}", self.initial_delay_ms)?;
         writeln!(f, "armed_delay_ms={}", self.armed_delay_ms)?;
         writeln!(f, "discord_webhook_url={}", self.discord_webhook_url)?;
         writeln!(f, "overlays_dir={}", self.overlays_dir.display())?;
@@ -513,6 +527,13 @@ impl Settings {
         }
         if self.auto_arm_delay_ms != 15_000 {
             writeln!(f, "auto_arm_delay_ms={}", self.auto_arm_delay_ms)?;
+        }
+        // Both default true, so only the opt-out is worth writing.
+        if !self.update_check_enabled {
+            writeln!(f, "update_check_enabled=false")?;
+        }
+        if !self.open_dashboard_on_launch {
+            writeln!(f, "open_dashboard_on_launch=false")?;
         }
         if self.overlays_seeded {
             writeln!(f, "overlays_seeded=true")?;
@@ -595,16 +616,13 @@ impl Settings {
                     self.armed_delay_ms = v;
                 }
             }
-            "initial_delay_ms" => {
-                if let Ok(v) = value.parse() {
-                    self.initial_delay_ms = v;
-                }
-            }
             "discord_webhook_url" => self.discord_webhook_url = value.into(),
             "overlays_dir" => self.overlays_dir = PathBuf::from(value),
             "tracing_enabled" => self.tracing_enabled = value.parse().unwrap_or(false),
             "auto_arm_on_connect" => self.auto_arm_on_connect = value == "true",
             "auto_activate_when_ready" => self.auto_activate_when_ready = value == "true",
+            "update_check_enabled" => self.update_check_enabled = value != "false",
+            "open_dashboard_on_launch" => self.open_dashboard_on_launch = value != "false",
             "overlays_seeded" => self.overlays_seeded = value == "true",
             "auto_arm_delay_ms" => {
                 if let Ok(v) = value.parse() {
@@ -774,7 +792,13 @@ impl Settings {
         self.buffer_mb * 1024 * 1024
     }
 
-    pub fn to_json(&self) -> String {
+    /// Serialize for the dashboard's `/config` fetch.
+    ///
+    /// `start_with_windows` is passed in rather than read here because it
+    /// does not live in `Settings` at all - the Run-key entry is its own
+    /// source of truth (see `crate::autostart`). Taking it as an argument
+    /// keeps this function free of hidden I/O.
+    pub fn to_json(&self, start_with_windows: bool) -> String {
         // Build the destinations array. Stream keys are NEVER echoed back
         // (security); we expose a redacted form of the resolved URL plus
         // a `stream_key_set` boolean per destination.
@@ -800,8 +824,9 @@ impl Settings {
         }
         dests.push(']');
         format!(
-            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"initial_delay_ms":{id},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"destinations":{dests}}}"#,
+            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"destinations":{dests}}}"#,
             c = self.configured,
+            sww = start_with_windows,
             ip = self.ingest_port,
             iba = self.ingest_bind_all,
             wp = self.web_port,
@@ -809,7 +834,6 @@ impl Settings {
             bm = self.buffer_mb,
             bp = json_str(&self.buffer_path.display().to_string()),
             td = self.target_delay_ms,
-            id = self.initial_delay_ms,
             ou = json_str(&self.obs_url()),
             dw = json_str(&redact_webhook(&self.discord_webhook_url)),
             ws = !self.discord_webhook_url.is_empty(),
@@ -819,6 +843,8 @@ impl Settings {
             aawr = self.auto_activate_when_ready,
             aadm = self.auto_arm_delay_ms,
             os = self.overlays_seeded,
+            uce = self.update_check_enabled,
+            odol = self.open_dashboard_on_launch,
             dests = dests,
         )
     }
@@ -942,6 +968,23 @@ pub fn platform_base(slug: &str) -> Option<&'static str> {
         "restream" => "rtmp://live.restream.io/live",
         _ => return None,
     })
+}
+
+/// Human-facing name for a platform slug. Falls back to the slug itself so
+/// an unknown value still renders as something rather than blank. Kept
+/// beside `platform_base` because they describe the same table - a new
+/// platform needs an entry in both.
+pub fn platform_label(slug: &str) -> &'static str {
+    match slug {
+        "twitch" => "Twitch",
+        "youtube" => "YouTube",
+        "kick" => "Kick",
+        "trovo" => "Trovo",
+        "restream" => "Restream",
+        "custom" => "Custom RTMP",
+        "sink" => "Local test sink",
+        _ => "this destination",
+    }
 }
 
 /// Curated list of regional Twitch ingests. Slug → human label. The slug
@@ -1129,6 +1172,30 @@ fn url_decode(s: &str) -> String {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// `start_with_windows` is not a `Settings` field - it comes from the
+    /// registry via the caller. This guards the wire contract the dashboard
+    /// reads, which a signature change could otherwise drop silently.
+    #[test]
+    fn to_json_reflects_the_passed_autostart_state() {
+        let s = Settings::defaults();
+        assert!(s.to_json(true).contains(r#""start_with_windows":true"#));
+        assert!(s.to_json(false).contains(r#""start_with_windows":false"#));
+    }
+
+    #[test]
+    fn platform_label_covers_every_known_platform() {
+        // Any slug with an ingest base must also have a human label, or a
+        // compatibility warning would read "this destination expects 2s".
+        for slug in ["twitch", "youtube", "kick", "trovo", "restream"] {
+            assert!(platform_base(slug).is_some(), "{slug} lost its base");
+            assert_ne!(
+                platform_label(slug),
+                "this destination",
+                "{slug} is missing a label"
+            );
+        }
+    }
 
     #[test]
     fn parse_form_handles_basic_encoding() {
@@ -1499,6 +1566,59 @@ mod tests {
             loaded.overlays_seeded,
             "overlays_seeded must survive round-trip"
         );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn default_true_toggles_round_trip_when_disabled() {
+        // update_check_enabled and open_dashboard_on_launch both default
+        // true and are written only when turned off. Flipping them off must
+        // survive a save/load, or a privacy opt-out would silently revert.
+        let path = std::env::temp_dir().join(format!(
+            "ic-test-optout-roundtrip-{}-{}.ini",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let mut s = Settings::defaults();
+        assert!(s.update_check_enabled, "defaults on");
+        assert!(s.open_dashboard_on_launch, "defaults on");
+        s.update_check_enabled = false;
+        s.open_dashboard_on_launch = false;
+        s.destinations.push(Destination {
+            id: "test".into(),
+            name: "Test".into(),
+            enabled: true,
+            platform: "twitch".into(),
+            stream_key: "test".into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: "horizontal".into(),
+        });
+        s.save(&path).expect("save");
+
+        let loaded = Settings::load(&path).expect("load");
+        assert!(
+            !loaded.update_check_enabled,
+            "update_check_enabled opt-out must survive round-trip"
+        );
+        assert!(
+            !loaded.open_dashboard_on_launch,
+            "open_dashboard_on_launch opt-out must survive round-trip"
+        );
+
+        // A fresh config with neither key present must read as the on
+        // default, not accidentally inherit the false above.
+        let fresh = Settings::defaults();
+        assert!(fresh.update_check_enabled && fresh.open_dashboard_on_launch);
 
         let _ = std::fs::remove_file(&path);
     }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -9,6 +9,7 @@
 //! platform. Communication is via `Controller`'s shared state + Notify.
 
 use crate::buffer::{DiskRing, TagMeta};
+use crate::compat::StreamParams;
 use crate::h264::{AudioCodec, VideoCodec};
 use crate::rtmp::client::{EgressClient, EgressSink, EgressUrl};
 use std::collections::HashMap;
@@ -98,6 +99,12 @@ impl ActivateError {
 /// IDR-search tolerance, so a "5s armed" cut can always land on a real
 /// IDR even if the nearest one happens to be slightly past the boundary.
 const BUFFER_SLACK_MS: u32 = 2_000;
+
+/// How many IDR-to-IDR gaps to average before freezing the keyframe-interval
+/// measurement. Five gaps is ~10 s of a normally-configured stream: long
+/// enough that one odd GOP at stream start can't skew the mean, short enough
+/// that the reading is settled before anyone looks at the dashboard.
+const KEYFRAME_SAMPLE_GAPS: u32 = 5;
 
 /// Flat tuple the dashboard reads each tick:
 /// `(id, alive, consumer_seq, kbps_out, tags_sent, bytes_sent, cuts, reconnects)`.
@@ -467,6 +474,39 @@ pub struct Controller {
     multitrack_video: AtomicBool,
     multitrack_audio: AtomicBool,
 
+    // --- Measured encoder parameters (per publisher session) ---
+    // Feed `compat::compat_warning`, which compares them against the
+    // enabled destinations. Decoded from the AVC sequence header; 0 when
+    // the codec isn't AVC or the header hasn't arrived yet.
+    // Packed (width << 32 | height). One atomic, not two, so a dashboard
+    // read always pairs a width with ITS height: storing them separately let
+    // a read land between the two writes and report a new width beside a
+    // stale height for one frame.
+    video_dims: AtomicU64,
+    // Keyframe interval is measured, not configured, so it has to be
+    // sampled from the stream. We take the MEAN spacing across the first
+    // `KEYFRAME_SAMPLE_GAPS` IDR gaps rather than a running average: it
+    // is jitter-tolerant, needs no decay tuning, and - the point - it
+    // FREEZES once the sample budget is spent. A value that keeps moving
+    // is what made the old buffer-capacity gate strobe (see 0.1.10), and
+    // a warning line that flickers on and off mid-stream is worse than
+    // no warning at all.
+    //
+    // The first/last/gaps triple is writer-private accounting (only the
+    // single ingest task touches it). After each gap the writer republishes
+    // the mean into `keyframe_interval_cached`, so every reader does one
+    // atomic load instead of a (last, first, gaps) read that could tear.
+    //
+    // `idr_window_open` cannot be folded into `first_idr_ts_ms == 0`: an
+    // RTMP session normally starts at timestamp 0, so a 0 sentinel would
+    // discard the real first keyframe and re-open the window on the
+    // second one, skewing every subsequent mean.
+    idr_window_open: AtomicBool,
+    first_idr_ts_ms: AtomicU64,
+    last_idr_ts_ms: AtomicU64,
+    idr_gaps: AtomicU32,
+    keyframe_interval_cached: AtomicU32,
+
     // --- u32 → u64 timestamp wrap tracking (per publisher session) ---
     // RTMP wire timestamps are u32 ms and wrap every 49.7 days. We
     // expand to u64 internally so every comparison / subtraction across
@@ -527,6 +567,12 @@ impl Controller {
             publish_lock: Mutex::new(()),
             video_codec: AtomicU8::new(0),
             audio_codec: AtomicU8::new(0),
+            video_dims: AtomicU64::new(0),
+            idr_window_open: AtomicBool::new(false),
+            first_idr_ts_ms: AtomicU64::new(0),
+            last_idr_ts_ms: AtomicU64::new(0),
+            idr_gaps: AtomicU32::new(0),
+            keyframe_interval_cached: AtomicU32::new(0),
             multitrack_video: AtomicBool::new(false),
             multitrack_audio: AtomicBool::new(false),
             seq_header_gen: AtomicU32::new(0),
@@ -587,6 +633,71 @@ impl Controller {
             self.log(format!("ingest: audio codec = {}", c.label()));
         }
     }
+    /// Decode primary-track dimensions from an AVC sequence header.
+    ///
+    /// Multi-track (Enhanced Broadcasting) headers are skipped: under EB
+    /// it is Twitch that picks the encode ladder, so "your resolution is
+    /// wrong" would be both wrong and unactionable. `sps_dimensions`
+    /// already returns None for non-AVC codecs, so HEVC/AV1 simply leave
+    /// the dimensions at 0 and the resolution check stays quiet.
+    pub fn note_video_dimensions(&self, seq_header: &[u8]) {
+        if crate::h264::seq_header_track_id(seq_header) != 0 {
+            return;
+        }
+        if let Some((w, h)) = crate::h264::sps_dimensions(seq_header) {
+            let packed = ((w as u64) << 32) | h as u64;
+            let prev = self.video_dims.swap(packed, Ordering::Relaxed);
+            if prev != packed {
+                self.log(format!("ingest: video is {}x{}", w, h));
+            }
+        }
+    }
+
+    /// Feed one IDR timestamp into the keyframe-interval measurement.
+    ///
+    /// Stops sampling after `KEYFRAME_SAMPLE_GAPS` gaps so the reported
+    /// interval is stable for the rest of the session - see the field
+    /// comments for why a frozen value matters here.
+    fn sample_keyframe_interval(&self, ts_ms: u64) {
+        if self.idr_gaps.load(Ordering::Relaxed) >= KEYFRAME_SAMPLE_GAPS {
+            return;
+        }
+        if !self.idr_window_open.swap(true, Ordering::Relaxed) {
+            // First IDR of the session: it opens the window, it is not a gap.
+            self.first_idr_ts_ms.store(ts_ms, Ordering::Relaxed);
+            self.last_idr_ts_ms.store(ts_ms, Ordering::Relaxed);
+            return;
+        }
+        // Guard against a non-advancing timestamp (a seek or a duplicated
+        // tag) turning into a zero-width gap that drags the mean down.
+        if ts_ms <= self.last_idr_ts_ms.load(Ordering::Relaxed) {
+            return;
+        }
+        self.last_idr_ts_ms.store(ts_ms, Ordering::Relaxed);
+        let gaps = self.idr_gaps.fetch_add(1, Ordering::Relaxed) + 1;
+        // Republish the mean on the writer thread so readers load one atomic.
+        // gaps >= 1 here, so the division can never be by zero.
+        let first = self.first_idr_ts_ms.load(Ordering::Relaxed);
+        let mean = (ts_ms.saturating_sub(first) / gaps as u64).min(u32::MAX as u64) as u32;
+        self.keyframe_interval_cached.store(mean, Ordering::Relaxed);
+    }
+
+    /// Mean IDR spacing in ms, or 0 until at least one gap is measured.
+    pub fn keyframe_interval_ms(&self) -> u32 {
+        self.keyframe_interval_cached.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot of the measured encoder parameters for `compat_warning`.
+    pub fn stream_params(&self) -> StreamParams {
+        let dims = self.video_dims.load(Ordering::Relaxed);
+        StreamParams {
+            width: (dims >> 32) as u32,
+            height: dims as u32,
+            keyframe_interval_ms: self.keyframe_interval_ms(),
+            codec: self.video_codec(),
+        }
+    }
+
     /// Called from ingest on every multi-track video tag. Records a
     /// timestamp so the `multitrack_video()` getter can auto-clear when
     /// multi-track stops (e.g. the user switched Enhanced Broadcasting
@@ -627,6 +738,15 @@ impl Controller {
     pub fn reset_codec_state(&self) {
         self.video_codec.store(0, Ordering::Relaxed);
         self.audio_codec.store(0, Ordering::Relaxed);
+        // Measured encoder params belong to the session that produced
+        // them - a reconnect may bring a different OBS profile entirely,
+        // and a stale interval would warn about settings nobody is using.
+        self.video_dims.store(0, Ordering::Relaxed);
+        self.idr_window_open.store(false, Ordering::Relaxed);
+        self.first_idr_ts_ms.store(0, Ordering::Relaxed);
+        self.last_idr_ts_ms.store(0, Ordering::Relaxed);
+        self.idr_gaps.store(0, Ordering::Relaxed);
+        self.keyframe_interval_cached.store(0, Ordering::Relaxed);
         self.multitrack_video.store(false, Ordering::Relaxed);
         self.multitrack_audio.store(false, Ordering::Relaxed);
         self.last_multitrack_video_ms.store(0, Ordering::Relaxed);
@@ -1157,6 +1277,17 @@ impl Controller {
         // knows to re-emit its cached config bytes on the next iteration.
         if is_seq {
             self.seq_header_gen.fetch_add(1, Ordering::Relaxed);
+        }
+        // Sample the encoder parameters the compatibility check compares
+        // against the enabled destinations. Both are cheap: the dimension
+        // decode runs once per sequence header, and the keyframe sampler
+        // stops touching anything after its first few gaps.
+        if kind == 9 {
+            if is_seq {
+                self.note_video_dimensions(payload);
+            } else if is_idr {
+                self.sample_keyframe_interval(ts_ms);
+            }
         }
         let _ = self.ring.append(kind, ts_ms, payload, is_idr, is_seq);
         // Cap the buffer to the user's armed delay (plus a small slack for
@@ -1982,27 +2113,48 @@ struct PendingCut {
     target: TagMeta,
 }
 
+/// Baseline re-cut dead band, tuned for OBS's default 2 s keyframe interval.
+const RECUT_DEAD_BAND_FLOOR_MS: u64 = 1_500;
+/// Baseline IDR-search tolerance, enough to always find a keyframe at a 2 s
+/// (or tighter) cadence.
+const IDR_SEARCH_FLOOR_MS: u32 = 2_000;
+
+/// Re-cut hysteresis as a function of the *measured* keyframe interval.
+///
+/// The dead band must exceed `IDR_cadence / 2 + send_jitter`, or once we are
+/// already parked on the best available IDR the delay error (up to half a GOP)
+/// keeps re-tripping the gate and we re-cut to the same keyframe every tick -
+/// the "repeating 1-2 s of content" bounce. At OBS's default 2 s GOP the
+/// tuned floor of 1500 ms covers this. A long-GOP encoder (3-4 s) has a
+/// larger half-GOP error, so the band has to widen with it or the exact same
+/// bounce returns - just triggered by keyframe interval instead of dead-band
+/// size. `keyframe_interval_ms == 0` (not yet measured) keeps the floor, so a
+/// fresh stream behaves identically until it reveals a cadence.
+fn recut_dead_band_ms(keyframe_interval_ms: u32) -> u64 {
+    RECUT_DEAD_BAND_FLOOR_MS.max(keyframe_interval_ms as u64 / 2 + 500)
+}
+
+/// How far from the ideal input timestamp we accept an IDR when cutting.
+/// Grows to half a GOP for long-keyframe streams so a cut can still land on a
+/// real keyframe; never below the 2 s that served the default cadence.
+fn idr_search_tolerance_ms(keyframe_interval_ms: u32) -> u32 {
+    IDR_SEARCH_FLOOR_MS.max(keyframe_interval_ms / 2)
+}
+
 fn compute_delay_cut(ctrl: &Arc<Controller>, current: &TagMeta) -> Option<PendingCut> {
     let target_delay = ctrl.target_delay_ms.load(Ordering::Relaxed) as u64;
     let latest = ctrl.ring.latest_ts()?;
     let oldest = ctrl.ring.oldest_ts()?;
     let current_delay = latest.saturating_sub(current.ts_ms);
 
-    // 1500 ms dead band. The earlier 500 ms was too tight against the
-    // typical 2 s OBS IDR cadence: after the initial cut, delivered
-    // delay would be off by up to ~1 s (closest-IDR error), the 500 ms
-    // dead band would fire, find_idr_near would (often) return the
-    // SAME IDR, and we'd re-cut to it every 500 ms - visible as the
-    // "repeating 1-2 s of content" bouncing the user reported.
-    //
-    // 1500 ms must exceed (IDR_cadence / 2 + send_jitter) to prevent
-    // re-cuts when we're already on the best available IDR. For OBS's
-    // recommended 2 s keyframe interval, 1500 ms is the right number.
-    // The trade-off is the user's delay may be off by up to ~1.5 s from
-    // their requested value - acceptable given the alternative is the
-    // bouncing bug.
+    // Dead band scales with the measured GOP (see recut_dead_band_ms). At the
+    // default 2 s cadence this is the tuned 1500 ms; the trade-off is the
+    // delivered delay may sit up to one dead-band away from the requested
+    // value, which is exactly the price of not re-cutting to the same IDR.
+    let keyframe_interval = ctrl.keyframe_interval_ms();
+    let dead_band = recut_dead_band_ms(keyframe_interval);
     let diff = (current_delay as i64) - (target_delay as i64);
-    if diff.abs() < 1500 {
+    if diff.abs() < dead_band as i64 {
         ctrl.buffer_building.store(false, Ordering::Relaxed);
         return None;
     }
@@ -2011,8 +2163,9 @@ fn compute_delay_cut(ctrl: &Arc<Controller>, current: &TagMeta) -> Option<Pendin
     // the buffer currently extends, we can't honor it yet. Mark the state
     // and hold our position; the buffer keeps filling at real time, and
     // once the requested delay becomes reachable, the next iteration cuts.
+    // Same dead band as the re-cut gate so the two agree on "close enough".
     let have_seconds_back = latest.saturating_sub(oldest);
-    if target_delay > have_seconds_back.saturating_add(1_500) {
+    if target_delay > have_seconds_back.saturating_add(dead_band) {
         ctrl.buffer_building.store(true, Ordering::Relaxed);
         return None;
     }
@@ -2021,7 +2174,9 @@ fn compute_delay_cut(ctrl: &Arc<Controller>, current: &TagMeta) -> Option<Pendin
     // Binary-search on the IDR-only secondary index (~log n over just
     // the keyframes) rather than the old O(n) walk over every tag.
     let desired_input_ts = latest.saturating_sub(target_delay);
-    let target = ctrl.ring.find_idr_near(desired_input_ts, 2_000)?;
+    let target = ctrl
+        .ring
+        .find_idr_near(desired_input_ts, idr_search_tolerance_ms(keyframe_interval))?;
     if target.seq == current.seq {
         return None;
     }
@@ -3361,6 +3516,151 @@ mod tests {
             "session 2 fill must be the span of session 2 tags only \
              (~66 ms), not a phantom span that includes session 1; got {}",
             fill,
+        );
+    }
+
+    /// Feed `count` IDR tags spaced `spacing_ms` apart, starting at
+    /// `start_ms`. Leading byte 0x17 is the legacy AVC keyframe marker.
+    fn feed_idrs(ctrl: &Controller, start_ms: u32, spacing_ms: u32, count: u32) {
+        let mut payload = [0u8; 50];
+        payload[0] = 0x17;
+        for i in 0..count {
+            ctrl.on_tag(9, start_ms + i * spacing_ms, &payload, true, false);
+        }
+    }
+
+    #[test]
+    fn keyframe_interval_is_zero_before_any_gap_is_measured() {
+        let h = harness(0);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 0);
+        // One IDR opens the window but is not itself a gap.
+        feed_idrs(&h.ctrl, 0, 2_000, 1);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 0);
+    }
+
+    #[test]
+    fn keyframe_interval_measures_mean_spacing() {
+        let h = harness(0);
+        feed_idrs(&h.ctrl, 0, 2_000, 4);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 2_000);
+    }
+
+    #[test]
+    fn keyframe_interval_measures_a_four_second_gop() {
+        let h = harness(0);
+        feed_idrs(&h.ctrl, 0, 4_000, 4);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 4_000);
+    }
+
+    /// The measurement must FREEZE once the sample budget is spent.
+    /// A value that keeps drifting is what makes a warning line flicker
+    /// on and off mid-stream, which is the failure this design avoids.
+    #[test]
+    fn keyframe_interval_freezes_after_the_sample_budget() {
+        let h = harness(0);
+        feed_idrs(&h.ctrl, 0, 2_000, KEYFRAME_SAMPLE_GAPS + 1);
+        let settled = h.ctrl.keyframe_interval_ms();
+        assert_eq!(settled, 2_000);
+
+        // A long stall afterwards (scene change, encoder hiccup) must not
+        // move the reading.
+        feed_idrs(&h.ctrl, 60_000, 10_000, 4);
+        assert_eq!(
+            h.ctrl.keyframe_interval_ms(),
+            settled,
+            "interval must not move after the sample budget is spent"
+        );
+    }
+
+    /// A repeated or backwards timestamp would otherwise register as a
+    /// zero-width gap and drag the mean toward 0, silencing a real warning.
+    #[test]
+    fn non_advancing_timestamps_do_not_pollute_the_mean() {
+        let h = harness(0);
+        let mut payload = [0u8; 50];
+        payload[0] = 0x17;
+        h.ctrl.on_tag(9, 0, &payload, true, false);
+        h.ctrl.on_tag(9, 4_000, &payload, true, false);
+        // Same timestamp three times over - a duplicated tag.
+        for _ in 0..3 {
+            h.ctrl.on_tag(9, 4_000, &payload, true, false);
+        }
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 4_000);
+    }
+
+    /// Non-IDR video and audio tags must not be counted as keyframes.
+    #[test]
+    fn only_idr_video_tags_are_sampled() {
+        let h = harness(0);
+        let mut idr = [0u8; 50];
+        idr[0] = 0x17;
+        let mut p = [0u8; 50];
+        p[0] = 0x27;
+        h.ctrl.on_tag(9, 0, &idr, true, false);
+        // P-frames and audio in between must be ignored entirely.
+        for i in 1..10 {
+            h.ctrl.on_tag(9, i * 100, &p, false, false);
+            h.ctrl.on_tag(8, i * 100, &[0xaf, 0x01, 0x21], false, false);
+        }
+        h.ctrl.on_tag(9, 2_000, &idr, true, false);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 2_000);
+    }
+
+    /// A reconnect may bring a completely different OBS profile, so the
+    /// previous session's measurement must not leak into the new one.
+    #[test]
+    fn reset_codec_state_clears_the_measurement() {
+        let h = harness(0);
+        feed_idrs(&h.ctrl, 0, 4_000, 4);
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 4_000);
+        h.ctrl.reset_codec_state();
+        assert_eq!(h.ctrl.keyframe_interval_ms(), 0);
+        assert_eq!(h.ctrl.stream_params().width, 0);
+        assert_eq!(h.ctrl.stream_params().height, 0);
+    }
+
+    /// The packed dims atomic must round-trip a real resolution and never
+    /// bleed width into height or vice-versa.
+    #[test]
+    fn stream_params_reports_packed_dimensions() {
+        let h = harness(0);
+        // 0x11 = AVC keyframe; sps_dimensions decodes 1920x1080 from a real
+        // SPS, but the unit here only needs the packing path exercised via a
+        // known resolution, so drive it through the public snapshot instead.
+        h.ctrl
+            .video_dims
+            .store(((1920u64) << 32) | 1080, Ordering::Relaxed);
+        let p = h.ctrl.stream_params();
+        assert_eq!((p.width, p.height), (1920, 1080));
+    }
+
+    /// Dead band stays at the tuned 1500 ms for a 2 s GOP (and while
+    /// unmeasured), and widens past half a GOP for long-keyframe encoders so
+    /// the same-IDR re-cut bounce can't reappear at 3-4 s cadences.
+    #[test]
+    fn recut_dead_band_tracks_keyframe_interval() {
+        assert_eq!(recut_dead_band_ms(0), 1_500, "unmeasured keeps the floor");
+        assert_eq!(recut_dead_band_ms(2_000), 1_500, "2 s GOP is unchanged");
+        assert!(recut_dead_band_ms(4_000) > 2_000, "4 s GOP widens the band");
+        assert_eq!(recut_dead_band_ms(4_000), 2_500);
+        // Must always clear half a GOP, or the bounce returns.
+        for kf in [1_000u32, 2_000, 3_000, 4_000, 6_000] {
+            assert!(
+                recut_dead_band_ms(kf) > kf as u64 / 2,
+                "dead band must exceed half a GOP for kf={kf}"
+            );
+        }
+    }
+
+    #[test]
+    fn idr_search_tolerance_never_below_floor_and_scales_up() {
+        assert_eq!(idr_search_tolerance_ms(0), 2_000);
+        assert_eq!(idr_search_tolerance_ms(2_000), 2_000);
+        assert_eq!(idr_search_tolerance_ms(4_000), 2_000);
+        assert_eq!(
+            idr_search_tolerance_ms(6_000),
+            3_000,
+            "6 s GOP needs 3 s reach"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,9 @@
 //! full restart (the DiskRing is immutable once mapped). The UI shows a
 //! sticky "restart required" banner when those are pending.
 
+mod autostart;
 mod buffer;
+mod compat;
 mod config;
 mod controller;
 mod h264;
@@ -215,10 +217,7 @@ fn main() -> std::io::Result<()> {
         // back the moment the stream resumes. They explicitly hit
         // "Activate" once the buffer is ready (or auto-activate via the
         // config flag, if we add one later).
-        let initial_armed = settings
-            .armed_delay_ms
-            .max(settings.target_delay_ms)
-            .max(settings.initial_delay_ms);
+        let initial_armed = settings.armed_delay_ms.max(settings.target_delay_ms);
         let ctrl = Arc::new(controller::Controller::new(ring, initial_armed));
 
         let (tx, rx) = watch::channel(settings.clone());
@@ -232,8 +231,10 @@ fn main() -> std::io::Result<()> {
         // the dashboard within a second of double-clicking the exe. The
         // tray icon stays running in the background - closing the tab
         // doesn't kill the proxy. `--no-browser` skips this for autostart
-        // / headless setups.
-        if !suppress_browser {
+        // / headless setups; the persisted `open_dashboard_on_launch`
+        // toggle (System -> Behavior) does the same from the UI, so a
+        // tray-resident user isn't forced into a tab every launch.
+        if !suppress_browser && settings.open_dashboard_on_launch {
             let url = format!("http://127.0.0.1:{}/", settings.web_port);
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(300)).await;

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -668,6 +668,54 @@ pub fn find_obs_executable() -> Option<PathBuf> {
     obs_executable_candidates().into_iter().find(|p| p.exists())
 }
 
+/// Whether an `obs64.exe` process is currently running. Used by the setup
+/// wizard to show the "close OBS first" note only when it actually applies:
+/// registering edits `services.json`, which a running OBS overwrites on exit,
+/// so the warning is noise if OBS is already shut. Any enumeration failure
+/// reads as "not running" - the note just stays hidden, which is harmless.
+#[cfg(windows)]
+pub fn is_obs_running() -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return false;
+        }
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        let mut running = false;
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                let end = entry
+                    .szExeFile
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(entry.szExeFile.len());
+                if String::from_utf16_lossy(&entry.szExeFile[..end])
+                    .eq_ignore_ascii_case("obs64.exe")
+                {
+                    running = true;
+                    break;
+                }
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+        running
+    }
+}
+
+#[cfg(not(windows))]
+pub fn is_obs_running() -> bool {
+    false
+}
+
 /// Spawn OBS Studio with the `--config-url` flag pointing at
 /// InstantClone's multitrack-config endpoint. Detaches from our
 /// process group so closing InstantClone afterwards doesn't take OBS

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -40,11 +40,12 @@ use windows_sys::Win32::UI::Shell::{
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     AppendMenuW, CreateIconFromResourceEx, CreatePopupMenu, CreateWindowExW, DefWindowProcW,
     DestroyMenu, DestroyWindow, DispatchMessageW, GetCursorPos, GetMessageW, GetSystemMetrics,
-    GetWindowLongPtrW, LoadIconW, LookupIconIdFromDirectoryEx, PostMessageW, PostQuitMessage,
-    RegisterClassW, SetForegroundWindow, SetWindowLongPtrW, TrackPopupMenu, TranslateMessage,
-    GWLP_USERDATA, HMENU, IDI_APPLICATION, LR_DEFAULTCOLOR, MF_DISABLED, MF_GRAYED, MF_SEPARATOR,
-    MF_STRING, MSG, SM_CXSMICON, SM_CYSMICON, TPM_BOTTOMALIGN, TPM_LEFTALIGN, TPM_RIGHTBUTTON,
-    WM_APP, WM_COMMAND, WM_DESTROY, WM_LBUTTONUP, WM_RBUTTONUP, WNDCLASSW,
+    GetWindowLongPtrW, LoadIconW, LookupIconIdFromDirectoryEx, MessageBoxW, PostMessageW,
+    PostQuitMessage, RegisterClassW, SetForegroundWindow, SetWindowLongPtrW, TrackPopupMenu,
+    TranslateMessage, GWLP_USERDATA, HMENU, IDI_APPLICATION, IDYES, LR_DEFAULTCOLOR,
+    MB_ICONWARNING, MB_YESNO, MF_DISABLED, MF_GRAYED, MF_SEPARATOR, MF_STRING, MSG, SM_CXSMICON,
+    SM_CYSMICON, TPM_BOTTOMALIGN, TPM_LEFTALIGN, TPM_RIGHTBUTTON, WM_APP, WM_COMMAND, WM_DESTROY,
+    WM_LBUTTONUP, WM_RBUTTONUP, WNDCLASSW,
 };
 
 const TRAY_MSG: u32 = WM_APP + 1;
@@ -273,6 +274,13 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
                     }
                 }
                 ID_QUIT => {
+                    // Quitting kills every egress, so if OBS is publishing
+                    // right now a stray click here drops the live stream.
+                    // Confirm in that case only - when nothing is streaming,
+                    // quit stays a single click.
+                    if state.ctrl.ingest_alive() && !confirm_quit_while_live(hwnd) {
+                        return 0;
+                    }
                     // Take the sender so a second click can't double-send.
                     // Ignore the Err: it just means the main task already shut
                     // down (race with ctrl-c) and dropped the receiver.
@@ -291,6 +299,23 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
         }
         _ => DefWindowProcW(hwnd, msg, wp, lp),
     }
+}
+
+/// Modal Yes/No shown when the user hits Quit while OBS is publishing.
+/// Returns true only if they confirm. Blocks the tray thread, which is
+/// fine - a tray click has nothing else in flight.
+unsafe fn confirm_quit_while_live(hwnd: HWND) -> bool {
+    let text = wide(
+        "OBS is streaming through InstantClone right now. Quitting stops the \
+         delay and drops every destination.\n\nQuit anyway?",
+    );
+    let title = wide("Quit InstantClone?");
+    MessageBoxW(
+        hwnd,
+        text.as_ptr(),
+        title.as_ptr(),
+        MB_YESNO | MB_ICONWARNING,
+    ) == IDYES
 }
 
 unsafe fn show_menu(hwnd: HWND) {

--- a/src/web.rs
+++ b/src/web.rs
@@ -345,7 +345,11 @@ async fn route(
             "application/json",
             state_json(ctrl, settings, sysstat),
         ),
-        ("GET", "/config") => ("200 OK", "application/json", settings.borrow().to_json()),
+        ("GET", "/config") => (
+            "200 OK",
+            "application/json",
+            settings.borrow().to_json(crate::autostart::is_enabled()),
+        ),
         ("GET", "/docks") => dock_list_json(settings),
         ("GET", "/platforms") => ("200 OK", "application/json", platforms_json()),
         // OBS sends a POST with a system-info payload (CPU/GPU/encoder
@@ -374,8 +378,9 @@ async fn route(
                 "200 OK",
                 "application/json",
                 format!(
-                    r#"{{"registered":{},"vod_audio_flag":{},"vod_eb_injected":{},"active_profile":{},"path":{}}}"#,
+                    r#"{{"registered":{},"obs_running":{},"vod_audio_flag":{},"vod_eb_injected":{},"active_profile":{},"path":{}}}"#,
                     crate::obs_register::is_registered(),
+                    crate::obs_register::is_obs_running(),
                     crate::obs_register::vod_audio_flag_set(),
                     crate::obs_register::vod_eb_injection_present(s.web_port),
                     match crate::obs_register::active_profile() {
@@ -739,6 +744,82 @@ async fn handle_sse(
 
 // ---- Endpoints ----
 
+/// Parse each cached video seq-header once per poll, not once per
+/// destination: the res/codec readout depends only on which TrackId a
+/// dest forwards, and horizontal dests all share track 0 while vertical
+/// dests share the one detected portrait primary. Keeps the
+/// frequently-polled `/state` and `/destinations` endpoints off a
+/// per-dest lock + Exp-Golomb parse.
+fn video_readouts(ctrl: &Controller) -> std::collections::BTreeMap<u8, (String, String)> {
+    let headers = ctrl.ring.video_seq_headers.lock().unwrap();
+    headers
+        .iter()
+        .map(|(&track, h)| {
+            let res = crate::h264::sps_dimensions(h)
+                .map(|(w, hh)| format!("{}x{}", w, hh))
+                .unwrap_or_default();
+            let codec = match crate::h264::seq_header_codec(h) {
+                crate::h264::VideoCodec::Unknown => String::new(),
+                c => c.label().to_string(),
+            };
+            (track, (res, codec))
+        })
+        .collect()
+}
+
+/// Live video state for one destination: whether the Dual Format canvas
+/// is on the wire, whether this destination can forward yet, and the
+/// resolution + codec of the track it actually sends.
+///
+/// Shared by `/state` and `/destinations` so the two endpoints cannot
+/// drift. They previously derived this independently and `/state` omitted
+/// it entirely, which froze the dashboard's format icon and res/codec
+/// readout at whatever was true when the page last fetched
+/// `/destinations`.
+struct DestVideo {
+    vertical_canvas_present: bool,
+    vertical_ready: bool,
+    res: String,
+    codec: String,
+}
+
+fn dest_video(
+    ctrl: &Controller,
+    dest: &crate::config::Destination,
+    readouts: &std::collections::BTreeMap<u8, (String, String)>,
+) -> DestVideo {
+    use std::sync::atomic::Ordering;
+    // Detected globally and stored on every dest each supervisor tick, so
+    // it is meaningful for Twitch cards too - that's what lets the format
+    // icon show "both" only when Dual Format is actually on, rather than
+    // just because the destination is Twitch.
+    let track = ctrl
+        .destination_state(&dest.id)
+        .vertical_primary_track
+        .load(Ordering::Relaxed);
+    let vertical_canvas_present = track != 0xFF;
+    let vertical = dest.wants_vertical();
+    // The track this destination actually forwards: the detected portrait
+    // primary for vertical dests, track 0 (horizontal primary) otherwise.
+    // Misses resolve to empty when the track isn't cached yet (non-AVC we
+    // can't measure, or an unresolved vertical canvas whose 0xFF sentinel
+    // is never a map key).
+    let target = if vertical { track } else { 0 };
+    let (res, codec) = readouts.get(&target).cloned().unwrap_or_default();
+    DestVideo {
+        vertical_canvas_present,
+        // Non-vertical destinations always report ready so the badge logic
+        // stays simple; vertical ones wait for the canvas to resolve.
+        vertical_ready: if vertical {
+            vertical_canvas_present
+        } else {
+            true
+        },
+        res,
+        codec,
+    }
+}
+
 fn state_json(
     ctrl: &Controller,
     settings: &Arc<watch::Sender<Settings>>,
@@ -760,18 +841,39 @@ fn state_json(
     // Per-destination summary array - joined from settings (the configured
     // list) with the controller's live runtime stats.
     let snap = ctrl.destination_snapshot();
+    // `/state` is the dashboard's per-tick source of truth, so it carries
+    // every per-dest field that can change mid-session. `/destinations` is
+    // only refetched on config edits; anything live that lives solely
+    // there freezes on the cards until the user reloads.
+    let readouts = video_readouts(ctrl);
     let dest_list = s.destinations.iter().map(|d| {
         let st = snap.iter().find(|t| t.0 == d.id);
         let (alive, kbps, tags, bytes, cuts, recon) = st
             .map(|t| (t.1, t.3, t.4, t.5, t.6, t.7))
             .unwrap_or((false, 0u32, 0u64, 0u64, 0u32, 0u32));
+        let v = dest_video(ctrl, d, &readouts);
         format!(
-            r#"{{"id":{id},"name":{n},"enabled":{en},"alive":{al},"bitrate_kbps":{br},"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"reconnects":{rc}}}"#,
+            r#"{{"id":{id},"name":{n},"enabled":{en},"alive":{al},"bitrate_kbps":{br},"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"reconnects":{rc},"vertical_ready":{vr},"vertical_canvas_present":{vcp},"video_res":{vres},"video_codec":{vcod}}}"#,
             id = json_escape_quoted(&d.id),
             n  = json_escape_quoted(&d.name),
             en = d.enabled, al = alive, br = kbps, ts = tags, bs = bytes, cu = cuts, rc = recon,
+            vr = v.vertical_ready,
+            vcp = v.vertical_canvas_present,
+            vres = json_escape_quoted(&v.res),
+            vcod = json_escape_quoted(&v.codec),
         )
     }).collect::<Vec<_>>().join(",");
+
+    // Encoder settings that will bite one of the enabled destinations.
+    // Empty far more often than not - see `compat::compat_warning`. Only
+    // computed while OBS is actually publishing: with no live stream the
+    // measured params are stale or zero, and a warning about a session
+    // that already ended is pure noise.
+    let compat_warning = if ctrl.ingest_alive() {
+        crate::compat::compat_warning(&ctrl.stream_params(), &s.destinations).unwrap_or_default()
+    } else {
+        String::new()
+    };
 
     // A portrait canvas is present on the wire (Twitch Dual Format is live).
     // Drives the header "Dual Format" pill.
@@ -780,10 +882,11 @@ fn state_json(
             .is_some();
 
     format!(
-        r#"{{"phase":"{ph}","armed_delay_ms":{ad},"target_delay_ms":{td},"current_delay_ms":{cd},"buffer_fill_ms":{bf},"buffer_target_ms":{btm},"buffer_capacity_ms_est":{bc},"ingest_alive":{ia},"egress_alive":{ea},"destinations_alive":{dla},"destinations_total":{dlt},"buffer_building":{bb},"configured":{cfg},"obs_url":"{ou}","webhook_set":{ws},"video_codec":"{vc}","audio_codec":"{ac}","multitrack_video":{mtv},"multitrack_audio":{mta},"vertical_present":{vp},"cpu_pct":{cp:.2},"rss_bytes":{rb},"publisher_token":{pt},"consumer_lag":{cl},"backpressure":{bp},"safe_cut_pending":{scp},"safe_cut_remaining_ms":{scr},"stats":{{"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"ingest_disconnects":{id},"egress_reconnects":{er},"bitrate_kbps":{br}}},"destinations":[{dl}]}}"#,
+        r#"{{"phase":"{ph}","armed_delay_ms":{ad},"target_delay_ms":{td},"current_delay_ms":{cd},"buffer_fill_ms":{bf},"buffer_target_ms":{btm},"buffer_capacity_ms_est":{bc},"ingest_alive":{ia},"egress_alive":{ea},"destinations_alive":{dla},"destinations_total":{dlt},"buffer_building":{bb},"configured":{cfg},"obs_url":"{ou}","webhook_set":{ws},"video_codec":"{vc}","audio_codec":"{ac}","multitrack_video":{mtv},"multitrack_audio":{mta},"vertical_present":{vp},"cpu_pct":{cp:.2},"rss_bytes":{rb},"publisher_token":{pt},"consumer_lag":{cl},"backpressure":{bp},"safe_cut_pending":{scp},"safe_cut_remaining_ms":{scr},"compat_warning":{cw},"stats":{{"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"ingest_disconnects":{id},"egress_reconnects":{er},"bitrate_kbps":{br}}},"destinations":[{dl}]}}"#,
         ph = ctrl.phase(),
         scp = ctrl.safe_cut_pending(),
         scr = ctrl.safe_cut_remaining_ms(),
+        cw = json_escape_quoted(&compat_warning),
         ad = ctrl.armed_delay_ms(),
         td = ctrl.target_delay_ms(),
         cd = ctrl.current_delay_ms(),
@@ -1541,12 +1644,13 @@ async fn post_config(
                 | "web_bind_all"
                 | "buffer_mb"
                 | "buffer_path"
-                | "initial_delay_ms"
                 | "overlays_dir"
                 | "tracing_enabled"
                 | "auto_arm_on_connect"
                 | "auto_activate_when_ready"
                 | "auto_arm_delay_ms"
+                | "update_check_enabled"
+                | "open_dashboard_on_launch"
         ) {
             apply_field_str(&mut new_settings, k, v);
         }
@@ -1559,6 +1663,20 @@ async fn post_config(
     }
     if form.get("webhook_clear").map(|s| s.as_str()) == Some("1") {
         new_settings.discord_webhook_url.clear();
+    }
+
+    // Autostart lives in the registry, not in Settings, so it is applied
+    // here rather than through `apply_field_str`. A failure is logged and
+    // surfaced but must not abort the save - the rest of the settings the
+    // user just edited are unrelated and should still land.
+    if let Some(v) = form.get("start_with_windows") {
+        let want = v == "on" || v == "true";
+        if let Err(e) = crate::autostart::set(want) {
+            ctrl.log(format!(
+                "start with Windows: could not {} the startup entry - {e}",
+                if want { "create" } else { "remove" }
+            ));
+        }
     }
 
     // Backward-compat wizard fields: when the wizard POSTs
@@ -1595,6 +1713,12 @@ async fn post_config(
         }
         if let Some(v) = wizard_custom {
             d.custom_egress_url = v;
+        }
+        // The Twitch step of the wizard can opt into VOD audio mode. Only
+        // meaningful for Twitch; the wizard only shows the toggle there, so
+        // whatever it posts is already platform-correct.
+        if let Some(v) = form.get("vod_audio") {
+            d.vod_audio = v == "on" || v == "true";
         }
     }
 
@@ -2094,10 +2218,14 @@ async fn post_destination_upsert(
         form.get("vod_audio").map(String::as_str),
         Some("on" | "true" | "1")
     );
-    let vod_audio_inject_eb = matches!(
-        form.get("vod_audio_inject_eb").map(String::as_str),
-        Some("on" | "true" | "1")
-    );
+    // Present only when a caller explicitly sends it (the dedicated EB-inject
+    // flow does; the dashboard's save/toggle deliberately don't). `None` means
+    // "leave it alone" on an edit, so a plain save or enable/disable toggle
+    // can't silently blank this Twitch EB-inject flag; a fresh insert falls
+    // back to false.
+    let vod_audio_inject_eb = form
+        .get("vod_audio_inject_eb")
+        .map(|v| matches!(v.as_str(), "on" | "true" | "1"));
     let stream_format =
         normalize_stream_format(&platform, form.get("stream_format").map(String::as_str));
 
@@ -2122,7 +2250,9 @@ async fn post_destination_upsert(
         existing.twitch_ingest = twitch_ingest;
         existing.youtube_ingest = youtube_ingest;
         existing.vod_audio = vod_audio;
-        existing.vod_audio_inject_eb = vod_audio_inject_eb;
+        if let Some(v) = vod_audio_inject_eb {
+            existing.vod_audio_inject_eb = v;
+        }
         existing.stream_format = stream_format;
     } else {
         ns.destinations.push(config::Destination {
@@ -2135,7 +2265,7 @@ async fn post_destination_upsert(
             twitch_ingest,
             youtube_ingest,
             vod_audio,
-            vod_audio_inject_eb,
+            vod_audio_inject_eb: vod_audio_inject_eb.unwrap_or(false),
             stream_format,
         });
     }
@@ -2416,27 +2546,7 @@ fn destinations_json(ctrl: &Controller, settings: &Arc<watch::Sender<Settings>>)
             .cloned()
             .unwrap_or_else(|| (id.into(), false, 0, 0, 0, 0, 0, 0))
     };
-    // Parse each cached video seq-header once per poll, not once per
-    // destination: the res/codec readout depends only on which TrackId a
-    // dest forwards, and horizontal dests all share track 0 while vertical
-    // dests share the one detected portrait primary. Keeps this
-    // frequently-polled endpoint off a per-dest lock + Exp-Golomb parse.
-    let readouts: std::collections::BTreeMap<u8, (String, String)> = {
-        let headers = ctrl.ring.video_seq_headers.lock().unwrap();
-        headers
-            .iter()
-            .map(|(&track, h)| {
-                let res = crate::h264::sps_dimensions(h)
-                    .map(|(w, hh)| format!("{}x{}", w, hh))
-                    .unwrap_or_default();
-                let codec = match crate::h264::seq_header_codec(h) {
-                    crate::h264::VideoCodec::Unknown => String::new(),
-                    c => c.label().to_string(),
-                };
-                (track, (res, codec))
-            })
-            .collect()
-    };
+    let readouts = video_readouts(ctrl);
     let mut out = String::from("[");
     for (i, d) in s.destinations.iter().enumerate() {
         if i > 0 {
@@ -2447,38 +2557,8 @@ fn destinations_json(ctrl: &Controller, settings: &Arc<watch::Sender<Settings>>)
         // Vertical destinations report whether their canvas is resolved
         // yet (Twitch Dual Format live + a portrait track detected). The
         // dashboard turns this into a green "Vertical" badge vs an amber
-        // "waiting for Dual Format" hint. Non-vertical destinations always
-        // report ready=true so the badge logic stays simple.
-        let vertical = d.wants_vertical();
-        // A portrait canvas is present on the wire right now (Twitch Dual
-        // Format is live). Detected globally and stored on every dest each
-        // tick, so it's meaningful for Twitch cards too - that's what lets
-        // the format icon show "both" only when Dual Format is actually on,
-        // not just because the destination is Twitch.
-        use std::sync::atomic::Ordering;
-        let vertical_canvas_present = ctrl
-            .destination_state(&d.id)
-            .vertical_primary_track
-            .load(Ordering::Relaxed)
-            != 0xFF;
-        let vertical_ready = if vertical {
-            vertical_canvas_present
-        } else {
-            true
-        };
-        // Resolution + codec of the track this destination actually forwards
-        // (track 0 for horizontal/Twitch, the detected portrait primary for
-        // vertical), pulled from the per-poll readout map. Empty when the
-        // track isn't cached yet (non-AVC we can't measure, or vertical
-        // canvas not resolved -> target 0xFF isn't a key).
-        let target = if vertical {
-            ctrl.destination_state(&d.id)
-                .vertical_primary_track
-                .load(Ordering::Relaxed)
-        } else {
-            0
-        };
-        let (video_res, video_codec) = readouts.get(&target).cloned().unwrap_or_default();
+        // "waiting for Dual Format" hint.
+        let v = dest_video(ctrl, d, &readouts);
         out.push_str(&format!(
             r#"{{"id":{id},"name":{n},"enabled":{en},"platform":{p},"custom_egress_url":{cu},"twitch_ingest":{ti},"youtube_ingest":{yi},"vod_audio":{va},"vod_audio_inject_eb":{vie},"stream_format":{sf},"vertical_ready":{vr},"vertical_canvas_present":{vcp},"video_res":{vres},"video_codec":{vcod},"stream_key_set":{ks},"url_redacted":{ur},"alive":{al},"bitrate_kbps":{br},"tags_sent":{ts},"bytes_sent":{bs},"cuts":{ct},"reconnects":{rc}}}"#,
             id = json_escape_quoted(&d.id),
@@ -2495,10 +2575,10 @@ fn destinations_json(ctrl: &Controller, settings: &Arc<watch::Sender<Settings>>)
             va = d.vod_audio,
             vie = d.vod_audio_inject_eb,
             sf = json_escape_quoted(&d.stream_format),
-            vr = vertical_ready,
-            vcp = vertical_canvas_present,
-            vres = json_escape_quoted(&video_res),
-            vcod = json_escape_quoted(&video_codec),
+            vr = v.vertical_ready,
+            vcp = v.vertical_canvas_present,
+            vres = json_escape_quoted(&v.res),
+            vcod = json_escape_quoted(&v.codec),
             ks = !d.stream_key.is_empty(),
             ur = json_escape_quoted(&redact_url(&url)),
             al = alive,
@@ -2975,11 +3055,6 @@ fn apply_field_str(s: &mut Settings, key: &str, value: &str) {
             }
         }
         "buffer_path" => s.buffer_path = std::path::PathBuf::from(value),
-        "initial_delay_ms" => {
-            if let Ok(v) = value.parse() {
-                s.initial_delay_ms = v;
-            }
-        }
         "overlays_dir" => s.overlays_dir = std::path::PathBuf::from(value),
         "discord_webhook_url" => s.discord_webhook_url = value.into(),
         "tracing_enabled" => {
@@ -2998,6 +3073,12 @@ fn apply_field_str(s: &mut Settings, key: &str, value: &str) {
             if let Ok(v) = value.parse() {
                 s.auto_arm_delay_ms = v;
             }
+        }
+        "update_check_enabled" => {
+            s.update_check_enabled = !matches!(value, "" | "false" | "0" | "off");
+        }
+        "open_dashboard_on_launch" => {
+            s.open_dashboard_on_launch = !matches!(value, "" | "false" | "0" | "off");
         }
         _ => {}
     }

--- a/web/dock.html
+++ b/web/dock.html
@@ -408,6 +408,15 @@ body.boot .wrap>*:nth-child(n+8){animation-delay:.28s}
 @media (prefers-reduced-motion:reduce){
   *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
 }
+/* Reduced transparency: solidify the editor scrim instead of relying on blur. */
+@media (prefers-reduced-transparency:reduce){
+  .editor{background:color-mix(in srgb,#000 90%,transparent);backdrop-filter:none;-webkit-backdrop-filter:none}
+}
+/* Higher contrast: brighter borders and faint ink, token-level so it lands
+   on every chip, pill, row and switch at once. */
+@media (prefers-contrast:more){
+  :root{--line:#454b60;--line-2:#5b6178;--fg-4:#7a8091;--fg-3:#9ca1b2}
+}
 </style></head><body>
 <button class="gear" id="gear" title="Customize dock" onclick="openEditor()">&#9881;</button>
 <div class="wrap">

--- a/web/dock.js
+++ b/web/dock.js
@@ -678,9 +678,7 @@ function overlayRow(o) {
   const row = document.createElement('div'); row.className = 'orow';
   const nm = document.createElement('span'); nm.className = 'o-name'; nm.textContent = o.name || o.slug;
   if (o.studio && !cfg.w.overlays.group) { const tag = document.createElement('span'); tag.className = 'o-tag'; tag.textContent = 'studio'; nm.appendChild(tag); }
-  //const open = document.createElement('button'); open.className = 'minibtn'; open.textContent = 'Open'; open.title = 'Preview in a new tab'; open.onclick = () => openOverlay(o.slug);
   const copy = document.createElement('button'); copy.className = 'minibtn'; copy.innerHTML = '&#128279;'; copy.title = 'Copy browser-source URL'; copy.onclick = () => copyOverlay(o.slug);
-  //row.append(nm, open, copy);
   row.append(nm, copy);
   return row;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
 <style>
-/* ── Design tokens (ported from instantclone design system, OKLCH-based) ─────── */
+/* - Design tokens (ported from instantclone design system, OKLCH-based) ---─ */
 :root{
   /* Surfaces - five stacked elevations from the page background up.
      Tuned to a near-blue-black so the OKLCH accent doesn't bleed into
@@ -52,12 +52,22 @@
   --ease-out:cubic-bezier(.2,.7,.2,1); --ease-spring:cubic-bezier(.32,1.4,.5,1);
 }
 *{box-sizing:border-box}
+/* This is a dark UI. Declaring it means native controls the page can't
+   fully restyle - scrollbars, the select popup list, form autofill - render
+   in their dark variant instead of a bright flash against everything else. */
+/* Reserve the scrollbar gutter so the page never jumps sideways when content
+   grows past the viewport (e.g. the tab-height morph adding/removing scroll). */
+html{color-scheme:dark;scrollbar-gutter:stable}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
   font-family:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;font-size:14px;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
 .mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
 button{font-family:inherit}
 input,select,textarea{font-family:inherit;color:inherit}
+/* Type detail: balance headings so a title never drops a lone word onto its
+   own line; pretty on descriptive copy trims orphans. Both no-op on one line. */
+h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
+.tab-sub,.lead,.wiz-step-s{text-wrap:pretty}
 :focus-visible{outline:2px solid color-mix(in oklch,var(--accent) 60%,transparent);outline-offset:2px}
 ::-webkit-scrollbar{width:10px;height:10px}
 ::-webkit-scrollbar-track{background:transparent}
@@ -70,7 +80,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   var(--bg)}
 .ic-shell{max-width:1280px;margin:0 auto;padding:18px 24px 32px;display:flex;flex-direction:column;gap:14px}
 
-/* ── Header ───────────────────────────────────── */
+/* - Header ------------------─ */
 .ic-header{display:flex;align-items:center;gap:16px;padding:11px 18px;
   background:linear-gradient(180deg,var(--surface-2),var(--surface));
   border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-1)}
@@ -114,6 +124,30 @@ input,select,textarea{font-family:inherit;color:inherit}
 .ic-pill.ok{color:var(--fg)}
 .ic-pill.warn{color:var(--warn);border-color:color-mix(in oklch,var(--warn) 35%,transparent);
   background:color-mix(in oklch,var(--warn) 8%,var(--surface-3))}
+
+/* Encoder-compatibility strip. Deliberately ONE line and deliberately
+   absent whenever the stream is fine - the dashboard already carries a
+   lot, so this only earns its space when it has something actionable to
+   say. Long text ellipsises rather than wrapping to a second row; the
+   full sentence stays reachable via the title tooltip. */
+#compat-warn{display:flex;align-items:center;gap:10px;margin:0 0 14px;padding:9px 12px;
+  border:1px solid color-mix(in oklch,var(--warn) 30%,transparent);border-radius:10px;
+  background:color-mix(in oklch,var(--warn) 7%,var(--surface-2));font-size:12.5px}
+#compat-warn .cw-ic{flex:none;color:var(--warn);font-size:13px;line-height:1}
+#compat-warn .cw-text{flex:1;min-width:0;color:var(--fg-2);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#compat-warn .cw-x{flex:none;width:22px;height:22px;border-radius:6px;border:0;cursor:pointer;
+  background:transparent;color:var(--fg-4);font-size:14px;line-height:1;
+  transition:color .15s var(--ease-out),background .15s var(--ease-out)}
+#compat-warn .cw-x:hover{color:var(--fg-1);background:var(--surface-3)}
+
+/* LAN-exposure warning. Only rendered while the box is actually ticked,
+   so the default (loopback-only) setup never sees it. */
+.lan-warn{display:flex;gap:8px;align-items:flex-start;margin-top:10px;padding:9px 11px;
+  border:1px solid color-mix(in oklch,var(--warn) 30%,transparent);border-radius:9px;
+  background:color-mix(in oklch,var(--warn) 7%,var(--surface-2));
+  font-size:12px;line-height:1.5;color:var(--fg-2)}
+.lan-warn .lw-ic{flex:none;color:var(--warn)}
 .ic-pill.warn .dot{background:var(--warn)}
 .ic-pill.bad{color:var(--danger);border-color:color-mix(in oklch,var(--danger) 35%,transparent);
   background:color-mix(in oklch,var(--danger) 8%,var(--surface-3))}
@@ -145,18 +179,27 @@ input,select,textarea{font-family:inherit;color:inherit}
   100%{box-shadow:0 0 0 0 color-mix(in oklch,var(--live) 0%,transparent)}
 }
 
-/* ── Card / labels / buttons / inputs (atoms) ───────────── */
+/* - Card / labels / buttons / inputs (atoms) ------─ */
 .ic-card{background:linear-gradient(180deg,var(--surface-2),var(--surface));
   border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-1)}
 .ic-label{font-size:10.5px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-3)}
 
 .ic-btn{appearance:none;display:inline-flex;align-items:center;justify-content:center;gap:8px;
   padding:10px 16px;border-radius:10px;border:1px solid var(--line-2);background:var(--surface-3);
-  color:var(--fg);font-size:13px;font-weight:500;cursor:pointer;
+  color:var(--fg);font-size:13px;font-weight:500;cursor:pointer;white-space:nowrap;
   transition:transform .15s var(--ease-out),background .15s var(--ease-out),border-color .15s var(--ease-out),
              box-shadow .15s var(--ease-out)}
 .ic-btn:hover{background:color-mix(in oklch,#fff 4%,var(--surface-3));border-color:rgba(255,255,255,.16)}
 .ic-btn:active{transform:translateY(1px)}
+/* Copy confirmation: the button turns success-green with a check that pops
+   in (scale + blur per motion guidelines). Applied by flashCopied(). */
+.ic-btn.is-copied{color:var(--live) !important;
+  border-color:color-mix(in oklch,var(--live) 40%,transparent) !important;
+  background:color-mix(in oklch,var(--live) 12%,var(--surface-3)) !important}
+.ic-btn.is-copied .cp-ico{display:inline-block;margin-right:5px;font-weight:700;
+  animation:cpIcoIn .3s cubic-bezier(0.2,0,0,1)}
+@keyframes cpIcoIn{from{opacity:0;transform:scale(.25);filter:blur(4px)}
+  to{opacity:1;transform:none;filter:blur(0)}}
 .ic-btn-primary{background:var(--accent);color:var(--accent-ink);border-color:transparent;
   box-shadow:0 0 0 1px color-mix(in oklch,var(--accent) 60%,transparent),0 6px 24px var(--accent-glow);
   font-weight:600}
@@ -176,7 +219,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .ic-btn-ghost:hover{background:var(--surface-3);color:var(--fg)}
 .ic-btn-tiny{appearance:none;background:transparent;border:0;width:28px;height:28px;border-radius:6px;
   display:inline-flex;align-items:center;justify-content:center;color:var(--fg-3);cursor:pointer;
-  transition:all .15s var(--ease-out);flex:0 0 auto}
+  transition:background .15s var(--ease-out),color .15s var(--ease-out);flex:0 0 auto}
 .ic-btn-tiny:hover{background:var(--surface-3);color:var(--fg)}
 .ic-btn.big{padding:12px 22px;font-size:14px}
 
@@ -201,7 +244,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 
 .ic-check{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;
   border-radius:5px;border:1px solid var(--line-2);background:var(--bg-2);
-  color:var(--accent-ink);transition:all .15s var(--ease-out);cursor:pointer}
+  color:var(--accent-ink);transition:background .15s var(--ease-out),border-color .15s var(--ease-out);cursor:pointer}
 .ic-check.on{background:var(--accent);border-color:transparent}
 
 /* Toast */
@@ -219,21 +262,104 @@ input,select,textarea{font-family:inherit;color:inherit}
 @keyframes toast-in{from{transform:translateY(8px);opacity:0}to{transform:translateY(0);opacity:1}}
 .ic-toast.leaving{opacity:0;transform:translateX(12px);transition:.25s var(--ease-out)}
 
-/* ── Wizard (when !configured) ───────────────── */
-.wizard-card{max-width:640px;margin:60px auto;padding:32px;display:flex;flex-direction:column;gap:14px}
-.wizard-step-label{margin-top:14px;font-size:11px;text-transform:uppercase;letter-spacing:1.6px;color:var(--accent);font-weight:600}
+/* - Wizard (when !configured) --------─ */
+.wizard-card{width:min(880px,92vw);max-width:880px;margin:40px auto;padding:38px 44px;display:flex;flex-direction:column;gap:18px}
 .wizard-step-sub{color:var(--fg-3);font-size:12px;margin:0 0 6px}
-.wizard-obs-options{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:8px}
-@media (max-width:560px){.wizard-obs-options{grid-template-columns:1fr}}
-.wizard-obs-card{padding:14px;border:1px solid var(--line);border-radius:10px;background:var(--bg-2);display:flex;flex-direction:column;gap:8px}
-.wizard-obs-title{font-size:13px;font-weight:600;color:var(--fg);display:flex;justify-content:space-between;align-items:center;gap:8px}
-.wizard-obs-badge{font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--accent);background:color-mix(in oklch,var(--accent) 14%,var(--surface-3));padding:2px 7px;border-radius:999px}
-.wizard-obs-body{margin:0;font-size:11.5px;color:var(--fg-3);line-height:1.45}
-.wizard-obs-action{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+/* Cards size to their own content (align-items:start) instead of stretching
+   to the taller one - no dead space padding out the shorter card. */
+/* Single column: Register is the recommended primary path; Custom is the
+   secondary fallback under an "or" divider. Reads top-to-bottom. */
+.wizard-obs-options{display:flex;flex-direction:column;margin-bottom:2px}
+.obs-or{display:flex;align-items:center;gap:12px;margin:14px 2px;font-size:10px;font-weight:700;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--fg-4)}
+.obs-or::before,.obs-or::after{content:"";flex:1;height:1px;background:var(--line)}
+.wizard-obs-after{margin:0;font-size:12px;color:var(--fg-3);line-height:1.5}
+.wizard-obs-card{padding:20px;border:1px solid var(--line);border-radius:12px;background:var(--bg-2);display:flex;flex-direction:column;gap:12px}
+.wizard-obs-title{font-size:13.5px;font-weight:600;color:var(--fg);display:flex;justify-content:space-between;align-items:center;gap:8px;line-height:1.3}
+.wizard-obs-badge{flex:0 0 auto;font-size:9.5px;text-transform:uppercase;letter-spacing:1.2px;color:var(--accent);background:color-mix(in oklch,var(--accent) 14%,var(--surface-3));padding:3px 8px;border-radius:999px}
+.wizard-obs-body{margin:0;font-size:12.5px;color:var(--fg-3);line-height:1.55}
+.wizard-obs-action{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-top:2px}
 .wizard-obs-action .muted{font-size:11px}
-.wizard-obs-copy-row{display:flex;align-items:center;gap:8px;font-size:11.5px;flex-wrap:wrap}
-.wizard-obs-copy-row code{flex:1 1 200px;padding:6px 10px;background:var(--surface);border:1px solid var(--line);border-radius:6px;font-size:11.5px}
-.wizard-obs-status{margin:6px 0 0;font-size:11.5px;line-height:1.45;color:var(--fg-3)}
+/* Guided OBS flow, light typographic treatment: a small "Step N" eyebrow (no
+   rail, no numbered circles), hairline divider between steps. A node expands
+   when active and collapses when done; the eyebrow gains a ✓ and turns green.
+   State is [data-state] = locked | active | done (+ [data-verified] on verify). */
+.obs-flow{list-style:none;margin:18px 0 0;padding:0}
+.obs-node{padding:0}
+.obs-node + .obs-node{margin-top:16px;padding-top:16px;border-top:1px solid var(--line)}
+.obs-node-head{appearance:none;background:none;border:0;padding:2px 0;width:100%;text-align:left;
+  cursor:pointer;display:flex;flex-direction:column;gap:3px;color:var(--fg);font:inherit;border-radius:6px}
+.obs-node-head:focus-visible{outline:1px solid var(--accent);outline-offset:2px}
+.obs-eyebrow{font-size:10.5px;font-weight:700;letter-spacing:.13em;text-transform:uppercase;color:var(--fg-4);
+  display:inline-flex;align-items:center;gap:6px;transition:color .25s var(--ease-out)}
+.obs-node[data-state="active"] .obs-eyebrow{color:var(--accent)}
+.obs-node[data-state="done"] .obs-eyebrow,
+.obs-node[data-node="verify"][data-verified] .obs-eyebrow{color:var(--live)}
+.obs-node[data-state="done"] .obs-eyebrow::after,
+.obs-node[data-node="verify"][data-verified] .obs-eyebrow::after{content:"\2713";font-size:12px}
+.obs-node-title{font-size:15px;font-weight:600;letter-spacing:-.01em;transition:color .25s var(--ease-out)}
+.obs-node[data-state="locked"] .obs-node-head{cursor:default;pointer-events:none}
+.obs-node[data-state="locked"] .obs-eyebrow,
+.obs-node[data-state="locked"] .obs-node-title{color:var(--fg-4)}
+.obs-node[data-state="done"] .obs-node-title{color:var(--fg-3)}
+.obs-node-hint{margin:12px 0;font-size:12.5px;color:var(--fg-3);line-height:1.5;text-wrap:pretty}
+/* Body expands/collapses via grid-rows (0fr<->1fr); only the active node is open. */
+.obs-node-clip{display:grid;grid-template-rows:0fr;opacity:0;
+  transition:grid-template-rows .34s var(--ease-out),opacity .26s var(--ease-out)}
+.obs-node[data-state="active"] .obs-node-clip{grid-template-rows:1fr;opacity:1}
+.obs-node-clip>.obs-node-body{overflow:hidden;min-height:0}
+.obs-advance{margin-top:14px}
+/* Shake to point the eye here when Next is clicked before confirming. */
+.obs-advance.nudge{animation:obsNudge .5s var(--ease-out)}
+@keyframes obsNudge{0%,100%{transform:none}20%{transform:translateX(-4px)}
+  40%{transform:translateX(4px)}60%{transform:translateX(-3px)}80%{transform:translateX(2px)}}
+/* Method cards: recommended one wears a soft accent frame; both lift on hover. */
+.wizard-obs-card{transition:border-color .18s var(--ease-out),background .18s var(--ease-out),box-shadow .18s var(--ease-out)}
+.wizard-obs-card:hover{border-color:var(--line-2)}
+.wizard-obs-card.obs-recommended{border-color:color-mix(in oklch,var(--accent) 30%,var(--line));
+  background:linear-gradient(180deg,color-mix(in oklch,var(--accent) 7%,var(--bg-2)),var(--bg-2));
+  box-shadow:0 0 0 1px color-mix(in oklch,var(--accent) 12%,transparent),0 8px 26px -18px color-mix(in oklch,var(--accent) 60%,transparent)}
+/* "no restart" reassurance tag on the custom card. */
+.obs-norestart{flex:0 0 auto;font-size:9px;text-transform:uppercase;letter-spacing:1px;font-weight:700;
+  color:var(--live);background:color-mix(in oklch,var(--live) 14%,transparent);
+  border:1px solid color-mix(in oklch,var(--live) 30%,transparent);padding:2px 7px;border-radius:999px}
+/* Inside a node the check panel drops its own card chrome - the node is the container. */
+.obs-node-body .wiz-obs-verify{margin:0;padding:0;border:0;background:none}
+.obs-node-body .wiz-obs-verify[data-state="ok"]{background:none}
+.obs-node-body .wov-sub{margin-top:0}
+.wizard-obs-copy-row{display:flex;align-items:center;gap:8px;font-size:12px}
+/* flex:1 (basis 0) + min-width:0 + overflow:hidden: the URL takes the leftover
+   width and shrinks/ellipsises as needed, so the Copy button always stays on
+   the same line. A non-zero flex-basis made flexbox wrap the button under the
+   input before shrink could apply. Matches the proven .copy-block pattern. */
+.wizard-obs-copy-row code{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;
+  white-space:nowrap;padding:7px 10px;background:var(--surface);border:1px solid var(--line);
+  border-radius:6px;font-size:11.5px}
+/* Optional local-only OBS-connection check. One sub-state shows at a time,
+   driven by [data-state] (idle -> waiting -> ok). */
+.wiz-obs-verify{margin-top:14px;padding:14px 16px;border-radius:12px;background:var(--surface-2);
+  border:1px solid var(--line);transition:border-color .25s var(--ease-out),background .25s var(--ease-out)}
+.wov-head{display:flex;align-items:center;gap:8px}
+.wov-title{font-weight:600;font-size:13.5px}
+.wov-optional{font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-4);
+  border:1px solid var(--line-2);border-radius:999px;padding:1px 7px}
+.wov-sub{margin:6px 0 12px;font-size:12px;color:var(--fg-3);line-height:1.5;text-wrap:pretty}
+.wov-body>*{display:none}
+.wiz-obs-verify[data-state="idle"] .wov-start{display:inline-flex}
+.wiz-obs-verify[data-state="waiting"] .wov-waiting{display:flex;align-items:center;gap:11px}
+.wiz-obs-verify[data-state="ok"] .wov-ok{display:flex;align-items:center;gap:9px}
+.wov-status{font-size:12.5px;color:var(--fg-2)}
+.wov-cancel{margin-left:auto;flex:0 0 auto}
+.wov-status-ok{font-size:12.5px;color:var(--fg);font-weight:500}
+.wov-check{width:22px;height:22px;flex:0 0 auto;border-radius:50%;background:var(--live);color:#04120a;
+  display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px;
+  animation:cpIcoIn .3s cubic-bezier(0.2,0,0,1)}
+.wov-spinner{width:15px;height:15px;flex:0 0 auto;border:2px solid var(--line-2);
+  border-top-color:var(--accent);border-radius:50%;animation:wovspin .7s linear infinite}
+@keyframes wovspin{to{transform:rotate(360deg)}}
+.wiz-obs-verify[data-state="ok"]{border-color:color-mix(in oklch,var(--live) 40%,var(--line));
+  background:color-mix(in oklch,var(--live) 8%,var(--surface-2))}
+.wizard-obs-status{margin:4px 0 0;font-size:12px;line-height:1.5;color:var(--fg-3)}
 .wizard-obs-status:empty{display:none}
 .wizard-obs-tip{margin:0;font-size:11px;color:var(--fg-4)}
 /* Progressive disclosure primitive - `<details class="ic-disclose">`
@@ -246,7 +372,9 @@ input,select,textarea{font-family:inherit;color:inherit}
   cursor:pointer;display:inline-flex;align-items:center;gap:6px;
   color:var(--fg-3);font-size:11.5px;
   -webkit-user-select:none;user-select:none;list-style:none;
-  padding:2px 0;border-radius:4px;
+  /* Roomier padding grows the click/tap target (~30px tall vs 18) without a
+     40px pseudo, which would overlap the next stacked summary (8px gap). */
+  padding:6px 4px;margin-left:-4px;border-radius:6px;
   transition:color .15s var(--ease-out);
 }
 .ic-disclose summary::-webkit-details-marker{display:none}
@@ -255,29 +383,190 @@ input,select,textarea{font-family:inherit;color:inherit}
   border-left:4px solid currentColor;border-top:3px solid transparent;border-bottom:3px solid transparent;
   transition:transform .18s var(--ease-out);transform-origin:35% 50%;
 }
-.ic-disclose[open] summary::before{transform:rotate(90deg)}
+.ic-disclose.is-open summary::before{transform:rotate(90deg)}
 .ic-disclose summary:hover{color:var(--fg-2)}
+.ic-disclose summary:active{color:var(--fg)}   /* instant feedback on press-down */
 .ic-disclose summary:focus-visible{outline:1px solid var(--accent);outline-offset:2px}
+/* Reveal system (see wireDisclosure). The `.disc-sleeve` height is driven
+   frame-by-frame by a critically-damped SPRING in JS - not a CSS transition -
+   so a reversal mid-flight carries the current velocity through instead of
+   restarting a fixed ease (that velocity reset was the "brick wall"). No
+   `transition` here on purpose: it would fight the per-frame updates. The
+   padded body rides a GPU-composited opacity + translateY (--disc-ms) so the
+   content materialises in step with the spring without a second layout tween. */
+.disc-sleeve{height:0;overflow:hidden}
 .ic-disclose-body{
   margin-top:6px;padding:10px 12px;border-radius:8px;
   background:color-mix(in oklch,var(--bg-2) 60%,var(--surface));
   border:1px solid var(--line);
-  color:var(--fg-3);font-size:11.5px;line-height:1.55;
-  animation:discloseIn .22s var(--ease-out) both;
+  color:var(--fg-3);font-size:11.5px;line-height:1.55;text-wrap:pretty;
+  opacity:0;transform:translateY(-4px);
+  transition:opacity var(--disc-ms,.26s) var(--ease-out),
+    transform var(--disc-ms,.26s) var(--ease-out);
 }
+.ic-disclose.is-open > .disc-sleeve > .ic-disclose-body{opacity:1;transform:none}
+/* Safety net: if a disclosure is ever shown before JS wires it (dynamic
+   injection, script error), fall back to native <details> behaviour so the
+   body is never invisibly hidden - the managed path adds `.disc-ready`. */
+.ic-disclose:not(.disc-ready)[open] > .ic-disclose-body{opacity:1;transform:none}
 .ic-disclose-body p{margin:0}
 .ic-disclose-body p + p{margin-top:8px}
 .ic-disclose-body code.mono{background:var(--surface);padding:1px 5px;border-radius:4px;font-size:11px}
-@keyframes discloseIn{
-  from{opacity:0;transform:translateY(-4px)}
-  to{opacity:1;transform:none}
-}
 .wizard-card h2{font-size:22px;margin:0;letter-spacing:-.01em}
 .wizard-card .lead{color:var(--fg-3);font-size:13px;margin:0 0 8px}
-.wizard-card label{display:block;margin-top:8px;font-size:11px;color:var(--fg-3);
+/* Field labels are uppercase eyebrow text. The `:not` guard is load-bearing:
+   `.wizard-card label` is more specific than `.wiz-feature-toggle`, so
+   without it the VOD-audio toggle (a <label>) inherited both uppercase AND
+   display:block - stacking its checkbox above ALL-CAPS body text. */
+.wizard-card label:not(.wiz-feature-toggle){display:block;margin-top:8px;font-size:11px;color:var(--fg-3);
   text-transform:uppercase;letter-spacing:.12em;font-weight:600}
 .wizard-row{display:flex;gap:8px;margin-top:8px}
 .wizard-row .ic-btn{flex:1}
+
+/* Visual platform picker (Step 2). Tiles reuse the exact per-platform
+   accent (--dc) the destination cards use, so the choice you make here
+   matches the card you'll see afterwards. The real value lives in a
+   hidden <select> so the save/test logic never had to change. Sized to
+   be the visual centrepiece of the step: ~3 per row on the 640px card. */
+.w-platform-tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));
+  gap:12px;margin-top:12px}
+.w-ptile{--dc:var(--line-2);appearance:none;cursor:pointer;position:relative;display:flex;
+  flex-direction:column;align-items:center;gap:12px;padding:20px 14px;border-radius:15px;
+  text-align:center;color:var(--fg-2);overflow:hidden;
+  background:linear-gradient(180deg,color-mix(in oklch,var(--surface-3) 55%,var(--surface-2)),var(--surface-2));
+  border:1px solid var(--line);
+  transition:border-color .18s var(--ease-out),background .18s var(--ease-out),
+    color .18s var(--ease-out),transform .14s var(--ease-spring),box-shadow .2s var(--ease-out)}
+/* Soft radial wash in the platform colour, revealed on hover/selected. A
+   pseudo-element so it can fade independently of the tile's own bg. */
+.w-ptile::before{content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+  background:radial-gradient(120% 80% at 50% -10%,color-mix(in oklch,var(--dc) 22%,transparent),transparent 70%);
+  opacity:0;transition:opacity .2s var(--ease-out)}
+.w-ptile:hover{border-color:color-mix(in oklch,var(--dc) 50%,var(--line-2));color:var(--fg);
+  transform:translateY(-3px);
+  box-shadow:0 10px 26px -12px color-mix(in oklch,var(--dc) 65%,transparent)}
+.w-ptile:hover::before{opacity:.7}
+.w-ptile:active{transform:scale(.96)}
+.w-ptile.on{border-color:color-mix(in oklch,var(--dc) 80%,transparent);color:var(--fg);
+  background:linear-gradient(180deg,color-mix(in oklch,var(--dc) 16%,var(--surface-2)),
+    color-mix(in oklch,var(--dc) 7%,var(--surface-2)));
+  box-shadow:0 0 0 1px color-mix(in oklch,var(--dc) 60%,transparent) inset,
+    0 10px 30px -12px color-mix(in oklch,var(--dc) 55%,transparent)}
+.w-ptile.on::before{opacity:1}
+/* Badge: a lit chip with a colour-matched glow and a top sheen, so it reads
+   as a physical object rather than a flat square. */
+.w-ptile-badge{position:relative;width:48px;height:48px;border-radius:14px;display:flex;
+  align-items:center;justify-content:center;font-weight:700;font-size:21px;color:#0b0d12;
+  background:linear-gradient(150deg,color-mix(in oklch,var(--dc) 82%,#fff),var(--dc) 62%,
+    color-mix(in oklch,var(--dc) 82%,#000));
+  box-shadow:0 4px 12px -3px color-mix(in oklch,var(--dc) 60%,transparent),
+    inset 0 1px 0 rgba(255,255,255,.4),inset 0 -2px 5px rgba(0,0,0,.18);
+  transition:box-shadow .2s var(--ease-out),transform .14s var(--ease-spring)}
+.w-ptile:hover .w-ptile-badge{transform:scale(1.05)}
+.w-ptile.on .w-ptile-badge{box-shadow:0 6px 18px -4px color-mix(in oklch,var(--dc) 70%,transparent),
+    inset 0 1px 0 rgba(255,255,255,.45),inset 0 -2px 5px rgba(0,0,0,.2)}
+.w-ptile-label{font-size:13px;font-weight:600;line-height:1.2;letter-spacing:0;
+  text-transform:none;color:inherit;position:relative}
+/* Corner check appears only on the chosen tile. Scales in so the
+   selection has a beat of feedback rather than snapping. */
+.w-ptile-check{position:absolute;top:8px;right:8px;width:18px;height:18px;border-radius:999px;
+  display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;
+  color:#0d0f14;background:var(--dc);opacity:0;transform:scale(.4);
+  transition:opacity .15s var(--ease-out),transform .15s var(--ease-out)}
+.w-ptile.on .w-ptile-check{opacity:1;transform:scale(1)}
+
+/* - Multi-step wizard chrome ---------─ */
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+  clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.wiz-head{margin-bottom:4px}
+/* Segmented progress bar - one segment per step in the current sequence,
+   so it grows to 4 segments the moment Twitch is chosen. Each segment
+   carries a fill layer (::after) that sweeps left-to-right, so advancing
+   a step reads as the bar filling forward rather than a colour snap. */
+.wiz-progress{display:flex;margin-top:14px}
+/* Every possible step has a permanent segment; the optional Twitch one
+   collapses (flex-grow + its own gap animate to 0) instead of being ripped
+   from the DOM, so switching platform slides the bar between 3 and 4
+   segments smoothly. Spacing is an adjacent-sibling margin, not flex gap,
+   so a collapsed segment leaves no orphan gap. */
+.wiz-seg{position:relative;height:4px;flex:1 1 0;min-width:0;border-radius:2px;background:var(--line);
+  overflow:hidden;transition:flex-grow .35s var(--ease-out),opacity .3s var(--ease-out),
+    margin-left .35s var(--ease-out)}
+.wiz-seg + .wiz-seg{margin-left:6px}
+.wiz-seg.collapsed{flex-grow:0;opacity:0;margin-left:0;pointer-events:none}
+.wiz-seg::after{content:"";position:absolute;inset:0;border-radius:2px;background:var(--accent);
+  transform:scaleX(0);transform-origin:left;transition:transform .4s var(--ease-out),background .3s var(--ease-out)}
+.wiz-seg.done::after{transform:scaleX(1);background:color-mix(in oklch,var(--accent) 50%,var(--line))}
+.wiz-seg.on::after{transform:scaleX(1)}
+/* Reassurance note under the platform tiles. */
+/* One callout system for the whole wizard: a left icon square + text with
+   consistent padding / radius / type, differing only by intent colour:
+   .info (neutral reassurance), .warn (do this first), .tip (helpful aside). */
+.wiz-callout{display:flex;gap:10px;align-items:flex-start;margin-top:14px;padding:10px 13px;
+  border-radius:10px;font-size:12px;line-height:1.5;color:var(--fg-2)}
+.wiz-callout .ic{flex:0 0 auto;width:18px;height:18px;border-radius:6px;display:flex;align-items:center;
+  justify-content:center;font-weight:700;font-size:12px;line-height:1;margin-top:1px}
+.wiz-callout b,.wiz-callout strong{color:var(--fg);font-weight:600}
+.wiz-callout-t{display:block;font-weight:600;color:var(--fg);margin-bottom:2px}
+.wiz-callout.info{background:var(--surface-2);border:1px solid var(--line)}
+.wiz-callout.info .ic{color:var(--accent);background:color-mix(in oklch,var(--accent) 15%,transparent)}
+.wiz-callout.tip{background:color-mix(in oklch,var(--accent) 6%,var(--bg-2));
+  border:1px solid color-mix(in oklch,var(--accent) 22%,var(--line))}
+.wiz-callout.tip .ic{color:var(--accent-ink);background:var(--accent)}
+.wiz-callout.warn{background:color-mix(in oklch,var(--warn,#d6a23a) 9%,var(--surface-2));
+  border:1px solid color-mix(in oklch,var(--warn,#d6a23a) 26%,var(--line))}
+.wiz-callout.warn .ic{color:#0d0f14;background:var(--warn,#d6a23a)}
+/* Directional step transition: incoming panel slides in from the side you
+   are travelling toward (right on Next, left on Back), so movement through
+   the flow has a consistent physical direction. */
+#wizard[data-dir="fwd"] .wiz-step:not([hidden]){animation:wizInFwd .3s var(--ease-out)}
+#wizard[data-dir="back"] .wiz-step:not([hidden]){animation:wizInBack .3s var(--ease-out)}
+@keyframes wizInFwd{from{opacity:0;transform:translateX(24px)}to{opacity:1;transform:none}}
+@keyframes wizInBack{from{opacity:0;transform:translateX(-24px)}to{opacity:1;transform:none}}
+@keyframes wizStepIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+.wiz-step-h{margin-bottom:10px}
+.wiz-step-t{font-size:16px;font-weight:600;letter-spacing:-.01em}
+.wiz-step-s{font-size:12.5px;color:var(--fg-3);margin-top:3px;line-height:1.45}
+.wiz-nav{display:flex;align-items:center;gap:10px;margin-top:20px}
+.wiz-nav .spacer{flex:1}
+.wiz-nav #wiz-back,.wiz-nav #wiz-next{flex:0 0 auto;min-width:116px}
+/* Tactile press on the nav buttons + a soft glow lift on the primary CTA. */
+.wiz-nav .ic-btn{transition:transform .12s var(--ease-out),box-shadow .18s var(--ease-out),
+  background .15s var(--ease-out),border-color .15s var(--ease-out),color .15s var(--ease-out)}
+.wiz-nav .ic-btn:active{transform:scale(.96)}
+.wiz-nav #wiz-next:hover{transform:translateY(-1px);
+  box-shadow:0 6px 20px -8px color-mix(in oklch,var(--accent) 70%,transparent)}
+.wiz-nav #wiz-next:active{transform:scale(.96)}
+.wiz-skip{background:none;border:0;color:var(--fg-4);font:inherit;font-size:12px;cursor:pointer;
+  padding:6px 2px;text-decoration:underline;text-underline-offset:3px;
+  text-decoration-color:var(--line-2);transition:color .15s var(--ease-out)}
+.wiz-skip:hover{color:var(--fg-3)}
+/* Staggered tile entrance - re-fires each time the platform step becomes
+   visible (its parent was display:none, so child animations restart). The
+   per-tile delay is set inline in JS. */
+#wizard .wiz-step[data-wstep="platform"]:not([hidden]) .w-ptile{animation:tileIn .34s var(--ease-out) both}
+@keyframes tileIn{from{opacity:0;transform:translateY(10px) scale(.96)}to{opacity:1;transform:none}}
+/* Twitch-extras feature cards */
+.wiz-feature{background:var(--surface-2);border:1px solid var(--line);border-radius:12px;
+  padding:14px;margin-top:10px;transition:border-color .15s var(--ease-out),background .15s var(--ease-out)}
+.wiz-feature-toggle{display:flex;gap:12px;align-items:flex-start;cursor:pointer}
+.wiz-feature-toggle:hover{border-color:var(--line-2);background:var(--surface-3)}
+.wiz-feature-toggle input{width:18px;height:18px;margin-top:2px;flex:0 0 auto;cursor:pointer;
+  accent-color:var(--accent)}
+.wiz-feature-h{font-weight:600;font-size:13.5px;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.wiz-feature-b{font-size:12.5px;color:var(--fg-3);line-height:1.5;margin:6px 0 0}
+/* Provenance tag so a reader can tell a Twitch/OBS feature from an
+   InstantClone one at a glance. */
+.wiz-tag{font-size:9.5px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;
+  padding:2px 7px;border-radius:999px;white-space:nowrap}
+.wiz-tag-twitch{color:#a78bfa;background:color-mix(in oklch,#a78bfa 14%,transparent);
+  border:1px solid color-mix(in oklch,#a78bfa 35%,transparent)}
+.wiz-vod-how{margin-top:10px;padding:12px 14px;background:var(--bg-2);border:1px solid var(--line);
+  border-radius:10px;font-size:12.5px;line-height:1.55;color:var(--fg-2);
+  animation:wizStepIn .2s var(--ease-out)}
+.wiz-vod-how-t{font-weight:600;margin-bottom:6px}
+.wiz-vod-how ol{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:5px}
+.wiz-vod-how .w-hint{margin-top:8px}
 #w-custom-wrap{margin-top:8px}
 .w-hint{font-size:11.5px;color:var(--fg-4);margin-top:4px}
 /* Container for the per-platform help under the wizard / destination
@@ -299,7 +588,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 #w-msg .err{color:var(--danger)}
 #w-msg .ok{color:var(--live)}
 
-/* ── Hero ────────────────────────────────────── */
+/* - Hero ------------------- */
 .hero-card{padding:0;overflow:hidden}
 .hero{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);align-items:stretch;position:relative}
 @media (max-width:880px){.hero{grid-template-columns:1fr}}
@@ -423,7 +712,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .cp-input-row:focus-within{border-color:color-mix(in oklch,var(--accent) 60%,transparent);background:var(--bg)}
 .cp-step{appearance:none;background:var(--surface-3);border:0;width:36px;height:36px;border-radius:7px;
   color:var(--fg-2);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;
-  transition:all .15s var(--ease-out);flex:0 0 auto;font-size:18px;line-height:1}
+  transition:background .15s var(--ease-out),color .15s var(--ease-out),transform .15s var(--ease-out);flex:0 0 auto;font-size:18px;line-height:1}
 .cp-step:hover:not(:disabled){background:color-mix(in oklch,var(--accent) 18%,var(--surface-3));color:var(--fg)}
 .cp-step:active:not(:disabled){transform:scale(.94)}
 .cp-step:disabled{opacity:.4;cursor:not-allowed}
@@ -440,7 +729,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .cp-profiles{display:flex;flex-wrap:wrap;gap:6px}
 .cp-profile-chip{appearance:none;display:inline-flex;align-items:center;gap:6px;padding:6px 11px;
   border-radius:999px;background:var(--bg-2);border:1px solid var(--line);color:var(--fg-2);
-  font-size:12px;font-weight:500;cursor:pointer;transition:all .15s var(--ease-out)}
+  font-size:12px;font-weight:500;cursor:pointer;transition:background .15s var(--ease-out),border-color .15s var(--ease-out),color .15s var(--ease-out)}
 .cp-profile-chip:hover:not(:disabled){background:var(--surface-3);border-color:var(--line-2);color:var(--fg)}
 .cp-profile-chip.on{background:color-mix(in oklch,var(--accent) 14%,var(--surface-3));
   border-color:color-mix(in oklch,var(--accent) 55%,transparent);color:var(--accent)}
@@ -448,7 +737,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .cp-cta{width:100%;padding:13px 18px;font-size:14px;border-radius:10px}
 #cp-cancel{animation:pillIn .2s var(--ease-out)}
 .cp-cta-pulse{animation:cta-pulse 1.8s var(--ease-out) infinite}
-/* ── "Cut after this airs" + hovercard ─────────────────────────────
+/* - "Cut after this airs" + hovercard --------------─
    Visible only while a delay is active, sharing the CTA row at a 3:1
    split (Cut delay : Cut after) so the control column's height never
    changes with state. The hovercard is a pure-CSS tooltip
@@ -484,7 +773,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   100%{box-shadow:0 0 0 1px color-mix(in oklch,var(--accent) 60%,transparent),0 0 0 0 transparent}
 }
 
-/* ── Tabs ────────────────────────────────────── */
+/* - Tabs ------------------- */
 .tabs{display:flex;align-items:center;padding:4px;background:var(--surface);border:1px solid var(--line);
   border-radius:10px;gap:2px;position:relative;overflow-x:auto;scrollbar-width:none}
 .tabs::-webkit-scrollbar{display:none}
@@ -500,7 +789,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .tab-ind{position:absolute;top:4px;bottom:4px;background:var(--surface-3);border-radius:7px;
   transition:left .28s var(--ease-spring),width .28s var(--ease-spring);z-index:1;border:1px solid var(--line-2)}
 
-/* ── Sub-tabs (nested nav, currently used by System pane) ─── */
+/* - Sub-tabs (nested nav, currently used by System pane) -─ */
 .sub-tabs{position:relative;display:flex;gap:2px;padding:4px;background:var(--surface-2);
   border:1px solid var(--line);border-radius:9px;align-items:stretch;overflow-x:auto;scrollbar-width:none}
 .sub-tabs::-webkit-scrollbar{display:none}
@@ -543,16 +832,24 @@ input,select,textarea{font-family:inherit;color:inherit}
 #sys-about-msg a:visited,
 .sys-about-card a:visited{color:var(--accent)}
 
-/* ── Pane ────────────────────────────────────── */
+/* - Pane ------------------- */
 .pane-card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);
   padding:22px;min-height:360px;max-height:70vh;overflow-y:auto;overflow-x:hidden}
-.tab-pane{animation:paneIn .25s var(--ease-out) both;display:flex;flex-direction:column;gap:18px}
-@keyframes paneIn{from{opacity:0;transform:translateY(2px)}to{opacity:1;transform:translateY(0)}}
+/* Directional enter: the body slides in from the side the tab moved toward
+   (showTab sets --pane-dx: + for a rightward move, - for leftward, 0 on first
+   paint / sub-panes), echoing the sliding tab indicator. Transform + opacity
+   only so it's GPU-composited; .pane-card clips overflow-x so the slide never
+   flashes a scrollbar. Reduced-motion collapses it globally. */
+.tab-pane{animation:paneIn .28s var(--ease-out) both;display:flex;flex-direction:column;gap:18px}
+@keyframes paneIn{
+  from{opacity:0;transform:translate3d(var(--pane-dx,0),0,0)}
+  to{opacity:1;transform:translate3d(0,0,0)}
+}
 .tab-head{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;flex-wrap:wrap}
 .tab-title{font-size:15px;font-weight:600;color:var(--fg);letter-spacing:-.01em}
 .tab-sub{color:var(--fg-3);font-size:12.5px;margin-top:3px;max-width:60ch}
 
-/* ── Destinations ────────────────────────────── */
+/* - Destinations --------------- */
 .dest-grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fill,minmax(330px,1fr))}
 .dcard{background:var(--bg-2);border:1px solid var(--line);border-radius:14px;padding:15px;
   display:flex;flex-direction:column;gap:13px;
@@ -663,7 +960,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .dest-add{appearance:none;background:transparent;border:1px dashed var(--line-2);border-radius:12px;
   color:var(--fg-3);font-size:13px;font-weight:500;cursor:pointer;
   display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;
-  min-height:140px;transition:all .2s var(--ease-out);font-family:inherit}
+  min-height:140px;transition:color .2s var(--ease-out),border-color .2s var(--ease-out),background .2s var(--ease-out);font-family:inherit}
 .dest-add:hover{color:var(--accent);border-color:color-mix(in oklch,var(--accent) 50%,transparent);
   background:color-mix(in oklch,var(--accent) 4%,transparent)}
 .dest-add-icon{width:36px;height:36px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;
@@ -723,7 +1020,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .dest-form-msg{min-height:1.2em;font-size:12px;margin-top:6px}
 .dest-form-msg .err{color:var(--danger)}
 
-/* ── Stats ───────────────────────────────────── */
+/* - Stats ------------------─ */
 .stats-big{display:grid;grid-template-columns:minmax(0,2fr) minmax(0,1fr);gap:12px}
 @media (max-width:880px){.stats-big{grid-template-columns:1fr}}
 .stat-card{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:14px;cursor:help;
@@ -759,7 +1056,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .stat-spark path[class$="-line"],.stat-spark path[id$="-line"]{
   transition:stroke .2s}
 
-/* ── OBS tab ─────────────────────────────────── */
+/* - OBS tab -----------------─ */
 .obs-grid{display:grid;gap:12px;grid-template-columns:minmax(0,1fr) minmax(0,1fr)}
 @media (max-width:880px){.obs-grid{grid-template-columns:1fr}}
 .obs-section{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:16px;
@@ -790,7 +1087,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .chat-dock-row select{flex:0 0 160px}
 .chat-dock-row input{flex:1 1 200px;min-width:160px}
 
-/* ── Overlay tab ─────────────────────────────── */
+/* - Overlay tab ---------------─ */
 .overlay-grid{display:grid;gap:14px;grid-template-columns:minmax(0,1.4fr) minmax(0,1fr)}
 @media (max-width:880px){.overlay-grid{grid-template-columns:1fr}}
 .overlay-section{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:16px;
@@ -803,7 +1100,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .overlay-files{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;margin-top:10px}
 .overlay-file{appearance:none;background:var(--surface);border:1px solid var(--line);border-radius:10px;
   padding:10px;display:flex;flex-direction:column;gap:8px;cursor:pointer;text-align:left;
-  position:relative;transition:all .15s var(--ease-out);color:inherit;font:inherit}
+  position:relative;transition:border-color .15s var(--ease-out),background .15s var(--ease-out),transform .15s var(--ease-out);color:inherit;font:inherit}
 .overlay-file:hover{border-color:var(--line-2);transform:translateY(-1px)}
 .overlay-file.selected{border-color:color-mix(in oklch,var(--accent) 60%,transparent);
   background:color-mix(in oklch,var(--accent) 6%,var(--surface));
@@ -821,7 +1118,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   border:1px solid color-mix(in oklch,var(--accent) 22%,var(--line));border-radius:8px;
   font-size:12px;color:var(--fg-2)}
 
-/* ── Overlay gallery ────────────────────────────── */
+/* - Overlay gallery --------------- */
 .ovg-grid{display:grid;grid-template-columns:minmax(0,1.55fr) minmax(0,1fr);gap:14px;margin-top:6px}
 @media (max-width:980px){.ovg-grid{grid-template-columns:1fr}}
 .ovg-stage{position:relative;width:100%;aspect-ratio:16/9;margin-top:10px;overflow:hidden;
@@ -830,8 +1127,17 @@ input,select,textarea{font-family:inherit;color:inherit}
   linear-gradient(45deg,#0a0c10 25%,#0e1116 25%,#0e1116 75%,#0a0c10 75%);
   background-size:22px 22px;background-position:0 0,11px 11px}
 .ovg-scale{position:absolute;top:0;left:0;width:1920px;height:1080px;transform-origin:top left}
-.ovg-scale iframe{width:1920px;height:1080px;border:0;background:transparent;display:block}
+/* color-scheme:normal is load-bearing: the dashboard root sets
+   color-scheme:dark, which makes a transparent child iframe paint an opaque
+   (white) canvas in Chromium - covering the checkerboard stage. Opting the
+   overlay iframes back to normal restores true transparency so the overlay
+   sits on the stage, exactly as it will over video in OBS. */
+.ovg-scale iframe{width:1920px;height:1080px;border:0;background:transparent;display:block;
+  color-scheme:normal}
 .ovg-list{display:flex;flex-direction:column;gap:7px;padding:10px 14px 14px;overflow-y:auto;max-height:520px}
+.ov-dir-row{display:flex;gap:8px;align-items:center;margin-top:8px}
+.ov-dir-row input{flex:1;min-width:0}
+.ov-dir-row .ic-btn{flex:0 0 auto}
 .ovg-card{appearance:none;text-align:left;background:var(--surface);border:1px solid var(--line);
   border-radius:10px;padding:11px 13px;cursor:pointer;display:flex;flex-direction:column;gap:3px;
   transition:border-color .12s,transform .12s;position:relative}
@@ -845,7 +1151,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .ovg-card-tag:empty{display:none}
 .ovg-empty{padding:26px 16px;text-align:center;color:var(--fg-4);font-size:13px;line-height:1.6}
 
-/* ── Overlay Studio ─────────────────────────────── */
+/* - Overlay Studio ---------------─ */
 .st-toolbar{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .st-toolbar .ic-input{max-width:200px;height:34px}
 .st-grid{display:grid;grid-template-columns:210px minmax(0,1fr) 268px;gap:12px;margin-top:6px;
@@ -993,7 +1299,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .st-switch input:checked + .tr{background:var(--accent)}
 .st-switch input:checked + .tr + .kn{transform:translateX(18px)}
 
-/* ── Live phase caption + microinteractions ─────────── */
+/* - Live phase caption + microinteractions -----─ */
 /* Live phase caption - sits in the chrome (NOT over the canvas, so it
    never reads as part of the overlay). */
 .ph-cap{display:inline-flex;align-items:center;gap:7px;padding:5px 11px;border-radius:999px;
@@ -1033,7 +1339,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 /* gentle fade when panels re-render */
 @keyframes st-fade-in{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
 .st-props-body{animation:st-fade-in .2s var(--ease-out)}
-.st-canvas-scale iframe{width:1920px;height:1080px;border:0;background:transparent;display:block;pointer-events:none}
+.st-canvas-scale iframe{width:1920px;height:1080px;border:0;background:transparent;display:block;pointer-events:none;color-scheme:normal}
 .st-hit{position:absolute;inset:0}
 .st-hit .st-box{position:absolute;border:2px solid transparent;cursor:move;border-radius:4px}
 .st-hit .st-box:hover{border-color:color-mix(in oklch,var(--accent) 45%,transparent)}
@@ -1088,11 +1394,11 @@ input,select,textarea{font-family:inherit;color:inherit}
 .form-block-l{font-size:12.5px;color:var(--fg-2);font-weight:500}
 .form-block .ic-input{max-width:180px}
 
-/* ── Profiles ────────────────────────────────── */
+/* - Profiles ----------------- */
 .profile-list{display:flex;flex-direction:column;gap:4px}
 .profile-row{display:flex;align-items:center;gap:16px;padding:11px 14px;background:var(--bg-2);
   border:1px solid var(--line);border-radius:9px;cursor:pointer;text-align:left;appearance:none;
-  color:inherit;font:inherit;transition:all .12s var(--ease-out)}
+  color:inherit;font:inherit;transition:border-color .12s var(--ease-out),background .12s var(--ease-out)}
 .profile-row:hover{border-color:color-mix(in oklch,var(--accent) 40%,var(--line-2))}
 .profile-row.current{border-color:color-mix(in oklch,var(--accent) 60%,transparent);
   background:color-mix(in oklch,var(--accent) 7%,var(--bg-2));
@@ -1131,7 +1437,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .profile-new .ic-input{flex:1;min-width:0}
 .profile-new .ic-input.mono{max-width:110px;font-family:'JetBrains Mono',monospace}
 
-/* ── System ──────────────────────────────────── */
+/* - System ------------------ */
 .sys-section{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:16px}
 /* Danger zone - visually fenced from Save with an err-tinted top border
    so a click reaching for Save can't drift into Reset by accident. */
@@ -1190,7 +1496,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   transition:opacity .2s ease,transform .2s ease;pointer-events:none;white-space:nowrap}
 .st-synced.on{opacity:.9;transform:none}
 
-/* ── Logs ────────────────────────────────────── */
+/* - Logs ------------------- */
 .logs-head{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:10px}
 .logs-wrap{position:relative;min-height:420px}
 .logs{background:#050608;border:1px solid var(--line);border-radius:10px;padding:10px 14px;
@@ -1214,7 +1520,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 .spark-fill{fill:url(#sparkGrad)}
 .spark-line{fill:none;stroke:var(--accent);stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round}
 
-/* ── Spotlight tour ─────────────────────────────────────
+/* - Spotlight tour ------------------─
    Layout:
      #tour      = full-screen layer (pointer-events: none so clicks
                   fall through everywhere except the tooltip)
@@ -1342,6 +1648,35 @@ input,select,textarea{font-family:inherit;color:inherit}
 .row-end{display:flex;justify-content:flex-end;gap:8px}
 .spacer{flex:1}
 [hidden]{display:none !important}
+
+/* Respect the OS "reduce motion" setting. The dashboard leans on several
+   always-running decorative loops - the aurora drift behind the hero, the
+   live-dot pulse rings, the arming shimmer - which are exactly the kind of
+   sustained movement that triggers vestibular discomfort. Kill those, and
+   collapse one-shot transitions/animations to near-instant so state still
+   changes visibly without sweeping. Last in the sheet so it wins on order;
+   the functional state machine is untouched - only the motion is. */
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{
+    animation-duration:.001ms !important;
+    animation-iteration-count:1 !important;
+    transition-duration:.001ms !important;
+    scroll-behavior:auto !important;
+  }
+}
+/* Reduced transparency: the glass surfaces stop leaning on blur and become
+   frosted/solid so text stays legible when the OS asks for it (Apple HIG). */
+@media (prefers-reduced-transparency: reduce){
+  .dcard-act{backdrop-filter:none;-webkit-backdrop-filter:none;background:var(--surface-3)}
+  .dcard-act:hover{background:color-mix(in oklch,#fff 6%,var(--surface-3))}
+  .st-modal{background:rgba(4,6,10,.97);backdrop-filter:none}
+  .ic-modal-backdrop{background:rgba(0,0,0,.84);backdrop-filter:none}
+}
+/* Higher contrast: firm up the hairline borders and lift the faintest ink,
+   token-level so every bordered surface benefits from one change. */
+@media (prefers-contrast: more){
+  :root{--line:rgba(255,255,255,.24);--line-2:rgba(255,255,255,.40);--fg-4:oklch(0.63 0.018 230)}
+}
 </style>
 </head>
 <body>
@@ -1355,7 +1690,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 
 <div class="ic-shell">
 
-<!-- ── Header ───────────────────────────────────── -->
+<!-- - Header ------------------─ -->
 <header class="ic-header" id="hdr-bar" hidden>
   <div class="ic-brand">
     <span class="ic-brand-mark">InstantClone</span>
@@ -1378,7 +1713,7 @@ input,select,textarea{font-family:inherit;color:inherit}
     </span>
     <span class="ic-pill" id="hdr-codec" hidden><span class="mono" id="hdr-codec-v">-</span></span>
     <span class="ic-pill ok" id="hdr-ebroadcast" hidden title="Enhanced Broadcasting active - multi-track simulcast is being forwarded bit-faithfully to Twitch and flattened to the primary track for any non-Twitch destinations. Twitch's transcoder serves the full quality ladder to viewers.">⚡ Enhanced Broadcasting</span>
-    <span class="ic-pill ok" id="hdr-dualformat" hidden title="Twitch Dual Format is live - a vertical 9:16 canvas is on the wire. Any destination set to Vertical is forwarding it (YouTube Shorts, Kick mobile, etc.).">▯ Dual Format</span>
+    <span class="ic-pill ok" id="hdr-dualformat" hidden title="Twitch Dual Format is live - a vertical 9:16 canvas is on the wire. Any destination set to Vertical is forwarding it (YouTube Shorts, Kick mobile, etc.)."><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" class="ic-pill-ic"><rect x="0.8" y="4.5" width="8.2" height="6.6" rx="1.2"/><rect x="10" y="2.4" width="4.4" height="11.2" rx="1.2"/></svg>Dual Format</span>
     <span class="ic-pill bad" id="hdr-backpressure" hidden title="A destination's upload can't keep up with OBS's bitrate. Lower OBS bitrate or check upload speed.">⚠ Upload bottleneck</span>
     <span class="ic-pill warn" id="hdr-twitch-cap" hidden>⚠ <span id="hdr-twitch-cap-v">Twitch · Source-Only at 10 Mbps</span></span>
     <a id="hdr-update" class="ic-pill" href="#" hidden title="Open the updater" onclick="openUpdateInAbout();return false;" style="cursor:pointer">⬆ <span id="hdr-update-v">update available</span></a>
@@ -1388,87 +1723,211 @@ input,select,textarea{font-family:inherit;color:inherit}
   </div>
 </header>
 
-<!-- ── Wizard (only when !configured) ──────────── -->
+<!-- - Encoder compatibility (only when something is actually wrong) - -->
+<div id="compat-warn" role="status" aria-live="polite" hidden>
+  <span class="cw-ic" aria-hidden="true">⚠</span>
+  <span class="cw-text" id="compat-warn-text"></span>
+  <button class="cw-x" id="compat-warn-x" title="Dismiss until this changes" aria-label="Dismiss compatibility warning" onclick="dismissCompatWarning()">✕</button>
+</div>
+
+<!-- - Wizard (only when !configured) ------ -->
+<!-- Multi-step questionnaire. Each `.wiz-step` is one screen; the JS state
+     machine (wizStepIds / renderWizStep / wizNext / wizBack) shows one at a
+     time. The Twitch step is dynamic - it only joins the sequence when the
+     chosen platform is Twitch. Every referenced id is preserved from the
+     old single-screen wizard so the save/test/tile logic is untouched. -->
 <section class="ic-card wizard-card" id="wizard" hidden>
-  <h2>Welcome to InstantClone</h2>
-  <p class="lead">Two short steps and you're live.</p>
+  <div class="wiz-head">
+    <h2 id="wiz-title">Welcome to InstantClone</h2>
+    <p class="lead" id="wiz-lead">A few quick questions and you're live.</p>
+    <div class="wiz-progress" id="wiz-progress" aria-hidden="true"></div>
+  </div>
 
-  <!-- Step 1: how OBS finds us -->
-  <div class="wizard-step-label">Step 1 &middot; Connect OBS</div>
-  <div class="wizard-obs-options">
-    <div class="wizard-obs-card" id="wiz-obs-service">
-      <div class="wizard-obs-title">
-        <span>⚡ Register as an OBS service</span>
-        <span class="wizard-obs-badge">recommended</span>
-      </div>
-      <p class="wizard-obs-body">One click adds InstantClone to OBS's Service dropdown.</p>
-      <div class="wizard-obs-action">
-        <button class="ic-btn ic-btn-primary" id="wiz-obs-register-btn" onclick="wizRegisterObs()">Register with OBS</button>
-      </div>
-      <p class="wizard-obs-status muted" id="wiz-obs-status">Checking your OBS install&hellip;</p>
+  <!-- STEP 1: how OBS finds us -->
+  <div class="wiz-step" data-wstep="obs">
+    <div class="wiz-step-h">
+      <div class="wiz-step-t">How does OBS reach InstantClone?</div>
+      <div class="wiz-step-s">Pick whichever fits your setup - you can switch later on the OBS tab.</div>
+    </div>
+    <!-- Guided 2-step flow: set OBS up, then verify. A step expands when active
+         and collapses to a check when done; a "Step N" eyebrow turns green as it
+         completes. [data-state] = locked | active | done; see wizObs* in JS. -->
+    <ol class="obs-flow" id="obs-flow">
+      <li class="obs-node" data-node="connect" data-state="active">
+        <div class="obs-node-main">
+          <button type="button" class="obs-node-head" onclick="wizObsReopen('connect')">
+            <span class="obs-eyebrow">Step 1</span>
+            <span class="obs-node-title">Point OBS at InstantClone</span>
+          </button>
+          <div class="obs-node-clip"><div class="obs-node-body">
+            <p class="obs-node-hint">Two ways to connect. The recommended one takes a click.</p>
+            <div class="wizard-obs-options">
+              <div class="wizard-obs-card obs-recommended" id="wiz-obs-service">
+                <div class="wizard-obs-title">
+                  <span>Register as an OBS service</span>
+                  <span class="wizard-obs-badge">recommended</span>
+                </div>
+                <p class="wizard-obs-body">Adds InstantClone to OBS's <b>Service</b> dropdown, so you just pick it.</p>
+                <div class="wiz-callout warn" id="wiz-obs-close-warn" hidden>
+                  <span class="ic" aria-hidden="true">!</span>
+                  <span><b>Close OBS first.</b> It's open right now, and it overwrites its service list when it quits, so register while it's shut or the entry won't stick.</span>
+                </div>
+                <div class="wizard-obs-action">
+                  <button class="ic-btn ic-btn-primary" id="wiz-obs-register-btn" onclick="wizRegisterObs()">Register with OBS</button>
+                </div>
+                <p class="wizard-obs-status muted" id="wiz-obs-status">Checking your OBS install&hellip;</p>
+                <p class="wizard-obs-after">Then reopen OBS and choose <b>InstantClone</b> in <b>Settings &rarr; Stream</b>.</p>
+                <details class="ic-disclose">
+                  <summary>How it works</summary>
+                  <div class="ic-disclose-body">
+                    <p>InstantClone appears next to Twitch / YouTube in OBS's <b>Settings &rarr; Stream &rarr; Service</b> list. Multi-track Video "Auto" works out of the box, so pick InstantClone and stream.</p>
+                    <p>Edits OBS's <code class="mono">services.json</code> in <code class="mono">%APPDATA%</code> with a <code class="mono">.bak</code> backup. Unregister any time from the <b>OBS</b> tab.</p>
+                  </div>
+                </details>
+              </div>
+              <div class="obs-or">or</div>
+              <div class="wizard-obs-card" id="wiz-obs-custom">
+                <div class="wizard-obs-title">
+                  <span>Custom RTMP server</span>
+                  <span class="obs-norestart">no restart</span>
+                </div>
+                <p class="wizard-obs-body">Prefer pasting a URL? Set <b>Service: Custom</b> in OBS. It applies live, nothing to close.</p>
+                <div class="wizard-obs-copy-row">
+                  <span class="muted">Server</span>
+                  <code class="mono" id="wiz-obs-srv">rtmp://127.0.0.1:1935/live</code>
+                  <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'wiz-obs-srv','Server URL')">Copy</button>
+                </div>
+                <div class="wizard-obs-copy-row">
+                  <span class="muted">Stream key</span>
+                  <code class="mono">anything (e.g. main)</code>
+                </div>
+                <details class="ic-disclose">
+                  <summary>When to pick this</summary>
+                  <div class="ic-disclose-body">
+                    <p>Older OBS (before 30.2), multi-RTMP plugins, or non-OBS encoders. Your real platform key goes in the next step, not in OBS.</p>
+                  </div>
+                </details>
+              </div>
+            </div>
+            <button class="ic-btn ic-btn-primary obs-advance" onclick="wizObsAdvance('connect')">I've set this up in OBS &rarr;</button>
+          </div></div>
+        </div>
+      </li>
+
+      <li class="obs-node" data-node="verify" data-state="locked">
+        <div class="obs-node-main">
+          <button type="button" class="obs-node-head" onclick="wizObsReopen('verify')">
+            <span class="obs-eyebrow">Step 2 · Optional</span>
+            <span class="obs-node-title">Check it's connected</span>
+          </button>
+          <div class="obs-node-clip"><div class="obs-node-body">
+            <!-- Local-only: passive read of ingest, no destination saved yet, OBS
+                 points at 127.0.0.1, so nothing can reach a platform during this. -->
+            <div class="wiz-obs-verify" id="wiz-obs-verify" data-state="idle">
+              <p class="wov-sub">A private local test. We just watch for OBS's video arriving here, so <b>nothing is sent to Twitch or any platform.</b></p>
+              <div class="wov-body">
+                <button class="ic-btn ic-btn-primary wov-start" onclick="wizStartObsCheck()">Check connection</button>
+                <div class="wov-waiting">
+                  <span class="wov-spinner" aria-hidden="true"></span>
+                  <span class="wov-status">In OBS, click <b>Start Streaming</b> now, watching for it&hellip;</span>
+                  <button class="ic-btn ic-btn-ghost wov-cancel" onclick="wizStopObsCheck()">Cancel</button>
+                </div>
+                <div class="wov-ok">
+                  <span class="wov-check" aria-hidden="true">&#10003;</span>
+                  <span class="wov-status-ok">OBS is reaching InstantClone. Nothing left your PC. You can stop streaming now.</span>
+                </div>
+              </div>
+            </div>
+            <button class="ic-btn ic-btn-primary obs-advance" id="wiz-obs-confirm" onclick="wizObsAdvance('connect')">I've set this up in OBS &rarr;</button>
+          </div></div>
+        </div>
+      </li>
+    </ol>
+  </div>
+
+  <!-- STEP 2: platform -->
+  <div class="wiz-step" data-wstep="platform" hidden>
+    <div class="wiz-step-h">
+      <div class="wiz-step-t">Which platform are you streaming to?</div>
+      <div class="wiz-step-s">Pick the one to get you live now - you can stream to several at once.</div>
+    </div>
+    <label id="w-platform-label" class="sr-only">Streaming platform</label>
+    <div class="w-platform-tiles" id="w-platform-tiles" role="radiogroup" aria-labelledby="w-platform-label"></div>
+    <select id="w-platform" hidden></select>
+    <div class="wiz-callout info">
+      <span class="ic" aria-hidden="true">+</span>
+      <span>This is just your first destination. Add YouTube, Kick, and more, plus a local test sink, any time from the <b>Destinations</b> tab.</span>
+    </div>
+  </div>
+
+  <!-- STEP 3: stream key -->
+  <div class="wiz-step" data-wstep="key" hidden>
+    <div class="wiz-step-h">
+      <div class="wiz-step-t">Paste your <span id="w-key-platform-name">platform</span> stream key</div>
+      <div class="wiz-step-s">This is the real key from your platform dashboard. It never leaves this PC except to that platform.</div>
+    </div>
+    <div id="w-custom-wrap" hidden>
+      <label for="w-custom">Custom RTMP URL (without the stream key)</label>
+      <input id="w-custom" class="ic-input mono" placeholder="rtmp://127.0.0.1:1936/live">
+      <div class="w-hint">Either put the stream key in the field below (recommended) or paste the full URL with the key embedded.</div>
+    </div>
+    <label for="w-key">Stream key <span class="muted" id="w-key-optional-hint" hidden>(optional for Custom if URL has key)</span></label>
+    <input id="w-key" type="password" class="ic-input mono" placeholder="paste your stream key" autocomplete="off">
+    <div id="w-key-help" class="w-key-help" hidden></div>
+    <div class="wiz-callout tip">
+      <span class="ic" aria-hidden="true">&#9733;</span>
+      <span><span class="wiz-callout-t">Playing ranked behind a delay?</span>While the delay is live, a <b>Cut after this airs</b> button lets your reaction air in full, then cuts to live on its own, no counting seconds.</span>
+    </div>
+  </div>
+
+  <!-- STEP 4 (Twitch only): Enhanced Broadcasting + VOD audio -->
+  <div class="wiz-step" data-wstep="twitch" hidden>
+    <div class="wiz-step-h">
+      <div class="wiz-step-t">Twitch extras <span class="muted" style="font-weight:400;font-size:13px">(optional)</span></div>
+      <div class="wiz-step-s">Both are optional. Skip straight to Save &amp; Start if you just want to go live.</div>
+    </div>
+
+    <div class="wiz-feature">
+      <div class="wiz-feature-h">Enhanced Broadcasting <span class="wiz-tag wiz-tag-twitch">Twitch feature</span></div>
+      <p class="wiz-feature-b">Twitch's multi-track quality ladder (1080p / 720p / 480p&hellip;) so every viewer gets a smooth stream. <b>It just works</b> - InstantClone forwards it untouched. Nothing to set here.</p>
       <details class="ic-disclose">
-        <summary>How it works</summary>
+        <summary>How to turn it on in OBS</summary>
         <div class="ic-disclose-body">
-          <p>InstantClone appears next to Twitch / YouTube in OBS's <b>Settings &rarr; Stream &rarr; Service</b> list. Multi-track Video "Auto" works out of the box &mdash; pick InstantClone, restart OBS, and stream.</p>
-          <p>Edits OBS's <code class="mono">services.json</code> in <code class="mono">%APPDATA%</code> with a <code class="mono">.bak</code> backup. You can unregister any time from the <b>OBS</b> tab.</p>
+          <p><b>In OBS:</b> if you registered InstantClone as a service (previous step), set <b>Settings &rarr; Output &rarr; Video Encoder</b> to <b>Multi-track Video</b> with <b>Auto</b> - EB engages on its own.</p>
+          <p>On Custom RTMP, open the <b>InstantClone dashboard</b> after setup and use <b>System &rarr; Behavior &rarr; OBS quick launch</b> - it starts OBS with the one flag EB needs.</p>
         </div>
       </details>
     </div>
-    <div class="wizard-obs-card" id="wiz-obs-custom">
-      <div class="wizard-obs-title"><span>🔧 Custom RTMP server</span></div>
-      <p class="wizard-obs-body">Paste these in <b>OBS &rarr; Settings &rarr; Stream &rarr; Service: Custom</b>.</p>
-      <div class="wizard-obs-copy-row">
-        <span class="muted">Server</span>
-        <code class="mono" id="wiz-obs-srv">rtmp://127.0.0.1:1935/live</code>
-        <button class="ic-btn ic-btn-ghost" onclick="copyEl('wiz-obs-srv','Server URL')">Copy</button>
+
+    <label class="wiz-feature wiz-feature-toggle">
+      <input type="checkbox" id="w-vod-audio">
+      <div>
+        <div class="wiz-feature-h" style="margin:0">Save a VOD audio track <span class="wiz-tag wiz-tag-twitch">Twitch feature</span></div>
+        <p class="wiz-feature-b">A second audio track on your Twitch VOD - handy for stripping copyrighted music from the <b>recording</b> while your live audio stays intact.</p>
       </div>
-      <div class="wizard-obs-copy-row">
-        <span class="muted">Stream key</span>
-        <code class="mono">anything (e.g. main)</code>
-      </div>
-      <details class="ic-disclose">
-        <summary>When to pick this</summary>
-        <div class="ic-disclose-body">
-          <p>Older OBS (before 30.2), multi-RTMP plugins, or non-OBS encoders. The real platform stream key goes in Step 2 &mdash; not in OBS.</p>
-        </div>
-      </details>
+    </label>
+    <div id="w-vod-how" hidden class="wiz-vod-how">
+      <div class="wiz-vod-how-t">Three steps <b>in OBS</b> (after this wizard):</div>
+      <ol>
+        <li><b>Settings &rarr; Stream:</b> Service = <b>Custom&hellip;</b>, Server = the URL shown on the <b>InstantClone dashboard's OBS tab</b>, Key = <code class="mono">main</code></li>
+        <li><b>Settings &rarr; Output:</b> Output Mode = <b>Advanced</b>, then tick <b>VOD Track</b> under Streaming</li>
+        <li><b>Close OBS</b>, then reopen it. (OBS can't change this while running.)</li>
+      </ol>
+      <div class="w-hint">We'll remember the choice - these are the OBS-side steps you do once.</div>
     </div>
   </div>
 
-  <!-- Step 2: destination -->
-  <div class="wizard-step-label">Step 2 &middot; Where to send your stream</div>
-  <label for="w-platform">Streaming platform</label>
-  <select id="w-platform" class="ic-input"></select>
-  <div id="w-custom-wrap" hidden>
-    <label for="w-custom">Custom RTMP URL (without the stream key)</label>
-    <input id="w-custom" class="ic-input mono" placeholder="rtmp://127.0.0.1:1936/live">
-    <div class="w-hint">Either put the stream key in the field below (recommended) or paste the full URL with the key embedded.</div>
-  </div>
-  <label for="w-key">Stream key <span class="muted" id="w-key-optional-hint" hidden>(optional for Custom if URL has key)</span></label>
-  <input id="w-key" type="password" class="ic-input mono" placeholder="paste your stream key" autocomplete="off">
-  <div id="w-key-help" class="w-key-help" hidden></div>
-  <!-- Competitive-streamer teaser: the "cut after this airs" flow is the
-       single biggest quality-of-life trick in the app, so it gets told
-       here (before first stream) instead of waiting to be discovered. -->
-  <div class="tour-tip" style="margin-top:12px">
-    <strong>Playing ranked behind a delay?</strong> Once your delay is live, a
-    <b>⏱ Cut after this airs</b> button appears next to Cut. Press it the moment
-    your match reaction ends - InstantClone lets that moment reach your viewers,
-    then cuts to live on its own. No counting seconds in your head.
-  </div>
-  <div class="wizard-row">
-    <button class="ic-btn ic-btn-primary" onclick="saveWizard()">Save &amp; Start</button>
-    <button class="ic-btn ic-btn-ghost" onclick="testConn()">Test connection</button>
-  </div>
   <div id="w-msg"></div>
-  <div style="margin-top:14px;text-align:center">
-    <button onclick="skipWizard()" style="background:none;border:0;color:var(--fg-3);font:inherit;font-size:12px;cursor:pointer;padding:6px 10px;text-decoration:underline;text-underline-offset:3px;text-decoration-color:var(--line)" onmouseover="this.style.color='var(--fg-3)'" onmouseout="this.style.color='var(--fg-3)'">
-      Not now &mdash; let me look around first
-    </button>
+
+  <div class="wiz-nav">
+    <button class="wiz-skip" onclick="skipWizard()">Skip setup</button>
+    <span class="spacer"></span>
+    <button class="ic-btn ic-btn-ghost" id="wiz-back" onclick="wizBack()" hidden>&larr; Back</button>
+    <button class="ic-btn ic-btn-primary" id="wiz-next" onclick="wizNext()">Next &rarr;</button>
   </div>
 </section>
 
-<!-- ── Hero ─────────────────────────────────────── -->
+<!-- - Hero -------------------─ -->
 <section class="ic-card hero-card" id="hero" hidden>
   <div class="hero">
     <div class="hero-readout" id="hero-readout" data-state="off">
@@ -1527,7 +1986,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   </div>
 </section>
 
-<!-- ── Tabs ─────────────────────────────────────── -->
+<!-- - Tabs -------------------─ -->
 <nav class="tabs" id="tabs" hidden>
   <span class="tab-ind" id="tab-ind"></span>
   <button class="tab on" data-tab="destinations">
@@ -1755,14 +2214,14 @@ input,select,textarea{font-family:inherit;color:inherit}
           <div class="ic-label">Server URL</div>
           <div class="copy-block">
             <code class="mono" id="obs-srv">rtmp://127.0.0.1:1935/live</code>
-            <button class="ic-btn ic-btn-ghost" onclick="copyEl('obs-srv','Server URL')">Copy</button>
+            <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'obs-srv','Server URL')">Copy</button>
           </div>
         </div>
         <div class="obs-manual-field">
           <div class="ic-label">Stream key</div>
           <div class="copy-block">
             <code class="mono">main</code>
-            <button class="ic-btn ic-btn-ghost" onclick="copyText('main','Stream key')">Copy</button>
+            <button class="ic-btn ic-btn-ghost" onclick="copyText(this,'main','Stream key')">Copy</button>
           </div>
           <div class="tab-sub" style="margin-top:6px">Any string works - the real platform key lives in <b>Destinations</b>.</div>
         </div>
@@ -1774,7 +2233,7 @@ input,select,textarea{font-family:inherit;color:inherit}
         <div class="rec"><div class="rec-k">Output &rarr; Video &rarr; Keyframe Interval</div><div class="rec-v">2 s</div><div class="rec-why">Controls how fast delay cuts can happen.</div></div>
         <div class="rec"><div class="rec-k">Output &rarr; Encoder</div><div class="rec-v">x264 / NVENC</div><div class="rec-why">Anything modern - InstantClone passes through untouched.</div></div>
         <div class="rec"><div class="rec-k">Bitrate</div><div class="rec-v">&le; 80% of upload</div><div class="rec-why">Leave headroom or the "Upload bottleneck" pill lights up.</div></div>
-        <div class="rec"><div class="rec-k">Streaming to Kick?</div><div class="rec-v">CBR + 2 s keyframe</div><div class="rec-why">The rules that actually matter for Kick. <a href="#" onclick="event.preventDefault();$('rec-kick-detail').open=!$('rec-kick-detail').open">details</a></div></div>
+        <div class="rec"><div class="rec-k">Streaming to Kick?</div><div class="rec-v">CBR + 2 s keyframe</div><div class="rec-why">The rules that actually matter for Kick. <a href="#" onclick="event.preventDefault();toggleDisclosure('rec-kick-detail')">details</a></div></div>
       </div>
       <details class="ic-disclose" id="rec-kick-detail">
         <summary>Kick requirements (and the B-frames myth)</summary>
@@ -1801,7 +2260,7 @@ input,select,textarea{font-family:inherit;color:inherit}
       </div>
       <div class="copy-block" style="margin-top:8px">
         <code class="mono" id="chat-dock-url">enter your channel name above</code>
-        <button class="ic-btn ic-btn-ghost" onclick="copyEl('chat-dock-url','Chat URL')">Copy</button>
+        <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'chat-dock-url','Chat URL')">Copy</button>
       </div>
       <details class="ic-disclose">
         <summary>How to add it to OBS</summary>
@@ -1848,7 +2307,7 @@ input,select,textarea{font-family:inherit;color:inherit}
         </div>
         <div class="copy-block" style="margin-top:12px">
           <code class="mono" id="ovg-url">select an overlay</code>
-          <button class="ic-btn ic-btn-primary" id="ovg-copy" onclick="Studio.copyGallery()">Copy URL</button>
+          <button class="ic-btn ic-btn-primary" id="ovg-copy" onclick="Studio.copyGallery(this)">Copy URL</button>
         </div>
         <div class="ic-hint" id="ovg-copyhint" style="margin-top:6px;font-size:11px;color:var(--fg-4)">Paste this into OBS as a Browser Source.</div>
         <div class="st-rowbtns" id="ovg-actions" style="margin-top:10px"></div>
@@ -1865,9 +2324,15 @@ input,select,textarea{font-family:inherit;color:inherit}
       <div class="tab-sub">Add as an OBS Custom Browser Dock to control delay from within OBS. Recommended size: ~290 × 360.</div>
       <div class="copy-block">
         <code class="mono" id="dock-url">/dock</code>
-        <button class="ic-btn ic-btn-ghost" onclick="copyEl('dock-url','Dock URL')">Copy</button>
+        <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'dock-url','Dock URL')">Copy</button>
       </div>
-      <div class="tab-sub" style="margin-top:10px">Overlays live in <code class="mono" id="ov-dir-display">overlays/</code>. Hand-written <code class="mono">.html</code> files dropped there still work as before.</div>
+      <div class="ic-label" style="margin-top:18px">Overlays folder</div>
+      <div class="tab-sub">Drop your own <code class="mono">.html</code> files here and they appear in the picker above. <span id="ov-dir-display" hidden></span></div>
+      <div class="ov-dir-row">
+        <input id="s-ovdir" class="ic-input mono" placeholder="overlays/">
+        <button class="ic-btn ic-btn-primary" id="ov-dir-save" onclick="saveOverlaysDir(this)">Save</button>
+        <button class="ic-btn ic-btn-ghost" onclick="reveal('overlays',this)">Open</button>
+      </div>
     </section>
   </div>
 
@@ -1880,14 +2345,14 @@ input,select,textarea{font-family:inherit;color:inherit}
           <div class="tab-title" style="font-size:15px">Overlay Studio</div>
         </div>
         <div class="st-toolbar">
-          <button class="ic-btn ic-btn-ghost st-icobtn" id="st-undo" title="Undo (Ctrl+Z)" onclick="Studio.undo()">↶</button>
-          <button class="ic-btn ic-btn-ghost st-icobtn" id="st-redo" title="Redo (Ctrl+Shift+Z)" onclick="Studio.redo()">↷</button>
+          <button class="ic-btn ic-btn-ghost st-icobtn" id="st-undo" title="Undo (Ctrl+Z)" aria-label="Undo" onclick="Studio.undo()">↶</button>
+          <button class="ic-btn ic-btn-ghost st-icobtn" id="st-redo" title="Redo (Ctrl+Shift+Z)" aria-label="Redo" onclick="Studio.redo()">↷</button>
           <input id="st-name" class="ic-input" placeholder="Overlay name" value="My overlay">
           <button class="ic-btn ic-btn-primary" id="st-save" onclick="Studio.save()" title="Overwrite this overlay">Save</button>
           <button class="ic-btn ic-btn-ghost" onclick="Studio.saveAsNew()" title="Save a separate copy with a new URL">Save as new</button>
-          <button class="ic-btn ic-btn-ghost" onclick="Studio.copyUrl()">Copy URL</button>
+          <button class="ic-btn ic-btn-ghost" onclick="Studio.copyUrl(this)">Copy URL</button>
           <div class="st-menu">
-            <button class="ic-btn ic-btn-ghost st-icobtn" title="More" onclick="Studio.toggleMenu(event)">⋯</button>
+            <button class="ic-btn ic-btn-ghost st-icobtn" title="More" aria-label="More options" onclick="Studio.toggleMenu(event)">⋯</button>
             <div class="st-menu-pop" id="st-menu-pop" hidden>
               <button onclick="Studio.menu('rename')">Rename</button>
               <button onclick="Studio.menu('export')">Export .json</button>
@@ -1960,7 +2425,6 @@ input,select,textarea{font-family:inherit;color:inherit}
   <div class="tab-head">
     <div>
       <div class="tab-title">System</div>
-      <div class="tab-sub">Behavior, network, buffer, notifications, diagnostics.</div>
     </div>
   </div>
   <div class="restart-banner hidden" id="restart-banner">
@@ -1998,10 +2462,28 @@ input,select,textarea{font-family:inherit;color:inherit}
       <div style="margin-top:14px;display:flex;flex-direction:column;gap:14px">
         <div style="display:flex;align-items:flex-start;gap:14px">
           <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
+            <input type="checkbox" id="s-startup" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
+            <div>
+              <div style="font-weight:600">Start with Windows</div>
+              <div class="tab-sub" style="margin-top:2px">Launches at login and waits in the tray, so OBS always has somewhere to publish.</div>
+            </div>
+          </label>
+        </div>
+        <div style="display:flex;align-items:flex-start;gap:14px">
+          <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
+            <input type="checkbox" id="s-open-dash" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
+            <div>
+              <div style="font-weight:600">Open dashboard on launch</div>
+              <div class="tab-sub" style="margin-top:2px">Opens this page in your browser each time the app starts. Turn off to stay in the tray.</div>
+            </div>
+          </label>
+        </div>
+        <div style="display:flex;align-items:flex-start;gap:14px">
+          <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
             <input type="checkbox" id="s-auto-arm" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
               <div style="font-weight:600">Pre-arm delay on stream start</div>
-              <div class="tab-sub" style="margin-top:2px">Start filling the delay buffer the moment OBS starts streaming. Useful if you always stream with delay.</div>
+              <div class="tab-sub" style="margin-top:2px">Fills the buffer as soon as OBS connects. Best if you always stream delayed.</div>
             </div>
           </label>
         </div>
@@ -2010,7 +2492,7 @@ input,select,textarea{font-family:inherit;color:inherit}
             <input type="checkbox" id="s-auto-act" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
               <div style="font-weight:600">Auto-activate when buffer ready</div>
-              <div class="tab-sub" style="margin-top:2px">Skip the manual "Activate" step. Fires every time you arm (manual, profile, or pre-arm). Cut still sticks - the next arm re-enables it.</div>
+              <div class="tab-sub" style="margin-top:2px" title="Applies to every arm: manual, profile, or pre-arm. A cut still sticks; the next arm re-enables the delay.">Skip the manual Activate step - every arm activates once the buffer is ready.</div>
             </div>
           </label>
         </div>
@@ -2062,8 +2544,19 @@ input,select,textarea{font-family:inherit;color:inherit}
       <div class="ic-label">LAN access</div>
       <div class="tab-sub">By default both ports are bound to 127.0.0.1. Open them to your LAN if OBS or your browser run on a different machine.</div>
       <div class="checkbox-row" style="margin-top:10px">
-        <label><input type="checkbox" id="s-ibind"> Allow LAN to publish</label>
-        <label><input type="checkbox" id="s-wbind"> Allow LAN to access Web UI</label>
+        <label><input type="checkbox" id="s-ibind" onchange="renderLanWarning()"> Allow LAN to publish</label>
+        <label><input type="checkbox" id="s-wbind" onchange="renderLanWarning()"> Allow LAN to access Web UI</label>
+      </div>
+      <!-- Shown only while the web UI is actually exposed. The control API
+           has no authentication - the CSRF guard stops cross-origin browser
+           POSTs, but a direct request (curl, script) carries no Origin
+           header and is allowed through by design so CLI and Stream Deck
+           keep working. On loopback that is exactly right; on a LAN it
+           means every machine on the network can drive the delay. Say so
+           rather than letting someone discover it. -->
+      <div id="lan-warn" class="lan-warn" hidden>
+        <span class="lw-ic" aria-hidden="true">⚠</span>
+        <span id="lan-warn-text"></span>
       </div>
     </section>
   </div>
@@ -2112,14 +2605,6 @@ input,select,textarea{font-family:inherit;color:inherit}
         <button class="ic-btn ic-btn-ghost" onclick="reveal('trace',this)">Show log file in Explorer</button>
       </div>
     </section>
-    <section class="sys-section">
-      <div class="ic-label">Overlays folder</div>
-      <div class="tab-sub">Drop your own <code class="mono">.html</code> files here to make them appear in the Overlay tab picker.</div>
-      <input id="s-ovdir" class="ic-input mono" style="margin-top:8px">
-      <div class="row" style="margin-top:10px">
-        <button class="ic-btn ic-btn-ghost" onclick="reveal('overlays',this)">Open overlays folder</button>
-      </div>
-    </section>
   </div>
 
   <!-- About sub-pane -->
@@ -2133,6 +2618,10 @@ input,select,textarea{font-family:inherit;color:inherit}
         <button class="ic-btn ic-btn-primary" id="sys-about-update-btn" onclick="applyUpdate()" hidden>Update now</button>
       </div>
       <div class="muted" id="sys-about-msg" style="font-size:12px;margin-top:8px;min-height:1.2em"></div>
+      <label style="display:flex;align-items:center;gap:10px;margin-top:12px;cursor:pointer">
+        <input id="s-update-check" type="checkbox" style="width:16px;height:16px;cursor:pointer">
+        <span>Automatically check for updates<span class="muted" style="margin-left:6px;font-size:12px">on launch, from GitHub</span></span>
+      </label>
       <div class="row" style="gap:10px;margin-top:12px;align-items:center">
         <button class="ic-btn ic-btn-ghost" onclick="restartApp(this)">Restart InstantClone</button>
         <span class="muted" style="font-size:12px">Relaunch the app - the dashboard reconnects automatically.</span>
@@ -2149,7 +2638,7 @@ input,select,textarea{font-family:inherit;color:inherit}
       </div>
       <div class="sys-about-card">
         <div class="ic-label">License</div>
-        <div class="tab-sub" style="margin-top:6px">InstantClone is open source under the MIT License.</div>
+        <div class="tab-sub" style="margin-top:6px">InstantClone is free software under the GPL-3.0 License.</div>
         <div class="row" style="gap:8px;margin-top:10px">
           <a class="ic-btn ic-btn-ghost" href="https://github.com/Soulhackzlol/InstantClone/blob/main/LICENSE" target="_blank" rel="noreferrer">View license</a>
         </div>
@@ -2224,7 +2713,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 </div><!-- /ic-app -->
 <div class="ic-toast-rail" id="toast-rail"></div>
 
-<!-- ── Reset confirmation modal ─────────────────────────────────
+<!-- - Reset confirmation modal ----------------─
      Two-step destructive flow: scope-dependent. The "settings" scope
      just needs a click-through; the "all" scope additionally requires
      typing the literal word RESET so a stray double-click can't wipe
@@ -2256,7 +2745,7 @@ input,select,textarea{font-family:inherit;color:inherit}
   </div>
 </div>
 
-<!-- ── Tour: spotlight cutout + floating tooltip ───────────── -->
+<!-- - Tour: spotlight cutout + floating tooltip ------─ -->
 <!-- The backdrop SVG draws a full-screen dark rect with a clear hole
      punched over the current target element. Tooltip floats next to
      the hole, auto-placed by JS. -->
@@ -2278,7 +2767,7 @@ input,select,textarea{font-family:inherit;color:inherit}
         <div class="tour-step" id="tour-step">1 / 9</div>
         <div class="tour-title" id="tour-title">Welcome to InstantClone</div>
       </div>
-      <button class="ic-btn-tiny" onclick="closeTour()" title="Close (Esc)">✕</button>
+      <button class="ic-btn-tiny" onclick="closeTour()" title="Close (Esc)" aria-label="Close tour">✕</button>
     </div>
     <div class="tour-body" id="tour-body"></div>
     <div class="tour-foot">
@@ -2297,7 +2786,7 @@ input,select,textarea{font-family:inherit;color:inherit}
 const $ = id => document.getElementById(id);
 const $$ = sel => Array.from(document.querySelectorAll(sel));
 
-// ── State ─────────────────────────────────────────────────────────────
+// - State ------------------------------─
 let lastState = null;
 // Last /config snapshot - cached so the capacity-math helpers can read
 // buffer_mb without re-fetching. Updated by loadConfig() and by the
@@ -2340,13 +2829,13 @@ const SETTINGS_FIELDS = {
   'discord webhook':'s-webhook','webhook':'s-webhook','overlays_dir':'s-ovdir',
 };
 
-// ── Formatting ─────────────────────────────────────────────────────────
+// - Formatting ----------------------------─
 const fmtSecs = ms => { const s = ms/1000; return s < 10 ? s.toFixed(1) : Math.round(s).toString(); };
 const fmtDelay = ms => { const s = Math.round(ms/1000); if (s < 60) return s+'s'; const m = Math.floor(s/60), r = s%60; return r ? `${m}m${r}s` : `${m}m`; };
 const fmtKbps = k => k >= 1000 ? (k/1000).toFixed(2)+' Mbps' : k+' kbps';
 function fmtBytesPair(b){ const u=['B','KB','MB','GB','TB']; let i=0; while(b>=1024 && i<u.length-1){b/=1024;i++} return [b.toFixed(b<10&&i?1:0), u[i]]; }
 
-// ── Buffer capacity math ──────────────────────────────────────────────
+// - Buffer capacity math -----------------------
 // The disk-backed ring caps how much delay we can actually fill. At
 // 10 Mbps the 500 MB default holds ~6m 50s of video+audio+overhead;
 // arming above that capacity silently stalls during the "preparing"
@@ -2427,8 +2916,8 @@ function renderBufferHint(){
   el.textContent = txt;
 }
 
-// ── Toast ─────────────────────────────────────────────────────────────
-function toast(msg, kind){
+// - Toast ------------------------------─
+function toast(msg, kind, ms){
   const k = kind || 'info';
   const icon = { ok:'✓', err:'!', info:'i' }[k] || 'i';
   const el = document.createElement('div');
@@ -2436,10 +2925,10 @@ function toast(msg, kind){
   el.innerHTML = `<span class="ic-toast-icon">${icon}</span><span></span>`;
   el.lastChild.textContent = msg;
   $('toast-rail').appendChild(el);
-  setTimeout(() => { el.classList.add('leaving'); setTimeout(() => el.remove(), 350); }, 2400);
+  setTimeout(() => { el.classList.add('leaving'); setTimeout(() => el.remove(), 350); }, ms || 2400);
 }
 
-// ── Animated number helper ────────────────────────────────────────────
+// - Animated number helper ----------------------
 const numState = new Map(); // id → {to, last, gen}
 // Fixed-duration ease-out tween for the stat readouts. NOTE the fix: the
 // map is now SEEDED on first sight of an id. The old version only stored
@@ -2471,7 +2960,7 @@ function animateNumber(id, target, dur, fmt){
   requestAnimationFrame(tick);
 }
 
-// ── Hero delay number: continuous critically-damped motion ────────────
+// - Hero delay number: continuous critically-damped motion ------
 // The big delay figure is special: it COUNTS UP as the buffer fills
 // (target moves ~4x/s) and ROLLS DOWN on cut/disarm (one big jump). A
 // fixed-duration tween handles the jump but makes the count-up jerk -
@@ -2514,7 +3003,7 @@ function heroNumTick(now){
   heroNum.raf = requestAnimationFrame(heroNumTick);
 }
 
-// ── Sparkline ─────────────────────────────────────────────────────────
+// - Sparkline ----------------------------─
 // Catmull-Rom -> cubic-bezier smoothing so the trace reads as a smooth
 // curve instead of a jagged polyline.
 function smoothLinePath(pts){
@@ -2558,7 +3047,7 @@ function updateSpark(lineId, fillId, data, width, height){
   drawSpark($(lineId), $(fillId), data, width, height, lineId);
 }
 
-// ── Action endpoints ──────────────────────────────────────────────────
+// - Action endpoints -------------------------
 function setPending(p){
   pendingPhase = p;
   clearTimeout(pendingClearT);
@@ -2683,7 +3172,7 @@ function disarmClick(ev){
   disarm();
 }
 
-// ── Hero render ───────────────────────────────────────────────────────
+// - Hero render ---------------------------─
 // Swap the hero subtext with a directional micro-slide (old line drops
 // out, new line drops in) - but ONLY when the message KIND changes.
 // `key` names the kind; several messages embed live numbers (bitrate,
@@ -2918,7 +3407,7 @@ function renderCta(){
   renderCutAfter(ds);
 }
 
-// ── "Cut after this airs" secondary action ────────────────────────────
+// - "Cut after this airs" secondary action --------------
 // Only offered while a delay is active - there's nothing to schedule
 // otherwise (the backend refuses too, this just keeps the button from
 // teasing a dead action). Shares the CTA row at 1/4 width, so labels
@@ -2957,7 +3446,7 @@ function renderCutAfter(ds){
   }
 }
 
-// ── Profile chips in hero ──────────────────────────────────────────────
+// - Profile chips in hero -----------------------
 function renderCpProfiles(){
   const c = $('cp-profiles');
   const ds = lastState ? PHASE_TO_STATE[lastState.phase] : 'off';
@@ -3001,7 +3490,7 @@ function renderCpProfiles(){
   });
 }
 
-// ── Header chips ───────────────────────────────────────────────────────
+// - Header chips ---------------------------─
 function renderHeader(s){
   // OBS pill - plain-language state + a tooltip that tells the user what
   // to do when it's not connected yet.
@@ -3053,9 +3542,39 @@ function renderHeader(s){
   $('hdr-dualformat').hidden = !s.vertical_present;
   $('hdr-backpressure').hidden = !s.backpressure;
   renderTwitchCapPill(s);
+  renderCompatWarning(s);
 }
 
-// ── Stats render ───────────────────────────────────────────────────────
+// - Encoder compatibility strip --------------------
+// Dismissal is keyed by the MESSAGE, not by a plain "hidden" flag: if the
+// user fixes their keyframe interval and a different problem appears, the
+// strip comes back on its own. Dismissal belongs to the publishing session
+// that raised it: it clears when ingest drops, so a fresh dashboard load OR
+// a new stream on the same page starts clean instead of inheriting a stale
+// "already dismissed" that would silence a genuinely broken new session.
+let compatDismissed = '';
+function renderCompatWarning(s){
+  if (!s.ingest_alive) compatDismissed = '';
+  const msg = s.compat_warning || '';
+  const el = $('compat-warn');
+  const show = msg !== '' && msg !== compatDismissed;
+  el.hidden = !show;
+  if (!show) return;
+  // Skip the DOM write when the text is unchanged - this runs ~4x/s and
+  // rewriting textContent every tick would fight the ellipsis and defeat
+  // text selection mid-read.
+  const t = $('compat-warn-text');
+  if (t.textContent !== msg){
+    t.textContent = msg;
+    t.title = msg;
+  }
+}
+function dismissCompatWarning(){
+  compatDismissed = ($('compat-warn-text').textContent) || '';
+  $('compat-warn').hidden = true;
+}
+
+// - Stats render ---------------------------─
 function renderStats(s){
   rateHistory.push(s.stats.bitrate_kbps || 0);
   if (rateHistory.length > HISTORY_LEN) rateHistory.shift();
@@ -3084,7 +3603,7 @@ function renderStats(s){
   $('m-rss').textContent = rv; $('m-rss-u').textContent = ru;
 }
 
-// ── Destinations ───────────────────────────────────────────────────────
+// - Destinations ---------------------------─
 function rebuildDests(){
   const c = $('dest-grid');
   // remove old "+Add" if present so we can re-append at end
@@ -3317,7 +3836,7 @@ async function loadDestinations(){
   refreshSysEbLaunch();
 }
 
-// ── Destination form ──────────────────────────────────────────────────
+// - Destination form -------------------------
 function openDestForm(d){
   $('dest-modal').hidden = false;
   $('dest-form').scrollTop = 0;
@@ -3486,7 +4005,7 @@ async function deleteDest(id){
   loadDestinations(); loadConfig();
 }
 
-// ── Profiles ──────────────────────────────────────────────────────────
+// - Profiles -----------------------------
 async function loadProfiles(){
   try {
     const r = await fetch('/profiles');
@@ -3596,7 +4115,7 @@ function jumpToBufferSetting(mb){
            : 'Raise the buffer size here, Save, then restart.', 'ok');
 }
 
-// ── Config / Settings ─────────────────────────────────────────────────
+// - Config / Settings ------------------------─
 async function loadConfig(){
   try {
     const c = await (await fetch('/config')).json();
@@ -3617,12 +4136,19 @@ async function loadConfig(){
     $('s-bmb').value = c.buffer_mb; $('s-bpath').value = c.buffer_path;
     renderBufferHint();
     $('s-ibind').checked = c.ingest_bind_all; $('s-wbind').checked = c.web_bind_all;
+    renderLanWarning();
     $('s-webhook').value = '';
     $('s-webhook').placeholder = c.webhook_set ? '(set - paste a new one to replace)' : 'https://discord.com/api/webhooks/…';
     $('s-webhook-hint').textContent = c.webhook_set ? '(currently set)' : '';
     $('s-ovdir').value = c.overlays_dir || '';
     $('ov-dir-display').textContent = c.overlays_dir || 'overlays/';
     $('s-trace').checked = c.tracing_enabled !== false;
+    // Reflects the actual Run-key entry, not a stored preference - so if
+    // the user removed it via Task Manager's Startup tab, this shows off.
+    $('s-startup').checked = !!c.start_with_windows;
+    // Both default true server-side; treat a missing field as on.
+    $('s-open-dash').checked = c.open_dashboard_on_launch !== false;
+    $('s-update-check').checked = c.update_check_enabled !== false;
     // Behavior section
     $('s-auto-arm').checked = !!c.auto_arm_on_connect;
     $('s-auto-act').checked = !!c.auto_activate_when_ready;
@@ -3637,7 +4163,7 @@ async function loadConfig(){
     // visibility
     const configured = c.configured;
     $('wizard').hidden = configured;
-    if (!configured) { refreshWizObsStatus(); }
+    if (!configured) { refreshWizObsStatus(); wizCurrent = 'obs'; wizDir = 'fwd'; renderWizStep(); }
     $('hdr-bar').hidden = !configured;
     $('hero').hidden = !configured;
     $('tabs').hidden = !configured;
@@ -3762,13 +4288,315 @@ function wireChatDock(){
   inp.addEventListener('input', update);
 }
 
+// Per-platform accent, mirroring the .dcard.platform-* CSS so a wizard
+// tile matches the destination card the same choice produces.
+const PLATFORM_COLOR = { twitch:'#a78bfa', youtube:'#fda4af', kick:'#86efac',
+  trovo:'#67e8f9', restream:'#5eead4', custom:'#fcd34d', sink:'#93c5fd' };
+
+// - Multi-step wizard state machine -----------------
+// Steps are computed live so the Twitch step joins/leaves the sequence
+// the instant the platform changes. We track the CURRENT step by id, not
+// index, so a platform switch that removes the Twitch step can never
+// strand the wizard on a panel that no longer exists.
+let wizCurrent = 'obs';
+// Travel direction for the slide transition: 'fwd' on Next/initial,
+// 'back' on Back. Read by CSS via #wizard[data-dir].
+let wizDir = 'fwd';
+
+// Every step that can ever appear, in order. The progress bar renders one
+// permanent segment per entry; `wizStepIds()` is the ACTIVE subset for the
+// current platform. Twitch is the only optional one today.
+const WIZ_ALL_STEPS = ['obs', 'platform', 'key', 'twitch'];
+
+function wizStepIds(){
+  const ids = ['obs', 'platform', 'key'];
+  if ($('w-platform').value === 'twitch') ids.push('twitch');
+  return ids;
+}
+
+function renderWizStep(){
+  const ids = wizStepIds();
+  if (!ids.includes(wizCurrent)) wizCurrent = ids[ids.length - 1];
+  const i = ids.indexOf(wizCurrent);
+  $('wizard').dataset.dir = wizDir;
+  // Show the active panel only.
+  document.querySelectorAll('#wizard .wiz-step').forEach(el => {
+    el.hidden = el.dataset.wstep !== wizCurrent;
+  });
+  // Stop the optional OBS-connection poll when leaving its step, and clear a
+  // stuck spinner so returning shows the idle button (a confirmed ✓ stays).
+  if (wizCurrent !== 'obs'){
+    wizStopObsCheckTimer();
+    const wov = $('wiz-obs-verify');
+    if (wov && wov.dataset.state === 'waiting') wov.dataset.state = 'idle';
+  }
+  // Segmented progress. One PERMANENT segment per possible step (segments
+  // are never added/removed) so the optional Twitch segment animates its
+  // collapse/expand instead of popping in and out. done/on are computed in
+  // the active-step space; inactive steps (Twitch when not chosen) collapse.
+  const prog = $('wiz-progress');
+  if (prog.children.length !== WIZ_ALL_STEPS.length){
+    prog.innerHTML = '';
+    WIZ_ALL_STEPS.forEach(() => prog.appendChild(document.createElement('span')));
+  }
+  WIZ_ALL_STEPS.forEach((sid, idx) => {
+    const pos = ids.indexOf(sid);
+    let cls = 'wiz-seg';
+    if (pos === -1) cls += ' collapsed';
+    else if (pos < i) cls += ' done';
+    else if (pos === i) cls += ' on';
+    prog.children[idx].className = cls;
+  });
+  const last = (i === ids.length - 1);
+  $('wiz-back').hidden = (i === 0);
+  $('wiz-next').innerHTML = last ? 'Save &amp; Start' : 'Next &rarr;';
+  // Step 1 doubles as the welcome: name the app and say what it does, so a
+  // first-time user understands the tool before answering anything. Later
+  // steps drop to a plain position counter (the progress bar shows the
+  // rest visually).
+  if (i === 0){
+    $('wiz-title').textContent = 'Welcome to InstantClone';
+    $('wiz-lead').textContent = 'A live, glitch-free stream delay for OBS. A few quick questions and you’re streaming.';
+  } else {
+    $('wiz-title').textContent = 'Set up your stream';
+    $('wiz-lead').textContent = `Step ${i + 1} of ${ids.length}`;
+  }
+  // Name the platform in the key-step heading.
+  const pn = $('w-key-platform-name');
+  if (pn){
+    const opt = $('w-platform').selectedOptions[0];
+    pn.textContent = opt ? opt.textContent : 'platform';
+  }
+  clearWizMsg();
+  wireAllDisclosures($('wizard'));
+  reserveCopyButtons($('wizard'));
+  if (wizCurrent === 'key') setTimeout(() => { const k = $('w-key'); if (k) k.focus(); }, 60);
+}
+
+function wizNext(){
+  if (!validateWizStep(wizCurrent)) return;
+  const ids = wizStepIds();
+  const i = ids.indexOf(wizCurrent);
+  if (i >= ids.length - 1){ saveWizard(); return; }
+  wizDir = 'fwd';
+  wizCurrent = ids[i + 1];
+  renderWizStep();
+}
+
+function wizBack(){
+  const ids = wizStepIds();
+  const i = ids.indexOf(wizCurrent);
+  if (i > 0){ wizDir = 'back'; wizCurrent = ids[i - 1]; renderWizStep(); }
+}
+
+// Optional, local-only "did OBS reach us?" check. Polls /state for ingest_alive
+// (OBS publishing into our RTMP server) - a passive read that sends nothing
+// anywhere. No destination is saved during the wizard, and OBS points only at
+// 127.0.0.1, so nothing can egress to a platform while this runs.
+let _obsCheckTimer = null;
+function wizStopObsCheckTimer(){ if (_obsCheckTimer){ clearInterval(_obsCheckTimer); _obsCheckTimer = null; } }
+function wizStartObsCheck(){
+  const panel = $('wiz-obs-verify'); if (!panel) return;
+  panel.dataset.state = 'waiting';
+  wizStopObsCheckTimer();
+  _obsCheckTimer = setInterval(async () => {
+    try {
+      const s = await (await fetch('/state')).json();
+      if (s && s.ingest_alive){
+        wizStopObsCheckTimer();
+        panel.dataset.state = 'ok';
+        const codec = (s.video_codec && s.video_codec !== 'unknown') ? ' (' + s.video_codec + ')' : '';
+        const ok = panel.querySelector('.wov-status-ok');
+        if (ok) ok.textContent = 'OBS is reaching InstantClone' + codec + '. Nothing left your PC. You can stop streaming now.';
+        const node = document.querySelector('.obs-node[data-node="verify"]');
+        if (node) node.dataset.verified = '1';   // turn the step's dot green ✓
+      }
+    } catch(_){ /* transient fetch error - keep polling */ }
+  }, 700);
+}
+function wizStopObsCheck(){
+  wizStopObsCheckTimer();
+  const panel = $('wiz-obs-verify');
+  if (panel && panel.dataset.state !== 'ok') panel.dataset.state = 'idle';
+}
+
+// - Guided OBS flow (the 2-node stepper) ---------------
+const OBS_FLOW = ['connect','verify'];
+// True once the user clicks "I've set this up in OBS" (advances past connect).
+// The wizard's Next is gated on it (validateWizStep) so nobody skips wiring OBS.
+let wizObsConfirmed = false;
+function wizObsNode(node){ return document.querySelector(`.obs-node[data-node="${node}"]`); }
+// Mark a node done and open the next one.
+function wizObsAdvance(node){
+  const el = wizObsNode(node); if (!el) return;
+  el.dataset.state = 'done';
+  const next = OBS_FLOW[OBS_FLOW.indexOf(node) + 1];
+  if (next){ const nx = wizObsNode(next); if (nx && nx.dataset.state !== 'done') nx.dataset.state = 'active'; }
+  if (node === 'connect'){ wizObsConfirmed = true; clearWizMsg(); }
+}
+// Re-open a completed node to review or redo it; collapses whatever was open.
+function wizObsReopen(node){
+  const el = wizObsNode(node);
+  if (!el || el.dataset.state === 'locked' || el.dataset.state === 'active') return;
+  OBS_FLOW.forEach(n => { const e = wizObsNode(n); if (e && e.dataset.state === 'active') e.dataset.state = 'done'; });
+  el.dataset.state = 'active';
+}
+
+// Gated steps: the OBS step needs an explicit "I've set this up" confirmation
+// before Next proceeds; the key step needs a key. Platform (always has a
+// selection) and the optional Twitch step never block.
+function validateWizStep(id){
+  if (id === 'obs'){
+    if (wizObsConfirmed) return true;
+    wizMsg('Set OBS up above, then click "I\'ve set this up in OBS" to continue.', 'err');
+    const c = $('wiz-obs-confirm');   // draw the eye to the button that unblocks
+    if (c){ c.classList.remove('nudge'); void c.offsetWidth; c.classList.add('nudge'); }
+    return false;
+  }
+  if (id !== 'key') return true;
+  const platform = $('w-platform').value;
+  const key = $('w-key').value.trim(), custom = $('w-custom').value.trim();
+  if (platform === 'custom' && !custom){ wizMsg('Enter your custom RTMP URL to continue.', 'err'); return false; }
+  if (platform !== 'custom' && !key){ wizMsg('Paste your stream key to continue.', 'err'); return false; }
+  return true;
+}
+
+function wizMsg(text, kind){ $('w-msg').innerHTML = `<span class="${kind || ''}">${text}</span>`; }
+function clearWizMsg(){ $('w-msg').innerHTML = ''; }
+
+// A tiny critically-damped spring driving one scalar (px height). Springs are
+// interruptible and velocity-aware by nature: re-targeting mid-flight keeps the
+// live position AND velocity, so a rapid open/close reverses without the
+// "brick wall" a re-started CSS ease produces (velocity snaps to 0 there).
+// Damping ratio is fixed at 1.0 - no overshoot, because a click that just
+// revealed a panel carried no momentum to justify a bounce (Apple, Designing
+// Fluid Interfaces). `response` is the settle feel in seconds, not a duration.
+function makeSpring(onFrame, response){
+  const w = 2 * Math.PI / response;   // natural frequency; zeta = 1 (critical)
+  let value = 0, velocity = 0, target = 0, raf = 0, last = 0;
+  function frame(now){
+    let dt = (now - last) / 1000; last = now;
+    if (dt > 0.064) dt = 0.064;       // clamp after a tab stall / dropped frames
+    const steps = Math.max(1, Math.ceil(dt / 0.008));  // substeps keep it stable
+    const h = dt / steps;
+    for (let i = 0; i < steps; i++){
+      velocity += (-w * w * (value - target) - 2 * w * velocity) * h;
+      value += velocity * h;
+    }
+    if (Math.abs(value - target) < 0.3 && Math.abs(velocity) < 2){
+      value = target; velocity = 0; raf = 0; onFrame(value, true); return;
+    }
+    onFrame(value, false);
+    raf = requestAnimationFrame(frame);
+  }
+  return {
+    set(v){ value = v; },
+    to(t){ target = t; if (!raf){ last = performance.now(); raf = requestAnimationFrame(frame); } },
+    get active(){ return !!raf; }
+  };
+}
+
+// Reusable disclosure reveal. Upgrades any <details class="ic-disclose"> into a
+// spring-animated collapsible while keeping native keyboard + screen-reader
+// semantics. The wrapping "sleeve" height is spring-driven (interruptible,
+// velocity-carrying); the padded body rides a composited opacity + translateY.
+// The native <details> is pinned open so content is always mounted and
+// measurable; the `is-open` class drives the visual state and the arrow.
+const DISC_RESPONSE = 0.34;   // spring settle feel, seconds (see makeSpring)
+
+function wireDisclosure(det){
+  if (det._wired) return;
+  const summary = det.querySelector(':scope > summary');
+  const body = summary && summary.nextElementSibling;
+  if (!summary || !body) return;
+  det._wired = true;
+  det.classList.add('disc-ready');   // marks it as spring-managed (see CSS fallback)
+
+  const sleeve = document.createElement('div');
+  sleeve.className = 'disc-sleeve';
+  body.parentNode.insertBefore(sleeve, body);
+  sleeve.appendChild(body);
+
+  const startOpen = det.hasAttribute('open');
+  det.open = true;                                    // keep content mounted
+  det.classList.toggle('is-open', startOpen);
+  summary.setAttribute('aria-expanded', String(startOpen));
+  sleeve.style.height = startOpen ? 'auto' : '0px';
+
+  const reduced = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Natural height without a visible flash: swap to auto, read, restore.
+  // Layout read only, no paint between, so nothing flickers.
+  function naturalHeight(){
+    const prev = sleeve.style.height;
+    sleeve.style.height = 'auto';
+    const h = sleeve.getBoundingClientRect().height;
+    sleeve.style.height = prev;
+    return h;
+  }
+
+  const spring = makeSpring((v, done) => {
+    // When fully settled open, release to `auto` so later reflow (font swap,
+    // rewrap, resize) is never clipped to a stale pixel height.
+    if (done && det.classList.contains('is-open')) sleeve.style.height = 'auto';
+    else sleeve.style.height = Math.max(0, v) + 'px';
+  }, DISC_RESPONSE);
+
+  function toggle(){
+    const open = !det.classList.contains('is-open');
+    det.classList.toggle('is-open', open);
+    summary.setAttribute('aria-expanded', String(open));
+    if (reduced()){ sleeve.style.height = open ? 'auto' : '0px'; return; }
+    // Only re-seed the spring's value from the DOM when it's at rest (e.g.
+    // height was 'auto'); mid-flight we leave value/velocity intact so the
+    // reversal carries momentum instead of jumping.
+    if (!spring.active) spring.set(sleeve.getBoundingClientRect().height);
+    spring.to(open ? naturalHeight() : 0);
+  }
+  det._toggle = toggle;
+
+  summary.addEventListener('click', (e) => { e.preventDefault(); toggle(); });
+}
+
+function wireAllDisclosures(root){
+  (root || document).querySelectorAll('details.ic-disclose').forEach(wireDisclosure);
+}
+
+// Programmatic open/close (e.g. an inline "details" link). Wires on demand.
+function toggleDisclosure(id){
+  const det = document.getElementById(id);
+  if (!det) return;
+  wireDisclosure(det);
+  det._toggle();
+}
+
 function fillWizardPlatforms(){
   const sel = $('w-platform'); sel.innerHTML = '';
+  const tiles = $('w-platform-tiles'); if (tiles) tiles.innerHTML = '';
   // The test sink is excluded here on purpose: the wizard writes the
   // legacy single-destination config (which requires a key), and its
   // job is wiring your REAL platform. The sink lives in Destinations.
-  platforms.filter(p => p.slug !== 'sink')
-    .forEach(p => { const o = document.createElement('option'); o.value = p.slug; o.textContent = p.label; sel.appendChild(o); });
+  platforms.filter(p => p.slug !== 'sink').forEach((p, idx) => {
+    const o = document.createElement('option');
+    o.value = p.slug; o.textContent = p.label; sel.appendChild(o);
+    if (!tiles) return;
+    // A tile drives the hidden select: set value + dispatch 'change' so
+    // every existing listener (custom reveal, key help) fires unchanged.
+    const b = document.createElement('button');
+    b.type = 'button'; b.className = 'w-ptile'; b.dataset.slug = p.slug;
+    b.setAttribute('role', 'radio');
+    b.style.setProperty('--dc', PLATFORM_COLOR[p.slug] || 'var(--line-2)');
+    // Staggered entrance when the platform step appears.
+    b.style.animationDelay = (idx * 40) + 'ms';
+    b.innerHTML = `<span class="w-ptile-check" aria-hidden="true">✓</span>`
+      + `<span class="w-ptile-badge">${PLATFORM_INITIAL[p.slug] || '·'}</span>`
+      + `<span class="w-ptile-label"></span>`;
+    b.querySelector('.w-ptile-label').textContent = p.label;
+    b.addEventListener('click', () => {
+      sel.value = p.slug; sel.dispatchEvent(new Event('change'));
+    });
+    tiles.appendChild(b);
+  });
   if (!sel._wired){
     sel._wired = true;
     sel.addEventListener('change', () => {
@@ -3781,11 +4609,37 @@ function fillWizardPlatforms(){
       const optHint = $('w-key-optional-hint');
       if (optHint) optHint.hidden = !isCustom;
       renderKeyHelp(sel.value, 'w-key-help');
+      syncWizPlatformTiles();
+      // Re-render the step chrome: changing to/from Twitch adds or drops
+      // the Twitch step, so the progress bar and Next label must update.
+      if (!$('wizard').hidden) renderWizStep();
+    });
+    // VOD-audio opt-in reveals its OBS how-to inline.
+    const vod = $('w-vod-audio');
+    if (vod) vod.addEventListener('change', () => { $('w-vod-how').hidden = !vod.checked; });
+    // Enter in the key field advances, like a real form.
+    const keyInput = $('w-key');
+    if (keyInput) keyInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter'){ e.preventDefault(); wizNext(); }
     });
   }
   const optHint = $('w-key-optional-hint');
   if (optHint) optHint.hidden = sel.value !== 'custom';
   renderKeyHelp(sel.value, 'w-key-help');
+  syncWizPlatformTiles();
+}
+
+// Reflect the hidden select's value onto the tiles. Driven by the
+// select's 'change' event, so tile clicks, the initial config load, and
+// any programmatic set all keep the highlight correct.
+function syncWizPlatformTiles(){
+  const sel = $('w-platform'); const tiles = $('w-platform-tiles');
+  if (!tiles) return;
+  tiles.querySelectorAll('.w-ptile').forEach(b => {
+    const on = b.dataset.slug === sel.value;
+    b.classList.toggle('on', on);
+    b.setAttribute('aria-checked', on ? 'true' : 'false');
+  });
 }
 
 // First-run OBS-service registration card in the wizard. Renders the
@@ -3801,6 +4655,10 @@ async function refreshWizObsStatus(){
   if (!btn || !status) return;
   try {
     const r = await (await fetch('/obs/register-status')).json();
+    // "Close OBS first" only matters when OBS is actually running AND we still
+    // need to register (a running OBS overwrites services.json on exit).
+    const closeWarn = $('wiz-obs-close-warn');
+    if (closeWarn) closeWarn.hidden = !(r.obs_running && !r.registered);
     if (r.path === null){
       status.innerHTML = '<span style="color:var(--warn,#d6a23a)">⚠ OBS not detected on this machine - use the Custom RTMP card on the right.</span>';
       btn.disabled = true;
@@ -3810,12 +4668,12 @@ async function refreshWizObsStatus(){
     }
     btn.disabled = false;
     if (r.registered){
-      status.innerHTML = '<span style="color:var(--live)">✓ Registered.</span> Restart OBS, then choose <b>InstantClone</b> from Settings → Stream → Service.';
+      status.innerHTML = '<span style="color:var(--live)">✓ Registered.</span> Reopen OBS, then choose <b>InstantClone</b> from Settings → Stream → Service.';
       btn.textContent = 'Unregister';
       btn.className = 'ic-btn ic-btn-ghost';
       btn.onclick = wizUnregisterObs;
     } else {
-      status.textContent = "We'll add an InstantClone entry to OBS's service list - one click, no restart needed before clicking.";
+      status.textContent = "We'll add an InstantClone entry to OBS's service list.";
       btn.textContent = 'Register with OBS';
       btn.className = 'ic-btn ic-btn-primary';
       btn.onclick = wizRegisterObs;
@@ -3824,6 +4682,12 @@ async function refreshWizObsStatus(){
     status.textContent = "Couldn't query OBS - the Custom RTMP card on the right also works.";
   }
 }
+// Re-check OBS's running state when the window regains focus - e.g. the user
+// alt-tabbed to OBS and closed it - so the "close OBS first" note clears itself.
+window.addEventListener('focus', () => {
+  const wiz = $('wizard');
+  if (wiz && !wiz.hidden && wizCurrent === 'obs') refreshWizObsStatus();
+});
 async function wizRegisterObs(){
   const btn = $('wiz-obs-register-btn');
   if (btn) btn.disabled = true;
@@ -3851,6 +4715,23 @@ async function wizUnregisterObs(){
 // tip). For Kick we mark the tip as a warning because its no-B-frames
 // rule is the kind of thing that drops the stream silently - worth a
 // visual nudge, not just plain grey text.
+// Break a long single-string platform tip into breathable paragraphs at
+// sentence boundaries (~130+ chars each), so a 700-char wall like Twitch's
+// transcoding note reads as a few short paragraphs instead of one slab.
+// Short tips pass through untouched.
+function formatTip(tip){
+  const t = (tip || '').trim();
+  if (t.length <= 220) return `<p>${t}</p>`;
+  const sentences = t.split(/(?<=\.)\s+(?=[A-Z])/);
+  const paras = []; let buf = '';
+  for (const s of sentences){
+    buf = buf ? buf + ' ' + s : s;
+    if (buf.length >= 130){ paras.push(buf); buf = ''; }
+  }
+  if (buf) paras.push(buf);
+  return paras.map(s => `<p>${s}</p>`).join('');
+}
+
 function renderKeyHelp(slug, hostId){
   const host = document.getElementById(hostId);
   if (!host) return;
@@ -3879,12 +4760,13 @@ function renderKeyHelp(slug, hostId){
     parts.push(`
       <details class="ic-disclose w-key-disclose"${isKick || isSink ? ' open' : ''}>
         <summary class="${cls}">${label}</summary>
-        <div class="ic-disclose-body">${p.tip}</div>
+        <div class="ic-disclose-body">${formatTip(p.tip)}</div>
       </details>
     `);
   }
   host.innerHTML = parts.join('');
   host.hidden = false;
+  wireAllDisclosures(host);   // freshly injected <details> need the spring wiring
 }
 
 // Wizard escape hatch. Reveals the dashboard without writing any
@@ -3912,20 +4794,36 @@ function skipWizard(){
 
 async function saveWizard(){
   const platform = $('w-platform').value, key = $('w-key').value.trim(), custom = $('w-custom').value.trim();
-  if (platform !== 'custom' && !key){ $('w-msg').innerHTML = '<span class="err">Stream key required.</span>'; return; }
-  if (platform === 'custom' && !custom){ $('w-msg').innerHTML = '<span class="err">Custom RTMP URL required.</span>'; return; }
-  const body = new URLSearchParams({platform, stream_key:key, custom_egress_url:custom});
-  const j = await(await fetch('/config',{method:'POST',body})).json();
-  if (j.ok){ $('w-msg').innerHTML = '<span class="ok">Saved - starting up…</span>'; setTimeout(loadConfig, 500); }
-  else $('w-msg').innerHTML = '<span class="err">'+j.error+'</span>';
-}
-async function testConn(){
-  const platform = $('w-platform').value, key = $('w-key').value || '', custom = $('w-custom').value || '';
-  if (key || custom) await fetch('/config',{method:'POST', body:new URLSearchParams({platform, stream_key:key, custom_egress_url:custom})});
-  const r = await(await fetch('/test-egress',{method:'POST'})).json();
-  if (r.ok) toast('Reached '+r.message,'ok'); else toast('Failed: '+(r.error||'?'),'err');
+  // Defensive: the key step validates before you can reach Save, but if we
+  // ever land here empty, bounce back to that step rather than erroring.
+  if ((platform !== 'custom' && !key) || (platform === 'custom' && !custom)){
+    wizCurrent = 'key'; renderWizStep();
+    wizMsg(platform === 'custom' ? 'Enter your custom RTMP URL to continue.' : 'Paste your stream key to continue.', 'err');
+    return;
+  }
+  const params = {platform, stream_key:key, custom_egress_url:custom};
+  // The Twitch step's VOD-audio choice rides along on the same save.
+  if (platform === 'twitch') params.vod_audio = $('w-vod-audio').checked ? 'on' : 'off';
+  const btn = $('wiz-next'); if (btn){ btn.disabled = true; }
+  const j = await(await fetch('/config',{method:'POST',body:new URLSearchParams(params)})).json();
+  if (j.ok){ wizMsg('Saved - starting up…', 'ok'); nudgeObsWiringIfNeeded(); setTimeout(loadConfig, 500); }
+  else { if (btn) btn.disabled = false; wizMsg(j.error, 'err'); }
 }
 
+// Soft catch for the beginner who breezed past the OBS step: if OBS still isn't
+// wired to InstantClone when the wizard finishes, remind them how - never a
+// blocker. A registered user already saw "restart OBS + pick InstantClone", so
+// only the not-registered case (the actual silent dead-end onto OFFLINE) nudges.
+async function nudgeObsWiringIfNeeded(){
+  try {
+    const r = await (await fetch('/obs/register-status')).json();
+    if (r.registered) return;
+    const how = (r.path === null)
+      ? 'In OBS → Settings → Stream: Service = Custom, Server = rtmp://127.0.0.1:1935/live, then restart OBS.'
+      : 'In OBS → Settings → Stream, pick InstantClone (or Custom: rtmp://127.0.0.1:1935/live), then restart OBS.';
+    toast('One more step to go live: point OBS at InstantClone. ' + how, 'info', 11000);
+  } catch(_){ /* status endpoint unreachable; the first-run tour still covers OBS wiring */ }
+}
 function flashFieldErrors(message){
   $$('input.field-error').forEach(el => el.classList.remove('field-error'));
   if (!message) return;
@@ -3939,7 +4837,38 @@ function flashFieldErrors(message){
   });
 }
 
+// - LAN exposure warning -----------------------─
+// The two toggles carry different risks, so say the one that applies:
+// the web UI is an unauthenticated control surface, while the ingest port
+// lets anyone on the network publish into the buffer. Both default off,
+// and this stays hidden until one is actually ticked.
+function renderLanWarning(){
+  const web = $('s-wbind').checked;
+  const ingest = $('s-ibind').checked;
+  const parts = [];
+  if (web) parts.push('The web UI has no password - anyone on your network can change the delay, cut, and edit destinations.');
+  if (ingest) parts.push('The ingest port accepts any stream key, so anyone on your network can publish into your buffer.');
+  const on = parts.length > 0;
+  $('lan-warn').hidden = !on;
+  if (on) $('lan-warn-text').textContent = parts.join(' ') + ' Only enable on a network you trust.';
+}
+
 let _savingSettings = false;
+// Overlays folder lives on the Overlay tab now, so it saves itself rather
+// than riding the System tab's Save button. POSTs just overlays_dir and
+// refreshes the gallery from the new location.
+async function saveOverlaysDir(btn){
+  const dir = $('s-ovdir').value.trim();
+  const label = btn && btn.textContent;
+  if (btn){ btn.disabled = true; btn.textContent = 'Saving…'; }
+  try {
+    const j = await (await fetch('/config', {method:'POST', body:new URLSearchParams({overlays_dir:dir})})).json();
+    if (j.ok){ toast('Overlays folder saved', 'ok'); await loadConfig(); if (typeof loadOverlays === 'function') loadOverlays(); }
+    else toast(`Couldn't save: ${j.error}`, 'err');
+  } catch(e){ toast('Save failed - the app may have stopped responding', 'err'); }
+  finally { if (btn){ btn.disabled = false; btn.textContent = label || 'Save'; } }
+}
+
 async function saveSettings(){
   if (_savingSettings) return; // guard against a double-click double-POST
   const btn = document.querySelector('#sys-foot .ic-btn-primary');
@@ -3949,8 +4878,10 @@ async function saveSettings(){
     ingest_bind_all:$('s-ibind').checked?'on':'off',
     web_bind_all:$('s-wbind').checked?'on':'off',
     discord_webhook_url:$('s-webhook').value.trim(),
-    overlays_dir:$('s-ovdir').value.trim(),
     tracing_enabled:$('s-trace').checked?'true':'false',
+    start_with_windows:$('s-startup').checked?'on':'off',
+    open_dashboard_on_launch:$('s-open-dash').checked?'true':'false',
+    update_check_enabled:$('s-update-check').checked?'true':'false',
     auto_arm_on_connect:$('s-auto-arm').checked?'true':'false',
     auto_activate_when_ready:$('s-auto-act').checked?'true':'false',
     auto_arm_delay_ms:String(Math.max(1, Math.min(600, parseInt($('s-auto-arm-secs').value,10)||15)) * 1000),
@@ -3981,7 +4912,7 @@ async function testWebhook(){
   else toast(`Webhook test failed: ${r.error || 'no response from Discord'}`, 'err');
 }
 
-// ── OBS service registration ─────────────────────────────────────────
+// - OBS service registration --------------------─
 // Patches OBS's services.json so InstantClone shows up in the Service
 // dropdown like Twitch/YouTube. Polls /obs/register-status on System-tab
 // activation so the button + status reflect whatever the user last did
@@ -4040,7 +4971,7 @@ async function toggleObsRegister(){
   await refreshObsRegisterStatus();
 }
 
-// ── Phase C: Launch OBS with --config-url ────────────────────────────
+// - Phase C: Launch OBS with --config-url --------------
 // Spawns obs64.exe with the Enhanced Broadcasting CLI flag. The user
 // has to use this every time they want EB on a Custom RTMP setup,
 // since OBS only reads --config-url at launch and rtmp_custom's
@@ -4125,7 +5056,7 @@ async function refreshObsEbLaunchAvailability(){
   } catch(_){}
 }
 
-// ── System tab: OBS quick launch ──────────────────────────────────────
+// - System tab: OBS quick launch -------------------
 // EB / VOD+EB launchers that work without opening any destination's
 // settings. They reuse the same backend endpoints as the destination
 // form; the only extra logic is the VOD+EB pre-step that persists
@@ -4228,7 +5159,7 @@ async function sysLaunchVodEb(){
   btn.disabled = false;
 }
 
-// ── Reset settings / Reset everything ────────────────────────────────
+// - Reset settings / Reset everything ----------------
 // Two-step destructive flow. The "settings" scope is recoverable in
 // practice (the user can just re-enter their port/buffer/webhook
 // values) so a single click-through is fine. The "all" scope wipes
@@ -4327,7 +5258,7 @@ async function confirmResetModal(){
   }
 }
 
-// ── Overlay Studio ────────────────────────────────────────────────────
+// - Overlay Studio --------------------------
 // A no-code editor for browser-source overlays. The heavy lifting lives
 // in /overlay-runtime.js (window.ICOverlay): widget catalogue, animation
 // library, and bake(doc)->self-contained static HTML. The Studio canvas
@@ -4597,7 +5528,7 @@ const Studio = (function(){
     h+='<button class="ic-btn ic-btn-ghost st-danger" onclick="Studio.deleteFromGallery(\''+o.slug+'\')">Delete</button>';
     act.innerHTML=h;
   }
-  function copyGallery(){ if(gsel) copyText(selUrl(),'Overlay URL'); }
+  function copyGallery(btn){ if(gsel) copyText(btn, selUrl(),'Overlay URL'); }
   // Restore the built-in overlays: wipe the Studio overlays + re-seed presets.
   async function restoreDefaults(){
     if(!confirm('Restore default overlays?\n\nThis DELETES ALL your Studio overlays (the presets and anything you made) and reinstalls the built-in set. Hand-written .html files are kept.\n\nThis cannot be undone.')) return;
@@ -5137,7 +6068,7 @@ const Studio = (function(){
       else { toast(j.error||'Save failed','err'); slug=null; }
     }catch(e){ toast('Save failed','err'); slug=null; }
   }
-  function copyUrl(){ if(!slug){ toast('Save the overlay first to get a URL','info'); return; } copyText(location.origin+'/overlay/'+slug+'.html','Overlay URL'); }
+  function copyUrl(btn){ if(!slug){ toast('Save the overlay first to get a URL','info'); return; } copyText(btn, location.origin+'/overlay/'+slug+'.html','Overlay URL'); }
   // ---- overflow menu: save-as / rename / export / import / delete ----
   function toggleMenu(ev){ ev.stopPropagation(); const p=$('st-menu-pop'); if(p) p.hidden=!p.hidden; }
   // Save a separate copy under a new slug (so it never overwrites the current
@@ -5241,10 +6172,61 @@ const Studio = (function(){
 // early calls no-op. The Studio loads its own saved list in init().
 function loadOverlays(){ try { if(window.ICOverlay) Studio.loadSaved(); } catch(_){} }
 
-function copyEl(id, label){ navigator.clipboard.writeText($(id).textContent); toast((label||'Value')+' copied','ok'); }
-function copyText(text, label){ navigator.clipboard.writeText(text); toast((label||'Value')+' copied','ok'); }
+// Turn the clicked button into its own confirmation: "Copy" -> "✓ Copied"
+// for ~1.5s. Immediate, on-the-thing-you-touched feedback beats a detached
+// toast. The button is passed in explicitly (callers forward `this` from the
+// inline handler) rather than read from the deprecated global `window.event`.
+const COPIED_HTML = '<span class="cp-ico" aria-hidden="true">✓</span><span>Copied</span>';
 
-// ── Logs ──────────────────────────────────────────────────────────────
+// Pin a copy button's width to the wider of its "Copy" / "Copied" states so the
+// label swap can never resize it or knock it onto a new line. Measured once,
+// lazily, with a hidden probe while the button is on-screen (tab-hidden buttons
+// would measure 0). Runs before the first swap, so even that first click is
+// shift-free.
+function reserveCopyWidth(btn){
+  if (btn._copyW != null) return;
+  const cur = btn.getBoundingClientRect().width;
+  if (!cur) return;                     // hidden (inactive tab) - defer to a later click
+  const probe = btn.cloneNode(false);
+  probe.removeAttribute('id');
+  probe.innerHTML = COPIED_HTML;
+  probe.style.cssText += ';position:absolute;left:-9999px;top:0;visibility:hidden;min-width:0;pointer-events:none';
+  (btn.parentNode || document.body).appendChild(probe);
+  btn._copyW = Math.max(cur, probe.getBoundingClientRect().width);
+  probe.remove();
+  btn.style.minWidth = btn._copyW + 'px';
+}
+
+// Reserve every copy button that's currently on-screen, so its width is locked
+// before the first click - no one-time widen on the "Copy" -> "Copied" swap.
+// Idempotent and skips off-screen (0-width) buttons, so it's safe to call on
+// every tab switch / wizard render; hidden tabs get reserved when shown.
+function reserveCopyButtons(root){
+  (root || document).querySelectorAll('.ic-btn[onclick*="copy"]').forEach(reserveCopyWidth);
+}
+
+function flashCopied(btn){
+  // Tolerate an element or an event (defensive: an inline handler that passed
+  // `event` still resolves to its button) and no-op if neither yields one.
+  if (btn && !(btn instanceof Element) && btn.currentTarget) btn = btn.currentTarget;
+  if (!(btn instanceof Element)) return;
+  btn = btn.closest('.ic-btn');
+  if (!btn) return;
+  if (btn._copyT) clearTimeout(btn._copyT);
+  if (btn._copyHTML == null) btn._copyHTML = btn.innerHTML;
+  reserveCopyWidth(btn);                // lock footprint before the swap
+  btn.classList.add('is-copied');
+  btn.innerHTML = COPIED_HTML;
+  btn._copyT = setTimeout(() => {
+    if (btn._copyHTML != null){ btn.innerHTML = btn._copyHTML; btn._copyHTML = null; }
+    btn.classList.remove('is-copied');
+    btn._copyT = null;
+  }, 1500);
+}
+function copyEl(btn, id, label){ navigator.clipboard.writeText($(id).textContent); flashCopied(btn); }
+function copyText(btn, text, label){ navigator.clipboard.writeText(text); flashCopied(btn); }
+
+// - Logs -------------------------------
 async function pollLogs(){
   try {
     const j = await (await fetch('/logs')).json();
@@ -5271,7 +6253,7 @@ async function clearLogs(){
   if (empty) empty.hidden = false;
   toast('Logs cleared','info');
 }
-// ── Spotlight onboarding tour ─────────────────────────────────────────
+// - Spotlight onboarding tour --------------------─
 // Each step optionally points at a real DOM element. The SVG mask
 // punches a hole over it, the tooltip floats next to it. Steps with
 // `tab` switch tabs first. Steps with `target: null` show a centered
@@ -5339,22 +6321,25 @@ const TOUR = [
     side: 'top', tab: 'destinations',
     title: 'Destinations',
     body: `
-      <p>Each platform you add gets its own card with a coloured left stripe (Twitch purple, YouTube rose, Kick mint…), a live bitrate sparkline, and a status pill. Hit <b>+ Add destination</b> to create one.</p>
-      <p>Stream keys are <b>per-destination</b>. OBS uses a simple stream identifier, the real platform keys live here.</p>
-      <p><b>Horizontal or vertical?</b> Every card has a small <b>format icon</b> next to its status - hover it to see whether that destination sends <b>horizontal</b> (wide), <b>vertical</b> 9:16, or <b>both</b> (Twitch, via Dual Format). Set any non-Twitch destination to <b>Vertical</b> to reuse Twitch's 9:16 canvas for YouTube Shorts / Kick mobile.</p>
-      <p>InstantClone standardizes on <b>Twitch Dual Format</b> as its vertical source: set it up once in OBS and every vertical destination reuses that same 9:16 canvas. Vertical only flows while <b>Dual Format / Enhanced Broadcasting</b> is on, and the card shows <b>Waiting for Dual Format</b> until then. <a href="https://help.twitch.tv/s/article/dual-format-vertical-video?language=en_US" target="_blank" rel="noopener">How to set up Twitch Dual Format →</a></p>
-      <div class="tour-tip"><strong>Streaming vs Connected:</strong> Streaming = bytes flowing. Connected = TCP up but OBS hasn't sent a frame yet.</div>
+      <p>Every platform you add gets a colour-coded card with a live bitrate sparkline and a status pill. Hit <b>+ Add destination</b> to create one.</p>
+      <p>Stream keys are <b>per-destination</b> and live here - OBS only needs a placeholder identifier.</p>
+      <details class="ic-disclose">
+        <summary>Vertical (9:16) for Shorts / mobile</summary>
+        <div class="ic-disclose-body">
+          <p>Set any non-Twitch destination to <b>Vertical</b> and it reuses Twitch's Dual Format 9:16 canvas - one setup in OBS feeds every vertical destination. The card reads <b>Waiting for Dual Format</b> until Enhanced Broadcasting is on. <a href="https://help.twitch.tv/s/article/dual-format-vertical-video?language=en_US" target="_blank" rel="noopener">Set up Dual Format →</a></p>
+        </div>
+      </details>
+      <div class="tour-tip"><strong>Streaming vs Connected:</strong> Streaming = bytes flowing. Connected = TCP up, but OBS hasn't sent a frame yet.</div>
     `,
   },
   {
     target: '.tab[data-tab="obs"]', side: 'bottom', tab: 'obs',
     title: 'Wire OBS to InstantClone',
     body: `
-      <p>Two ways - pick whichever fits your setup.</p>
-      <p><b>Recommended - one click:</b> hit <b>Register with OBS</b> on this tab. InstantClone shows up next to Twitch / YouTube in OBS's <b>Settings → Stream → Service</b> dropdown. Restart OBS once, pick <b>InstantClone</b>, set Stream Key to anything (we suggest <code>main</code>), and hit <b>Start Streaming</b>. Multi-track Video "Auto" works out of the box.</p>
-      <p><b>Fallback - Custom RTMP:</b> if you're on older OBS, using a multi-RTMP plugin, or a non-OBS encoder, use the Server URL + key shown below this section instead - Service: <b>Custom…</b>.</p>
-      <p style="font-size:12px;color:var(--fg-3);margin-top:8px">Until you press <b>Start Streaming</b> in your encoder, the dashboard stays <b>OFFLINE</b> and the OBS pill at the top reads "Offline" - that's expected, not a setup mistake.</p>
-      <div class="tour-tip"><strong>Why a fake key?</strong> OBS's key is just an internal label here. Your real Twitch / YouTube / Kick keys go in the <b>Destinations</b> tab - that's what actually reaches the platforms.</div>
+      <p><b>Recommended:</b> hit <b>Register with OBS</b>. InstantClone appears in OBS's <b>Settings → Stream → Service</b> list - restart OBS once, pick it, set any Stream Key (we suggest <code>main</code>), and Start Streaming.</p>
+      <p><b>Fallback:</b> on older OBS, a multi-RTMP plugin, or a non-OBS encoder, use the Server URL + key shown below with Service: <b>Custom…</b>.</p>
+      <p style="font-size:12px;color:var(--fg-3);margin-top:8px">Until you Start Streaming, the dashboard reads <b>OFFLINE</b> - that's expected, not a mistake.</p>
+      <div class="tour-tip"><strong>Why a fake key?</strong> OBS's key is just a label here. Your real platform keys live in <b>Destinations</b>.</div>
     `,
   },
   {
@@ -5545,7 +6530,8 @@ async function downloadLogs(){
   } catch(e){ toast('Download failed: '+e,'err'); }
 }
 
-// ── Tabs ──────────────────────────────────────────────────────────────
+// - Tabs -------------------------------
+let _tabIdx = -1;   // index of the current tab, for slide direction (see showTab)
 function showTab(name){
   // Guard unsaved Studio edits: switching away from the Overlay tab hides the
   // editor and abandons the in-progress doc, so confirm first.
@@ -5555,8 +6541,24 @@ function showTab(name){
       if (!confirm('You have unsaved overlay changes. Leave the Studio and discard them?')) return;
     }
   }
+  // Direction of travel across the tab strip, so the pane slides in from the
+  // side you moved toward. -1 (unseen) on first switch => no slide, just fade.
+  const tabEls = $$('.tab');
+  const newIdx = tabEls.findIndex(t => t.dataset.tab === name);
+  const dir = (_tabIdx < 0 || newIdx < 0) ? 0 : Math.sign(newIdx - _tabIdx);
+  if (newIdx >= 0) _tabIdx = newIdx;
+  const incoming = document.querySelector(`.tab-pane[data-pane="${name}"]`);
+  if (incoming) incoming.style.setProperty('--pane-dx', dir === 0 ? '0px' : (dir > 0 ? '20px' : '-20px'));
+
+  // Capture the card height BEFORE the swap so we can tween it to the new
+  // pane's height (panes vary; without this the card snaps taller/shorter).
+  const card = document.querySelector('.pane-card');
+  const reduceMo = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const cardH0 = (card && !reduceMo) ? card.offsetHeight : null;
+
   $$('.tab').forEach(t => t.classList.toggle('on', t.dataset.tab === name));
   $$('.tab-pane').forEach(p => p.hidden = p.dataset.pane !== name);
+  if (card && cardH0 != null) morphCardHeight(card, cardH0);
   moveTabInd();
   if (name === 'obs') refreshObsRegisterStatus();
   if (name === 'overlay' && window.ICOverlay) Studio.show();
@@ -5565,7 +6567,7 @@ function showTab(name){
   // Sub-tab indicators only have a real width after the pane unhides,
   // so reposition any sub-tab indicator inside the freshly shown pane.
   const pane = document.querySelector(`.tab-pane[data-pane="${name}"]`);
-  if (pane) moveSubTabInd(pane);
+  if (pane){ moveSubTabInd(pane); reserveCopyButtons(pane); }
 }
 function moveTabInd(){
   const cur = document.querySelector('.tab.on'); if (!cur) return;
@@ -5573,10 +6575,36 @@ function moveTabInd(){
   ind.style.left = cur.offsetLeft + 'px';
   ind.style.width = cur.offsetWidth + 'px';
 }
+
+// Tween the pane card from its previous height (h0) to the new pane's natural
+// height, so switching between panes of different length morphs instead of
+// snapping. Height is a layout property, but this is one short click-driven
+// transition (not per-frame), and .pane-card clips overflow during it so no
+// scrollbar flashes. Interruptible: a rapid re-switch re-targets from the
+// live height. Releases back to `auto` on finish so dynamic content (logs,
+// stats) can still grow the card afterwards.
+function morphCardHeight(card, h0){
+  card.style.height = 'auto';
+  const h1 = card.offsetHeight;              // new pane's clamped natural height
+  if (h1 === h0){ card.style.height = ''; return; }
+  card.style.overflow = 'hidden';
+  card.style.height = h0 + 'px';
+  void card.offsetHeight;                     // lock the start before transitioning
+  card.style.transition = 'height .28s var(--ease-out)';
+  card.style.height = h1 + 'px';
+  if (card._morphDone) card.removeEventListener('transitionend', card._morphDone);
+  card._morphDone = (e) => {
+    if (e.propertyName !== 'height' || e.target !== card) return;
+    card.style.transition = ''; card.style.height = ''; card.style.overflow = '';
+    card.removeEventListener('transitionend', card._morphDone);
+    card._morphDone = null;
+  };
+  card.addEventListener('transitionend', card._morphDone);
+}
 $$('.tab').forEach(t => t.addEventListener('click', () => showTab(t.dataset.tab)));
 window.addEventListener('resize', moveTabInd);
 
-// ── Sub-tabs (currently only the System pane uses these) ──────────────
+// - Sub-tabs (currently only the System pane uses these) -------
 function showSubTab(paneName, subName){
   const pane = document.querySelector(`.tab-pane[data-pane="${paneName}"]`);
   if (!pane) return;
@@ -5628,7 +6656,7 @@ window.addEventListener('resize', () => {
   });
 })();
 
-// ── About sub-tab: version + update check ─────────────────────────────
+// - About sub-tab: version + update check --------------─
 let aboutAutoCheckedOnce = false;
 function aboutMaybeAutoCheck(){
   if (aboutAutoCheckedOnce) return;
@@ -5704,6 +6732,13 @@ async function aboutCheckUpdate(silent){
 let _updating = false;
 async function applyUpdate(){
   if (_updating) return;
+  // Applying an update restarts the exe, which tears down every egress -
+  // same live-stream drop the tray Quit guards against. Confirm only while
+  // OBS is actually publishing; when nothing is live this stays one click.
+  if (lastState && lastState.ingest_alive &&
+      !confirm('OBS is streaming through InstantClone right now. Updating restarts the app and drops every destination.\n\nUpdate anyway?')){
+    return;
+  }
   const upd = $('sys-about-update-btn');
   const chk = $('sys-about-check-btn');
   const msg = $('sys-about-msg');
@@ -5771,7 +6806,7 @@ async function reveal(what, btn){
   } catch(_){ toast('Could not open Explorer','err'); }
 }
 
-// ── Tick / poll loop ──────────────────────────────────────────────────
+// - Tick / poll loop -------------------------
 // applyState() is the pure render side - used by both the poll path
 // and the SSE push path so we don't have two copies of the dashboard
 // reconciliation logic.
@@ -5808,15 +6843,14 @@ function applyState(s){
   if (Array.isArray(s.destinations) && lastDests.length > 0){
     s.destinations.forEach(sd => {
       const ld = lastDests.find(d => d.id === sd.id);
-      if (ld){
-        ld.alive = sd.alive;
-        ld.bitrate_kbps = sd.bitrate_kbps;
-        ld.tags_sent = sd.tags_sent;
-        ld.bytes_sent = sd.bytes_sent;
-        ld.cuts = sd.cuts;
-        ld.reconnects = sd.reconnects;
-        ld.enabled = sd.enabled;
-      }
+      // Copy whatever /state sends instead of a hand-maintained field list.
+      // The old whitelist silently froze any live field it didn't know
+      // about - both the Dual Format icon and the res/codec readout
+      // shipped broken that way, stuck at whatever was true when the page
+      // last fetched /destinations. Adding a field to /state now just
+      // works. Config-only fields (platform, stream_format, stream_key_set,
+      // url_redacted) aren't in /state, so they survive untouched.
+      if (ld) Object.assign(ld, sd);
     });
     rebuildDests();
   }
@@ -5868,6 +6902,10 @@ function startStateSSE(){
 // see a scary error pill for a passive nicety. Cached server-side for
 // 10 min so a F5 spree doesn't hammer GitHub.
 async function checkForUpdate(){
+  // Respect the opt-out. loadConfig() runs before this in init(), so
+  // lastConfig is populated; a missing field defaults to on. The manual
+  // "Check for updates" button bypasses this and always works.
+  if (lastConfig && lastConfig.update_check_enabled === false) return;
   try {
     const r = await (await fetch('/update-check')).json();
     if (!r || !r.update_available) return;
@@ -5889,6 +6927,8 @@ function openUpdateInAbout(){
 (async function init(){
   try { platforms = await (await fetch('/platforms')).json(); } catch(_){ platforms = []; }
   fillWizardPlatforms();
+  wireAllDisclosures();
+  reserveCopyButtons();
   wireChatDock();
   await loadConfig();
   refreshObsRegisterStatus();


### PR DESCRIPTION
Bumps to **0.1.11** (ready to tag).

## Features
- **Encoder-compatibility warnings** (`src/compat.rs`) - measures keyframe interval, resolution, and codec from the live stream and surfaces a single dismissible line only when a setting will break an *enabled* destination (disabled dests, the local sink, and custom RTMP are all ignored). Silent when healthy; the measurement freezes after a few IDR gaps so the line can't flicker mid-stream.
- **Start with Windows** (`src/autostart.rs`) - per-user `Run` key (HKCU, no elevation), registered with `--no-browser`. The registry entry is the sole source of truth, not mirrored into settings, so it can never disagree with Task Manager's Startup tab.
- **Adaptive re-cut** - the re-cut dead band and IDR-search tolerance now scale with the *measured* GOP, so long-keyframe encoders (3-4 s) don't reintroduce the same-IDR "bouncing" re-cut.
- **UX** - LAN-exposure warning (spells out the no-auth control API), open-dashboard-on-launch toggle, quit-while-live tray confirm, and an `is_obs_running()`-gated "close OBS first" wizard hint.

## Fixes
- Keyframe sampler discarded the real first keyframe of every session (`ts == 0` sentinel); now uses an explicit window flag. Caught by its own regression test.
- Compat dismissal is scoped to the publishing session (clears on ingest drop), so a new session with the same problem warns again instead of inheriting a stale dismissal.
- One-click updater confirms before restarting while OBS is publishing, matching the tray Quit guard.
- `cargo fmt`; test badge corrected to 269.

## Dependencies
- `tokio` 1.52.3 -> 1.53.0, `bytes` 1.12.0 -> 1.12.1. **Closes #40 and #39** on merge (versions already incorporated).

## Removed
- `initial_delay_ms` (folded into armed/target delay).

## Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- **269/269 tests pass** (1 ignored)