### PR TITLE
refactor: centralize lock-poison unwrap in crate::sync

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -335,7 +335,6 @@ El HTML del panel se minifica + gzipea en tiempo de compilación con `build.rs` 
 
 - **Solo Windows por ahora.** Varios módulos (bandeja, pre-flight de puerto, muestreo de RSS) usan rutas específicas de Windows. Hay una versión para Linux (incluida una variante headless/terminal para servidor) en la hoja de ruta; macOS aún no está planeado.
 - **La escalera de transcodificado no está garantizada sin EB.** Solo los Twitch Partner tienen slot de transcodificado siempre; el resto se queda en Source-Only, donde algunos decodificadores por hardware fallan por encima de ~8 Mbps (es el comportamiento de asignación de Twitch, no del proxy). Para una escalera garantizada usa Enhanced Broadcasting; si no, mantén el bitrate cerca de ~6000 Kbps.
-- **Un puñado de `unwrap()` sobre guards de lock.** Seguro porque `panic = "abort"` hace que una condición de poison no pueda propagarse, pero sigue en la lista de limpieza.
 - **Servidor HTTP hecho a mano.** Binario más pequeño que con `hyper`, pero soy dueño de toda la superficie HTTP. A revisar si crece.
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ The dashboard HTML is minified + gzipped at build time by `build.rs` (`flate2`, 
 
 - **Windows only today.** Several modules (tray, port pre-flight, RSS sampler) use Windows-specific paths. A Linux build (including a headless/terminal server version) is on the roadmap; macOS isn't planned yet.
 - **Transcoded ladder isn't guaranteed without EB.** Only Twitch Partners get a transcode slot every time; everyone else stays Source-Only, where some hardware decoders fail above ~8 Mbps (Twitch's allocation behaviour, not the proxy). For a guaranteed ladder use Enhanced Broadcasting; otherwise keep bitrate near ~6000 Kbps.
-- **A handful of `unwrap()` on lock guards.** Safe because `panic = "abort"` means a poison condition can't propagate, but still on the cleanup list.
 - **Hand-rolled HTTP server.** Smaller binary than `hyper`, but I own the entire HTTP surface. Worth re-evaluating if it grows.
 
 > [!WARNING]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,11 +9,11 @@
 //! buffer. Each entry is 32 bytes, so 10 minutes of audio+video indexes in
 //! under 2 MB regardless of the bitrate of the underlying media.
 
+use crate::sync::Mutex;
 use std::collections::VecDeque;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::sync::Mutex;
 use tokio::sync::Notify;
 
 #[derive(Clone, Copy, Debug)]
@@ -155,7 +155,6 @@ impl DiskRing {
                     let track_id = crate::h264::seq_header_track_id(payload);
                     self.video_seq_headers
                         .lock()
-                        .unwrap()
                         .insert(track_id, payload.to_vec());
                 }
                 8 => {
@@ -165,7 +164,6 @@ impl DiskRing {
                     let track_id = crate::h264::audio_seq_header_track_id(payload);
                     self.audio_seq_headers
                         .lock()
-                        .unwrap()
                         .insert(track_id, payload.to_vec());
                 }
                 _ => {}
@@ -173,7 +171,7 @@ impl DiskRing {
             return Ok(None);
         }
         if kind == 18 {
-            *self.metadata.lock().unwrap() = Some(payload.to_vec());
+            *self.metadata.lock() = Some(payload.to_vec());
             return Ok(None);
         }
 
@@ -184,7 +182,7 @@ impl DiskRing {
         }
 
         let len = payload.len() as u64;
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         let offset = inner.write_cursor;
         let new_cursor = (offset + len) % self.capacity;
         let wraps = offset + len > self.capacity;
@@ -214,7 +212,7 @@ impl DiskRing {
         // of the syscalls; the index lock is held for the whole append so the
         // index and write cursor advance atomically together.
         {
-            let mut file = self.file.lock().unwrap();
+            let mut file = self.file.lock();
             if !wraps {
                 file.seek(SeekFrom::Start(offset))?;
                 file.write_all(payload)?;
@@ -264,7 +262,7 @@ impl DiskRing {
     /// cannot overwrite the bytes mid-read. Lock order matches `append`'s,
     /// so deadlock is impossible.
     pub fn try_read_seq(&self, seq: u64, buf: &mut Vec<u8>) -> Result<Option<()>> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         let front = match inner.index.front() {
             Some(m) => m.seq,
             None => return Ok(None),
@@ -281,7 +279,7 @@ impl DiskRing {
         buf.clear();
         buf.resize(meta.len as usize, 0);
         let end = meta.offset + meta.len as u64;
-        let mut file = self.file.lock().unwrap();
+        let mut file = self.file.lock();
         if end <= self.capacity {
             file.seek(SeekFrom::Start(meta.offset))?;
             file.read_exact(buf)?;
@@ -298,7 +296,7 @@ impl DiskRing {
     /// Find the entry with the given seq, returning its position in the
     /// VecDeque and the meta. `None` if it's been evicted or never existed.
     pub fn find_by_seq(&self, seq: u64) -> Option<(usize, TagMeta)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         let front = inner.index.front()?.seq;
         if seq < front {
             return None;
@@ -308,15 +306,15 @@ impl DiskRing {
     }
 
     pub fn front_seq(&self) -> Option<u64> {
-        self.inner.lock().unwrap().index.front().map(|m| m.seq)
+        self.inner.lock().index.front().map(|m| m.seq)
     }
 
     pub fn latest_ts(&self) -> Option<u64> {
-        self.inner.lock().unwrap().index.back().map(|m| m.ts_ms)
+        self.inner.lock().index.back().map(|m| m.ts_ms)
     }
 
     pub fn oldest_ts(&self) -> Option<u64> {
-        self.inner.lock().unwrap().index.front().map(|m| m.ts_ms)
+        self.inner.lock().index.front().map(|m| m.ts_ms)
     }
 
     /// Pick the IDR closest to `target_ts` within ±`tolerance_ms`.
@@ -335,7 +333,7 @@ impl DiskRing {
     /// 500 ms, replaying the same content. Closest-pick lets us land
     /// nearer the target on the first try and converges cleanly.
     pub fn find_idr_near(&self, target_ts: u64, tolerance_ms: u32) -> Option<TagMeta> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         let tol = tolerance_ms as u64;
         let pos = inner.idr_index.partition_point(|m| m.ts_ms <= target_ts);
         let below = if pos > 0 {
@@ -390,7 +388,7 @@ impl DiskRing {
     /// Return the most recent IDR (used to seed the egress state cleanly
     /// without walking the entire index entry-by-entry).
     pub fn newest_idr(&self) -> Option<TagMeta> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         inner.index.iter().rev().find(|m| m.is_idr).copied()
     }
 
@@ -398,7 +396,7 @@ impl DiskRing {
     /// Used after a publisher reconnect to skip stale IDRs from the
     /// previous session that still happen to live in the ring.
     pub fn newest_idr_after(&self, min_seq: u64) -> Option<TagMeta> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         inner
             .index
             .iter()
@@ -414,7 +412,7 @@ impl DiskRing {
     /// the *earliest* IDR at or after the skip target loses the least
     /// content while keeping the decode chain valid.
     pub fn oldest_idr_at_or_after(&self, min_seq: u64) -> Option<TagMeta> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         inner
             .index
             .iter()
@@ -424,7 +422,7 @@ impl DiskRing {
 
     /// Seq of the most recently appended tag, or None if the ring is empty.
     pub fn latest_seq(&self) -> Option<u64> {
-        self.inner.lock().unwrap().index.back().map(|m| m.seq)
+        self.inner.lock().index.back().map(|m| m.seq)
     }
 
     /// Trim oldest indexed tags whose timestamp is older than
@@ -437,7 +435,7 @@ impl DiskRing {
     /// buffer's *useful contents* exactly at the user's armed delay
     /// without juggling actual disk layout.
     pub fn trim_older_than(&self, max_age_ms: u32, current_ts: u64, min_seq: u64) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         let cutoff = current_ts.saturating_sub(max_age_ms as u64);
         while let Some(front) = inner.index.front().copied() {
             // Never evict a tag the consumer is still reading or hasn't
@@ -476,7 +474,7 @@ impl DiskRing {
     /// onto fresh data), and the disk bytes get overwritten as new tags
     /// land.
     pub fn clear(&self) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.index.clear();
         inner.idr_index.clear();
     }
@@ -616,7 +614,7 @@ mod tests {
         assert!(r.is_none(), "seq headers must not return a ring seq");
         // Single-track seq headers cache under track id 0 - same slot
         // they used before the per-track refactor for multi-track.
-        let map = t.0.video_seq_headers.lock().unwrap();
+        let map = t.0.video_seq_headers.lock();
         assert_eq!(map.get(&0), Some(&b"AVCDecoderConfig".to_vec()));
     }
 
@@ -636,7 +634,7 @@ mod tests {
         ];
         t.0.append(9, 0, &track_0, false, true).unwrap();
         t.0.append(9, 0, &track_4, false, true).unwrap();
-        let map = t.0.video_seq_headers.lock().unwrap();
+        let map = t.0.video_seq_headers.lock();
         assert_eq!(map.get(&0), Some(&track_0));
         assert_eq!(map.get(&4), Some(&track_4));
         assert_eq!(map.len(), 2);
@@ -659,7 +657,7 @@ mod tests {
         ];
         t.0.append(8, 0, &live, false, true).unwrap();
         t.0.append(8, 0, &vod, false, true).unwrap();
-        let map = t.0.audio_seq_headers.lock().unwrap();
+        let map = t.0.audio_seq_headers.lock();
         assert_eq!(map.get(&0), Some(&live));
         assert_eq!(map.get(&1), Some(&vod));
         assert_eq!(map.len(), 2);
@@ -672,7 +670,7 @@ mod tests {
         let t = tmp(4096);
         let aac = vec![0xaf, 0x00, 0x12, 0x10, 0x56, 0xe5];
         t.0.append(8, 0, &aac, false, true).unwrap();
-        let map = t.0.audio_seq_headers.lock().unwrap();
+        let map = t.0.audio_seq_headers.lock();
         assert_eq!(map.get(&0), Some(&aac));
         assert_eq!(map.len(), 1);
     }
@@ -682,7 +680,7 @@ mod tests {
         let t = tmp(4096);
         let r = t.0.append(18, 0, b"onMetaData", false, false).unwrap();
         assert!(r.is_none());
-        assert_eq!(*t.0.metadata.lock().unwrap(), Some(b"onMetaData".to_vec()));
+        assert_eq!(*t.0.metadata.lock(), Some(b"onMetaData".to_vec()));
     }
 
     #[test]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -194,7 +194,7 @@ pub struct DestinationState {
     /// uses it instead of the configured destination URL. Cleared on
     /// publisher disconnect so the next normal stream goes back to
     /// the configured URL.
-    pub eb_override_url: std::sync::Mutex<Option<String>>,
+    pub eb_override_url: crate::sync::Mutex<Option<String>>,
     /// In-flight latch for the VOD-audio IVS session fetch. Invariant:
     /// `true` for exactly as long as one `fetch_twitch_vod_session` task is
     /// running, `false` otherwise. The supervisor fires every ~2 s; without
@@ -255,7 +255,7 @@ impl DestinationState {
             bitrate_kbps_out: AtomicU32::new(0),
             shutdown_requested: AtomicBool::new(false),
             last_seq_header_gen: AtomicU32::new(0),
-            eb_override_url: std::sync::Mutex::new(None),
+            eb_override_url: crate::sync::Mutex::new(None),
             rate_window_bytes: AtomicU64::new(0),
             rate_window_start_ms: AtomicU64::new(0),
             // Default false: every newly-spawned destination flattens
@@ -328,7 +328,7 @@ impl DestinationState {
         if self.vod_fetch_pending.swap(true, Ordering::Relaxed) {
             return false;
         }
-        if self.eb_override_url.lock().unwrap().is_some() {
+        if self.eb_override_url.lock().is_some() {
             self.vod_fetch_pending.store(false, Ordering::Relaxed);
             return false;
         }
@@ -350,7 +350,7 @@ impl DestinationState {
     /// The epoch is read under the override mutex, so it cannot race
     /// `invalidate_session_override`'s clear+bump.
     pub fn apply_vod_session_if_current(&self, url: String, captured_epoch: u64) -> bool {
-        let mut guard = self.eb_override_url.lock().unwrap();
+        let mut guard = self.eb_override_url.lock();
         if self.session_epoch.load(Ordering::Relaxed) != captured_epoch {
             return false;
         }
@@ -363,7 +363,7 @@ impl DestinationState {
     /// section, so a fetch still in flight discards its (now-stale) result
     /// rather than writing it into the next session.
     pub fn invalidate_session_override(&self) {
-        let mut guard = self.eb_override_url.lock().unwrap();
+        let mut guard = self.eb_override_url.lock();
         *guard = None;
         self.session_epoch.fetch_add(1, Ordering::Relaxed);
     }
@@ -465,7 +465,7 @@ pub struct Controller {
     // `dest.consumer_seq.store` write the pumps do. RwLock lets the
     // hot read path go through concurrently; writes (add/remove dest)
     // are rare so the write-side contention is fine.
-    destinations: std::sync::RwLock<HashMap<String, Arc<DestinationState>>>,
+    destinations: crate::sync::RwLock<HashMap<String, Arc<DestinationState>>>,
 
     // Ingest-side stats
     ingest_disconnects: AtomicU32,
@@ -474,7 +474,7 @@ pub struct Controller {
     rate_window_start_ms: AtomicU64,
 
     // Discord webhook URL. Empty = disabled. Updated live via update_webhook.
-    webhook_url: std::sync::Mutex<String>,
+    webhook_url: crate::sync::Mutex<String>,
     // Wall-clock ms (since UNIX epoch) of last webhook fire. Throttles
     // rapid event sequences (e.g. reconnect flapping) so we never spawn
     // more than one curl every ~2 s.
@@ -556,7 +556,7 @@ pub struct Controller {
     seq_header_gen: AtomicU32,
 
     // In-process log ring (most recent N lines).
-    pub logs: std::sync::Mutex<std::collections::VecDeque<String>>,
+    pub logs: crate::sync::Mutex<std::collections::VecDeque<String>>,
 }
 
 impl Controller {
@@ -575,12 +575,12 @@ impl Controller {
             ingest_alive: AtomicBool::new(false),
             buffer_building: AtomicBool::new(false),
             publisher_token: AtomicU64::new(0),
-            destinations: std::sync::RwLock::new(HashMap::new()),
+            destinations: crate::sync::RwLock::new(HashMap::new()),
             ingest_disconnects: AtomicU32::new(0),
             bitrate_kbps: AtomicU32::new(0),
             rate_window_bytes: AtomicU64::new(0),
             rate_window_start_ms: AtomicU64::new(0),
-            webhook_url: std::sync::Mutex::new(String::new()),
+            webhook_url: crate::sync::Mutex::new(String::new()),
             webhook_last_fire_ms: AtomicU64::new(0),
             publish_lock: Mutex::new(()),
             video_codec: AtomicU8::new(0),
@@ -598,7 +598,7 @@ impl Controller {
             input_ts_wrap_high: AtomicU32::new(0),
             last_multitrack_video_ms: AtomicU64::new(0),
             backpressure_since_ms: AtomicU64::new(0),
-            logs: std::sync::Mutex::new(std::collections::VecDeque::with_capacity(512)),
+            logs: crate::sync::Mutex::new(std::collections::VecDeque::with_capacity(512)),
         }
     }
 
@@ -804,10 +804,10 @@ impl Controller {
     pub fn destination_state(&self, id: &str) -> Arc<DestinationState> {
         // Fast path: existing entry. Use read() so concurrent destination_state
         // calls don't serialise (e.g. supervisor + state endpoint).
-        if let Some(s) = self.destinations.read().unwrap().get(id) {
+        if let Some(s) = self.destinations.read().get(id) {
             return s.clone();
         }
-        let mut map = self.destinations.write().unwrap();
+        let mut map = self.destinations.write();
         map.entry(id.to_string())
             .or_insert_with(|| Arc::new(DestinationState::new(id.to_string())))
             .clone()
@@ -815,7 +815,7 @@ impl Controller {
 
     /// Drop a destination's state - call when the user removes it.
     pub fn remove_destination_state(&self, id: &str) {
-        self.destinations.write().unwrap().remove(id);
+        self.destinations.write().remove(id);
     }
 
     /// Snapshot of every (id → state) pair. Used by graceful-shutdown
@@ -823,7 +823,6 @@ impl Controller {
     pub fn all_destination_states(&self) -> Vec<(String, Arc<DestinationState>)> {
         self.destinations
             .read()
-            .unwrap()
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect()
@@ -831,7 +830,7 @@ impl Controller {
 
     /// Snapshot for the dashboard: (id, alive, consumer_seq, kbps_out, tags, bytes, cuts, reconnects).
     pub fn destination_snapshot(&self) -> Vec<DestinationSnapshot> {
-        let map = self.destinations.read().unwrap();
+        let map = self.destinations.read();
         map.values()
             .map(|d| {
                 (
@@ -852,14 +851,13 @@ impl Controller {
     pub fn any_destination_alive(&self) -> bool {
         self.destinations
             .read()
-            .unwrap()
             .values()
             .any(|d| d.egress_alive.load(Ordering::Relaxed))
     }
 
     /// (alive_count, total_count) - for "2/3 destinations live" chips.
     pub fn destination_alive_summary(&self) -> (u32, u32) {
-        let map = self.destinations.read().unwrap();
+        let map = self.destinations.read();
         let total = map.len() as u32;
         let alive = map
             .values()
@@ -1045,7 +1043,7 @@ impl Controller {
     /// fully caught up, which reads as the live edge.
     fn slowest_live_consumer_ts(&self) -> Option<u64> {
         let min_consumer = {
-            let map = self.destinations.read().unwrap();
+            let map = self.destinations.read();
             map.values()
                 .filter(|d| d.egress_alive.load(Ordering::Relaxed))
                 .map(|d| d.consumer_seq.load(Ordering::Relaxed))
@@ -1135,7 +1133,6 @@ impl Controller {
     pub fn tags_sent(&self) -> u64 {
         self.destinations
             .read()
-            .unwrap()
             .values()
             .map(|d| d.tags_sent.load(Ordering::Relaxed))
             .sum()
@@ -1143,7 +1140,6 @@ impl Controller {
     pub fn bytes_sent(&self) -> u64 {
         self.destinations
             .read()
-            .unwrap()
             .values()
             .map(|d| d.bytes_sent.load(Ordering::Relaxed))
             .sum()
@@ -1151,7 +1147,6 @@ impl Controller {
     pub fn cuts_performed(&self) -> u32 {
         self.destinations
             .read()
-            .unwrap()
             .values()
             .map(|d| d.cuts_performed.load(Ordering::Relaxed))
             .sum()
@@ -1159,7 +1154,6 @@ impl Controller {
     pub fn egress_reconnects(&self) -> u32 {
         self.destinations
             .read()
-            .unwrap()
             .values()
             .map(|d| d.reconnects.load(Ordering::Relaxed))
             .sum()
@@ -1206,7 +1200,7 @@ impl Controller {
     /// other - invaluable for diagnosing "the bouncing happened around
     /// 30 seconds in".
     pub fn log(&self, line: impl Into<String>) {
-        let mut q = self.logs.lock().unwrap();
+        let mut q = self.logs.lock();
         if q.len() >= 1500 {
             q.pop_front();
         }
@@ -1215,7 +1209,7 @@ impl Controller {
     }
 
     pub fn clear_logs(&self) {
-        self.logs.lock().unwrap().clear();
+        self.logs.lock().clear();
     }
 
     // ---- Ingest entry points (called from rtmp::server) ----
@@ -1239,18 +1233,12 @@ impl Controller {
         // we clear them only when a new publisher takes the slot -
         // otherwise stale multi-track SPS/PPS leak into a non-EB
         // session and freeze the destination's decoder.
-        if let Ok(mut hdrs) = self.ring.video_seq_headers.lock() {
-            hdrs.clear();
-        }
-        if let Ok(mut hdrs) = self.ring.audio_seq_headers.lock() {
-            hdrs.clear();
-        }
+        self.ring.video_seq_headers.lock().clear();
+        self.ring.audio_seq_headers.lock().clear();
         // onMetaData leaks the same way: the prior publisher's
         // resolution / fps / encoder fields would be replayed at every
         // pump start until the new publisher's first onMetaData arrives.
-        if let Ok(mut meta) = self.ring.metadata.lock() {
-            *meta = None;
-        }
+        *self.ring.metadata.lock() = None;
         // The ring's indexed tags also have to go. OBS's RTMP wire
         // timestamps restart from ~0 on every fresh stream session
         // (Start Streaming -> Stop -> Start), but the ring still holds
@@ -1324,7 +1312,7 @@ impl Controller {
     /// no in-flight read can be invalidated. If no destinations exist or
     /// none have produced a seq yet, returns u64::MAX so trim is a no-op.
     fn min_consumer_seq(&self) -> u64 {
-        let map = self.destinations.read().unwrap();
+        let map = self.destinations.read();
         map.values()
             .map(|d| d.consumer_seq.load(Ordering::Relaxed))
             .min()
@@ -1341,7 +1329,7 @@ impl Controller {
             return 0;
         };
         let min_consumer = {
-            let map = self.destinations.read().unwrap();
+            let map = self.destinations.read();
             map.values()
                 .filter(|d| d.egress_alive.load(Ordering::Relaxed))
                 .map(|d| d.consumer_seq.load(Ordering::Relaxed))
@@ -1372,7 +1360,7 @@ impl Controller {
         // Skip the check entirely if there's no live destination - the
         // signal is meaningless when nothing is being sent.
         let any_alive = {
-            let map = self.destinations.read().unwrap();
+            let map = self.destinations.read();
             map.values().any(|d| d.egress_alive.load(Ordering::Relaxed))
         };
         if !any_alive {
@@ -1429,7 +1417,7 @@ impl Controller {
     }
 
     pub fn on_metadata(&self, payload: Vec<u8>) {
-        *self.ring.metadata.lock().unwrap() = Some(payload);
+        *self.ring.metadata.lock() = Some(payload);
     }
 
     pub fn mark_ingest_dead(&self) {
@@ -1466,7 +1454,7 @@ impl Controller {
     /// Update the Discord webhook URL - call when settings change. Empty
     /// string disables webhook delivery entirely.
     pub fn update_webhook(&self, url: String) {
-        *self.webhook_url.lock().unwrap() = url;
+        *self.webhook_url.lock() = url;
     }
 
     /// Snapshot the current webhook URL. Used by the test endpoint so it
@@ -1474,7 +1462,7 @@ impl Controller {
     /// going through `fire_webhook` (which is fire-and-forget and
     /// silently swallows everything from empty-URL to TLS failures).
     pub fn webhook_url_snapshot(&self) -> String {
-        self.webhook_url.lock().unwrap().clone()
+        self.webhook_url.lock().clone()
     }
 
     /// Fire-and-forget Discord post. Skips silently when no webhook is
@@ -1487,7 +1475,7 @@ impl Controller {
     /// (a) silently failed when `curl.exe` wasn't on PATH and (b) made
     /// "runtime deps" technically include the system curl binary.
     pub fn fire_webhook(&self, emoji: &str, message: &str) {
-        let url = self.webhook_url.lock().unwrap().clone();
+        let url = self.webhook_url.lock().clone();
         if url.is_empty() {
             return;
         }
@@ -1708,7 +1696,7 @@ async fn pump_dest(
     dest: &Arc<DestinationState>,
     mut sink: EgressSink,
 ) -> io::Result<()> {
-    let meta = ctrl.ring.metadata.lock().unwrap().clone();
+    let meta = ctrl.ring.metadata.lock().clone();
     if let Some(meta) = meta {
         let _ = sink.send_metadata(&meta).await;
     }
@@ -2323,7 +2311,6 @@ async fn send_sequence_headers(
         .ring
         .video_seq_headers
         .lock()
-        .unwrap()
         .iter()
         .map(|(k, v)| (*k, v.clone()))
         .collect();
@@ -2401,7 +2388,6 @@ async fn send_sequence_headers(
         .ring
         .audio_seq_headers
         .lock()
-        .unwrap()
         .iter()
         .map(|(k, v)| (*k, v.clone()))
         .collect();
@@ -3044,10 +3030,10 @@ mod tests {
         // the seq-header cache itself belongs to the ring and only
         // gets wiped by a fresh publisher session - verify it stays.
         let dest = h.ctrl.destination_state("d1");
-        *dest.eb_override_url.lock().unwrap() = Some("rtmps://stale".into());
+        *dest.eb_override_url.lock() = Some("rtmps://stale".into());
         h.ctrl.ingest_alive.store(true, Ordering::Relaxed);
         h.ctrl.mark_ingest_dead();
-        let cache = h.ctrl.ring.video_seq_headers.lock().unwrap();
+        let cache = h.ctrl.ring.video_seq_headers.lock();
         assert_eq!(cache.len(), 4, "all 4 tracks must persist across cut");
         for track in 0u8..=3 {
             assert!(cache.contains_key(&track), "track {track} dropped");
@@ -3064,13 +3050,13 @@ mod tests {
         let h = harness(0);
         for id in ["dest-a", "dest-b", "dest-c"] {
             let s = h.ctrl.destination_state(id);
-            *s.eb_override_url.lock().unwrap() = Some(format!("rtmps://ivs/{id}"));
+            *s.eb_override_url.lock() = Some(format!("rtmps://ivs/{id}"));
         }
         h.ctrl.ingest_alive.store(true, Ordering::Relaxed);
         h.ctrl.mark_ingest_dead();
         for (id, s) in h.ctrl.all_destination_states() {
             assert!(
-                s.eb_override_url.lock().unwrap().is_none(),
+                s.eb_override_url.lock().is_none(),
                 "override for {id} survived ingest cut"
             );
         }
@@ -3109,7 +3095,7 @@ mod tests {
     #[test]
     fn try_claim_vod_fetch_skips_when_session_already_allocated() {
         let s = DestinationState::new("main".into());
-        *s.eb_override_url.lock().unwrap() = Some("rtmps://ivs/session".into());
+        *s.eb_override_url.lock() = Some("rtmps://ivs/session".into());
         assert!(
             !s.try_claim_vod_fetch(),
             "must not claim when a session already exists"
@@ -3131,14 +3117,14 @@ mod tests {
     fn try_claim_vod_fetch_reclaims_after_override_cleared() {
         let s = DestinationState::new("main".into());
         // Post-success state: session allocated, latch released by the task.
-        *s.eb_override_url.lock().unwrap() = Some("rtmps://ivs/session".into());
+        *s.eb_override_url.lock() = Some("rtmps://ivs/session".into());
         s.vod_fetch_pending.store(false, Ordering::Relaxed);
         assert!(
             !s.try_claim_vod_fetch(),
             "a live session must block a re-fetch"
         );
         // Override cleared elsewhere (proxy cleanup / disconnect).
-        *s.eb_override_url.lock().unwrap() = None;
+        *s.eb_override_url.lock() = None;
         assert!(
             s.try_claim_vod_fetch(),
             "cleared override must allow a fresh fetch - no permanent lockout"
@@ -3181,10 +3167,7 @@ mod tests {
             s.apply_vod_session_if_current("rtmps://ivs/live".into(), epoch),
             "same-session fetch must apply"
         );
-        assert_eq!(
-            *s.eb_override_url.lock().unwrap(),
-            Some("rtmps://ivs/live".into())
-        );
+        assert_eq!(*s.eb_override_url.lock(), Some("rtmps://ivs/live".into()));
     }
 
     /// Regression guard for the late-completion race: a VOD-session fetch
@@ -3202,7 +3185,7 @@ mod tests {
             "a fetch outliving its session must be discarded"
         );
         assert!(
-            s.eb_override_url.lock().unwrap().is_none(),
+            s.eb_override_url.lock().is_none(),
             "the stale URL must not leak into the next session"
         );
     }
@@ -3213,13 +3196,10 @@ mod tests {
     #[test]
     fn invalidate_session_override_clears_url_and_bumps_epoch() {
         let s = DestinationState::new("main".into());
-        *s.eb_override_url.lock().unwrap() = Some("rtmps://ivs/old".into());
+        *s.eb_override_url.lock() = Some("rtmps://ivs/old".into());
         let before = s.session_epoch();
         s.invalidate_session_override();
-        assert!(
-            s.eb_override_url.lock().unwrap().is_none(),
-            "url must clear"
-        );
+        assert!(s.eb_override_url.lock().is_none(), "url must clear");
         assert_eq!(s.session_epoch(), before + 1, "epoch must advance");
     }
 
@@ -3235,10 +3215,7 @@ mod tests {
             s.apply_vod_session_if_current("rtmps://ivs/new".into(), fresh_epoch),
             "a fetch from the new session must apply"
         );
-        assert_eq!(
-            *s.eb_override_url.lock().unwrap(),
-            Some("rtmps://ivs/new".into())
-        );
+        assert_eq!(*s.eb_override_url.lock(), Some("rtmps://ivs/new".into()));
     }
 
     /// `complete_vod_fetch` on success applies the URL, reports Applied,
@@ -3253,10 +3230,7 @@ mod tests {
             s.complete_vod_fetch(Some("rtmps://ivs/live".into()), epoch),
             VodFetchOutcome::Applied
         );
-        assert_eq!(
-            *s.eb_override_url.lock().unwrap(),
-            Some("rtmps://ivs/live".into())
-        );
+        assert_eq!(*s.eb_override_url.lock(), Some("rtmps://ivs/live".into()));
         assert!(
             !s.vod_fetch_pending.load(Ordering::Relaxed),
             "latch must be released after a successful completion"
@@ -3276,7 +3250,7 @@ mod tests {
             s.complete_vod_fetch(Some("rtmps://ivs/stale".into()), epoch),
             VodFetchOutcome::DiscardedStale
         );
-        assert!(s.eb_override_url.lock().unwrap().is_none());
+        assert!(s.eb_override_url.lock().is_none());
         assert!(
             !s.vod_fetch_pending.load(Ordering::Relaxed),
             "latch must be released even when the result is discarded"
@@ -3291,7 +3265,7 @@ mod tests {
         assert!(s.try_claim_vod_fetch());
         let epoch = s.session_epoch();
         assert_eq!(s.complete_vod_fetch(None, epoch), VodFetchOutcome::Failed);
-        assert!(s.eb_override_url.lock().unwrap().is_none());
+        assert!(s.eb_override_url.lock().is_none());
         assert!(
             !s.vod_fetch_pending.load(Ordering::Relaxed),
             "latch must be released on failure"
@@ -3328,7 +3302,7 @@ mod tests {
                 });
             });
             assert!(
-                s.eb_override_url.lock().unwrap().is_none(),
+                s.eb_override_url.lock().is_none(),
                 "racing apply against the disconnect must never leave a stale override"
             );
         }
@@ -3401,16 +3375,16 @@ mod tests {
         }
 
         // 3. Populate metadata cache simulating Publisher A's onMetaData.
-        *h.ctrl.ring.metadata.lock().unwrap() = Some(b"onMetaData-publisher-A".to_vec());
+        *h.ctrl.ring.metadata.lock() = Some(b"onMetaData-publisher-A".to_vec());
 
         // Validate baseline assumptions: caches must be fully loaded.
         {
-            let video_cache = h.ctrl.ring.video_seq_headers.lock().unwrap();
+            let video_cache = h.ctrl.ring.video_seq_headers.lock();
             assert_eq!(video_cache.len(), 4, "video cache must start with 4 tracks");
-            let audio_cache = h.ctrl.ring.audio_seq_headers.lock().unwrap();
+            let audio_cache = h.ctrl.ring.audio_seq_headers.lock();
             assert_eq!(audio_cache.len(), 2, "audio cache must start with 2 tracks");
             assert!(
-                h.ctrl.ring.metadata.lock().unwrap().is_some(),
+                h.ctrl.ring.metadata.lock().is_some(),
                 "metadata cache must be active"
             );
         }
@@ -3422,8 +3396,8 @@ mod tests {
         h.ctrl.mark_ingest_dead();
 
         {
-            let video_cache = h.ctrl.ring.video_seq_headers.lock().unwrap();
-            let audio_cache = h.ctrl.ring.audio_seq_headers.lock().unwrap();
+            let video_cache = h.ctrl.ring.video_seq_headers.lock();
+            let audio_cache = h.ctrl.ring.audio_seq_headers.lock();
             assert_eq!(
                 video_cache.len(),
                 4,
@@ -3444,7 +3418,7 @@ mod tests {
             .expect("begin_publish must accept the new session token assignment");
 
         // 5. Hard assertions to guarantee a zeroed cache allocation before streaming starts.
-        let post_video_cache = h.ctrl.ring.video_seq_headers.lock().unwrap();
+        let post_video_cache = h.ctrl.ring.video_seq_headers.lock();
         assert!(
             post_video_cache.is_empty(),
             "leak detected: begin_publish failed to purge video_seq_headers cache. \
@@ -3452,7 +3426,7 @@ mod tests {
             post_video_cache.keys()
         );
 
-        let post_audio_cache = h.ctrl.ring.audio_seq_headers.lock().unwrap();
+        let post_audio_cache = h.ctrl.ring.audio_seq_headers.lock();
         assert!(
             post_audio_cache.is_empty(),
             "leak detected: begin_publish failed to clear stale audio_seq_headers cache. \
@@ -3460,7 +3434,7 @@ mod tests {
             post_audio_cache.keys()
         );
 
-        let post_metadata_cache = h.ctrl.ring.metadata.lock().unwrap();
+        let post_metadata_cache = h.ctrl.ring.metadata.lock();
         assert!(
             post_metadata_cache.is_none(),
             "leak detected: begin_publish failed to clear stale onMetaData. \

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod rtmp;
 mod self_update;
 mod sha256;
 mod sink;
+mod sync;
 mod sysstat;
 mod trace;
 #[cfg(windows)]
@@ -443,7 +444,7 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
         // a vanished vertical canvas reverts vertical destinations to
         // "waiting" without a restart.
         let vertical_track = {
-            let headers = ctrl.ring.video_seq_headers.lock().unwrap();
+            let headers = ctrl.ring.video_seq_headers.lock();
             crate::h264::detect_vertical_primary_track(&headers)
         };
         for (dest, url) in &desired {
@@ -496,7 +497,6 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
                 .destination_state(&dest.id)
                 .eb_override_url
                 .lock()
-                .unwrap()
                 .clone();
             // VOD-audio mode: when this is a Twitch destination with
             // vod_audio=true and we haven't yet fetched an IVS session

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -260,7 +260,7 @@ async fn handle_one(
                 // pre-framed once into an Arc so every connected client
                 // receives a cheap pointer clone, not a copy.
                 let bytes = Arc::new(flv_tag_bytes(18, msg.timestamp, &msg.payload));
-                *live.metadata.lock().unwrap() = Some(bytes.clone());
+                *live.metadata.lock() = Some(bytes.clone());
                 let _ = live.tx.send(bytes);
                 println!("[sink] metadata received ({} bytes)", msg.payload.len());
             }
@@ -270,7 +270,7 @@ async fn handle_one(
                 }
                 let bytes = Arc::new(flv_tag_bytes(8, msg.timestamp, &msg.payload));
                 if h264::is_aac_seq_header(&msg.payload) {
-                    *live.seq_audio.lock().unwrap() = Some(bytes.clone());
+                    *live.seq_audio.lock() = Some(bytes.clone());
                 }
                 let _ = live.tx.send(bytes);
                 stats.note_audio(msg.timestamp, msg.payload.len());
@@ -282,7 +282,7 @@ async fn handle_one(
                 }
                 let bytes = Arc::new(flv_tag_bytes(9, msg.timestamp, &msg.payload));
                 if info.is_seq_header {
-                    *live.seq_video.lock().unwrap() = Some(bytes.clone());
+                    *live.seq_video.lock() = Some(bytes.clone());
                 }
                 let _ = live.tx.send(bytes);
                 stats.note_video(msg.timestamp, msg.payload.len(), info.is_idr, info.is_seq_header);
@@ -576,9 +576,9 @@ fn truncate(s: &str, max: usize) -> String {
 /// Shared state for the live web preview. Cheap to clone (Arc-ed).
 pub struct LiveStream {
     tx: broadcast::Sender<Arc<Vec<u8>>>,
-    seq_video: std::sync::Mutex<Option<Arc<Vec<u8>>>>,
-    seq_audio: std::sync::Mutex<Option<Arc<Vec<u8>>>>,
-    metadata: std::sync::Mutex<Option<Arc<Vec<u8>>>>,
+    seq_video: crate::sync::Mutex<Option<Arc<Vec<u8>>>>,
+    seq_audio: crate::sync::Mutex<Option<Arc<Vec<u8>>>>,
+    metadata: crate::sync::Mutex<Option<Arc<Vec<u8>>>>,
 }
 
 impl LiveStream {
@@ -589,9 +589,9 @@ impl LiveStream {
         let (tx, _) = broadcast::channel(1024);
         Arc::new(Self {
             tx,
-            seq_video: std::sync::Mutex::new(None),
-            seq_audio: std::sync::Mutex::new(None),
-            metadata: std::sync::Mutex::new(None),
+            seq_video: crate::sync::Mutex::new(None),
+            seq_audio: crate::sync::Mutex::new(None),
+            metadata: crate::sync::Mutex::new(None),
         })
     }
 }
@@ -696,9 +696,9 @@ async fn serve_live_flv(sock: &mut TcpStream, live: Arc<LiveStream>) -> io::Resu
     // Bootstrap: cached onMetaData + AAC seq header + AVC seq header.
     // Without these flv.js can't initialize its decoder.
     let snapshots = {
-        let m = live.metadata.lock().unwrap().clone();
-        let a = live.seq_audio.lock().unwrap().clone();
-        let v = live.seq_video.lock().unwrap().clone();
+        let m = live.metadata.lock().clone();
+        let a = live.seq_audio.lock().clone();
+        let v = live.seq_video.lock().clone();
         [m, a, v]
     };
     for slot in snapshots.iter().flatten() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,60 @@
+//! Blocking `Mutex` / `RwLock` with the poison `unwrap` in one place.
+//!
+//! InstantClone ships with `panic = "abort"` (see `[profile.release]` in
+//! Cargo.toml), so in the release binary a lock can never be observed
+//! poisoned: a panic tears the whole process down instead of unwinding out of
+//! a held guard, so no other thread ever sees a half-updated "poisoned" lock.
+//! That makes the `LockResult` on `std`'s locks pure noise at every call site.
+//!
+//! These thin newtypes move that `unwrap` into a single place. `lock` / `read`
+//! / `write` hand back the guard directly, so call sites read as `.lock()`
+//! instead of `.lock().unwrap()`, and the "this cannot actually fail" reasoning
+//! lives here once rather than being re-derived at ~80 sites. Behavior is
+//! identical to the old per-site `.unwrap()`: infallible in release, and a loud
+//! fail-fast panic on the unwind-only poisoned path in debug/test builds (the
+//! right signal - a poisoned lock means a thread already panicked mid-mutation,
+//! so recovering would just mask it). We deliberately do *not* recover via
+//! `into_inner`: that pattern exists to keep an unwinding long-running server
+//! alive across a panicking request, which does not apply when every panic
+//! aborts the process anyway.
+//!
+//! Same memory layout and codegen as the `std` locks, no dependencies, and new
+//! code is clean by construction rather than by an `.unwrap()` convention
+//! everyone has to remember.
+
+use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
+
+/// A `std::sync::Mutex` whose `lock` returns the guard directly.
+#[derive(Debug, Default)]
+pub struct Mutex<T>(std::sync::Mutex<T>);
+
+impl<T> Mutex<T> {
+    pub const fn new(value: T) -> Self {
+        Self(std::sync::Mutex::new(value))
+    }
+
+    #[inline]
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        self.0.lock().unwrap()
+    }
+}
+
+/// A `std::sync::RwLock` whose `read` / `write` return the guard directly.
+#[derive(Debug, Default)]
+pub struct RwLock<T>(std::sync::RwLock<T>);
+
+impl<T> RwLock<T> {
+    pub const fn new(value: T) -> Self {
+        Self(std::sync::RwLock::new(value))
+    }
+
+    #[inline]
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.0.read().unwrap()
+    }
+
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        self.0.write().unwrap()
+    }
+}

--- a/src/sysstat.rs
+++ b/src/sysstat.rs
@@ -3,7 +3,7 @@
 //! dependency); other platforms compile to inert no-op stubs that report
 //! zero. Adding /proc and Mach impls later is a few dozen lines.
 
-use std::sync::Mutex;
+use crate::sync::Mutex;
 use std::time::Instant;
 
 /// One sampler per process. Cheap to create; calling `sample()` more
@@ -107,7 +107,7 @@ mod platform {
                 != 0
             {
                 let total = ft_to_100ns(&kernel).saturating_add(ft_to_100ns(&user));
-                let mut prev = s.prev.lock().unwrap();
+                let mut prev = s.prev.lock();
                 let pct = if let Some((prev_total, prev_t)) = *prev {
                     let dt_ns = now.duration_since(prev_t).as_nanos() as u64;
                     let dt_100ns = dt_ns / 100;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -22,11 +22,11 @@
 //! always-on default is the wrong call for a typical streamer; reserve
 //! the cost for users who are actively diagnosing.
 
+use crate::sync::Mutex;
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -125,7 +125,7 @@ pub fn log(category: &str, msg: &str) {
         // Try to be the thread that emits the final notice. swap to
         // false; only the winner sees `true` and writes the line.
         if ENABLED.swap(false, Ordering::Relaxed) {
-            let mut f = s.file.lock().unwrap();
+            let mut f = s.file.lock();
             let _ = writeln!(
                 f,
                 "T+{:>11.3}ms  {:<22}  trace cap reached ({} MB) - disabling. \
@@ -138,7 +138,7 @@ pub fn log(category: &str, msg: &str) {
         }
         return;
     }
-    let mut f = s.file.lock().unwrap();
+    let mut f = s.file.lock();
     let _ = writeln!(f, "T+{:>11.3}ms  {:<22}  {}", ms, category, msg);
 }
 
@@ -188,7 +188,7 @@ pub fn hex_prefix(bytes: &[u8], max: usize) -> String {
 /// don't get lost in the BufWriter when the process exits.
 pub fn flush() {
     if let Some(s) = STATE.get() {
-        let mut f = s.file.lock().unwrap();
+        let mut f = s.file.lock();
         let _ = f.flush();
     }
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -17,10 +17,11 @@
 
 #![cfg(windows)]
 
+use crate::sync::Mutex;
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tokio::sync::watch;
 
@@ -284,7 +285,7 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
                     // Take the sender so a second click can't double-send.
                     // Ignore the Err: it just means the main task already shut
                     // down (race with ctrl-c) and dropped the receiver.
-                    if let Some(tx) = state.quit.lock().unwrap().take() {
+                    if let Some(tx) = state.quit.lock().take() {
                         let _ = tx.send(());
                     }
                     PostQuitMessage(0);

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -10,7 +10,7 @@
 //! us, or the JSON shape changes, we silently report "couldn't check"
 //! and the dashboard hides the pill.
 
-use std::sync::Mutex;
+use crate::sync::Mutex;
 use std::time::{Duration, Instant};
 
 const RELEASES_URL: &str = "https://api.github.com/repos/Soulhackzlol/InstantClone/releases/latest";
@@ -57,13 +57,13 @@ pub fn current_version() -> &'static str {
 /// call site is the dashboard endpoint, which already runs on the web
 /// worker thread - a 10-second timeout caps the worst case.
 pub fn check_update() -> UpdateInfo {
-    if let Some((when, info)) = CACHE.lock().unwrap().as_ref() {
+    if let Some((when, info)) = CACHE.lock().as_ref() {
         if when.elapsed() < CACHE_TTL {
             return info.clone();
         }
     }
     let info = fetch_latest();
-    *CACHE.lock().unwrap() = Some((Instant::now(), info.clone()));
+    *CACHE.lock() = Some((Instant::now(), info.clone()));
     info
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -32,9 +32,12 @@ use tokio::sync::watch;
 /// this lock two overlapping POSTs each start from the same snapshot and the
 /// later `send()` clobbers the other's change. That lost update used to
 /// silently reset the `configured` flag and bounce users into the first-run
-/// wizard. A plain `std::sync::Mutex` is correct here because the critical
-/// section never `.await`s (its `!Send` guard makes that a compile error), so
-/// it can also be taken from the sync persist/overlay handlers.
+/// wizard. This is the one lock that deliberately keeps `std`'s poison
+/// handling (rather than `crate::sync`): a panic mid-save should not wedge
+/// every later config write, so `settings_write_guard` recovers the guard
+/// instead of propagating. A plain `std::sync::Mutex` is also correct here
+/// because the critical section never `.await`s (its `!Send` guard makes that
+/// a compile error), so it can be taken from the sync persist/overlay handlers.
 static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Take the settings write lock for a full read-modify-write-send cycle. Hold
@@ -774,7 +777,7 @@ async fn handle_sse(
 /// frequently-polled `/state` and `/destinations` endpoints off a
 /// per-dest lock + Exp-Golomb parse.
 fn video_readouts(ctrl: &Controller) -> std::collections::BTreeMap<u8, (String, String)> {
-    let headers = ctrl.ring.video_seq_headers.lock().unwrap();
+    let headers = ctrl.ring.video_seq_headers.lock();
     headers
         .iter()
         .map(|(&track, h)| {
@@ -901,8 +904,7 @@ fn state_json(
     // A portrait canvas is present on the wire (Twitch Dual Format is live).
     // Drives the header "Dual Format" pill.
     let vertical_present =
-        crate::h264::detect_vertical_primary_track(&ctrl.ring.video_seq_headers.lock().unwrap())
-            .is_some();
+        crate::h264::detect_vertical_primary_track(&ctrl.ring.video_seq_headers.lock()).is_some();
 
     format!(
         r#"{{"phase":"{ph}","armed_delay_ms":{ad},"target_delay_ms":{td},"current_delay_ms":{cd},"buffer_fill_ms":{bf},"buffer_target_ms":{btm},"buffer_capacity_ms_est":{bc},"ingest_alive":{ia},"egress_alive":{ea},"destinations_alive":{dla},"destinations_total":{dlt},"buffer_building":{bb},"configured":{cfg},"obs_url":"{ou}","webhook_set":{ws},"video_codec":"{vc}","audio_codec":"{ac}","multitrack_video":{mtv},"multitrack_audio":{mta},"vertical_present":{vp},"cpu_pct":{cp:.2},"rss_bytes":{rb},"publisher_token":{pt},"consumer_lag":{cl},"backpressure":{bp},"safe_cut_pending":{scp},"safe_cut_remaining_ms":{scr},"compat_warning":{cw},"stats":{{"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"ingest_disconnects":{id},"egress_reconnects":{er},"bitrate_kbps":{br}}},"destinations":[{dl}]}}"#,
@@ -1256,7 +1258,7 @@ async fn obs_multitrack_config_proxy(
         };
         if let Some(id) = chosen_id {
             let state = ctrl.destination_state(&id);
-            *state.eb_override_url.lock().unwrap() = Some(ivs.clone());
+            *state.eb_override_url.lock() = Some(ivs.clone());
         }
         // Clean up any stale override on OTHER Twitch destinations -
         // the proxy might have run before and left stale state from a
@@ -1272,7 +1274,7 @@ async fn obs_multitrack_config_proxy(
                 .collect();
             for id in &other_ids {
                 let state = ctrl.destination_state(id);
-                *state.eb_override_url.lock().unwrap() = None;
+                *state.eb_override_url.lock() = None;
             }
         }
         if twitch_count > 1 {
@@ -2137,7 +2139,7 @@ async fn post_profile_del(
 // ---- Logs viewer ----
 
 fn logs_json(ctrl: &Controller) -> String {
-    let q = ctrl.logs.lock().unwrap();
+    let q = ctrl.logs.lock();
     let mut out = String::from(r#"{"lines":["#);
     for (i, line) in q.iter().enumerate() {
         if i > 0 {


### PR DESCRIPTION
## Summary

Centralizes the lock-poison `unwrap` that was repeated at ~80 call sites into a single place.

`panic = "abort"` (release) means a `std` lock can never be observed poisoned, so every `.lock().unwrap()` / `.read()`/`.write()` `.unwrap()` was provably-infallible noise, repeated everywhere and re-derived by each reader. This adds `crate::sync` with thin `Mutex` / `RwLock` newtypes whose `lock` / `read` / `write` return the guard directly.

- Call sites become plain `.lock()` / `.read()` / `.write()`.
- The "this cannot actually fail" reasoning lives in **one** doc comment instead of at every site.
- Poison handling is now a property of the **type**, so new code is clean by construction and can't reintroduce the noise.

**Behavior is identical to the old per-site unwrap:** infallible in release, loud fail-fast on the unwind-only poison path in debug. It deliberately does **not** recover via `into_inner` (that pattern only helps an unwinding long-running server, which is moot when every panic aborts the process).

Also turns three dead `if let Ok(_) = .lock()` poison-branches into unconditional locks.

## Deliberately left untouched

- The async tokio `publish_lock` (different primitive, uses `.await`).
- `web::SETTINGS_WRITE_LOCK`, which intentionally keeps `std` poison recovery so a panic mid-save can't wedge later config writes. It's the one place poison handling is a real choice, not noise, and its comment now says so.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean.
- **282 tests green**, release build OK.
- Zero-cost: `#[inline]` newtype over the `std` lock, same layout and codegen.

## Notes

- No new dependencies (kept off `parking_lot` on purpose - its speed edge is irrelevant here since these locks are uncontended and the bottleneck is the syscall, and it would grow the dependency tree the project keeps minimal).
