### PR TITLE
Linux support with optional dashboard auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,75 @@ jobs:
           path: ${{ runner.temp }}/ic-e2e-*
           retention-days: 7
           if-no-files-found: ignore
+
+  # Linux mirror of the `test` job. Clippy here lints the Linux-only cfg code
+  # (the /proc sampler, .desktop autostart, OBS path resolution) that the
+  # Windows runner never compiles, so it's the real gate for the Linux port.
+  test-linux:
+    name: test + clippy (linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      # native-tls links system OpenSSL on Linux (schannel on Windows), so the
+      # headers must be present for the build to link.
+      - name: install build deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: build
+        run: cargo build --release
+
+      - name: test
+        run: cargo test --release
+
+      - name: upload binary for e2e
+        uses: actions/upload-artifact@v7
+        with:
+          name: instantclone-linux-${{ github.sha }}
+          path: target/release/instantclone
+          retention-days: 1
+
+  # Linux mirror of the e2e job: ffmpeg -> proxy -> sink over a real RTMP peer.
+  # Runs the SAME six scenarios as e2e.ps1 via the bash port, so the whole wire
+  # path (handshake / AMF0 / chunking / delay+cut) is proven on Linux too.
+  e2e-linux:
+    name: e2e linux (ffmpeg → proxy → sink)
+    needs: test-linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: download binary
+        uses: actions/download-artifact@v8
+        with:
+          name: instantclone-linux-${{ github.sha }}
+          path: target/release
+
+      - name: install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: make binary executable
+        run: chmod +x target/release/instantclone
+
+      - name: run e2e
+        run: bash scripts/e2e.sh
+
+      - name: upload e2e logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-linux-logs-${{ github.sha }}
+          path: /tmp/ic-e2e-*
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,56 @@ jobs:
       - name: test
         run: cargo test --release
 
-  # Gate 2: only runs if `test` succeeded. Builds, stages, publishes.
+  # Linux gate: same checks on Ubuntu so we never ship a Linux binary that
+  # fails clippy or tests on its own platform (the Linux-only cfg code is
+  # invisible to the Windows `test` job above).
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - name: install build deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: test
+        run: cargo test --release
+
+  # Builds the Linux binary and hands it to the publish job as an artifact, so
+  # the single GitHub Release carries both OS builds under one SHA256SUMS.
+  build-linux:
+    needs: test-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - name: install build deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: build release
+        run: cargo build --release
+      - name: stage linux binary
+        run: |
+          mkdir -p dist
+          cp target/release/instantclone "dist/instantclone-${{ github.ref_name }}-linux-x64"
+      - name: upload linux binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-binary
+          path: dist/instantclone-*-linux-x64
+          retention-days: 1
+
+  # Gate 2: only runs if BOTH platforms' tests passed and the Linux binary is
+  # built. Stages every artifact, hashes them into one SHA256SUMS, publishes.
   build:
-    needs: test
+    needs: [test, build-linux]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v7
@@ -53,19 +100,36 @@ jobs:
       - name: build release
         run: cargo build --release
 
+      # The Linux binary was built by build-linux; pull it in so it lands in
+      # the same release under the same SHA256SUMS.
+      - name: download linux binary
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-binary
+          path: artifacts
+
       - name: stage artifacts
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path artifacts | Out-Null
+          New-Item -ItemType Directory -Path artifacts -Force | Out-Null
           $tag = "${{ github.ref_name }}"
-          Copy-Item .\target\release\instantclone.exe "artifacts\instantclone-$tag-windows-x64.exe"
+          $win = "instantclone-$tag-windows-x64.exe"
+          $lin = "instantclone-$tag-linux-x64"
+          Copy-Item .\target\release\instantclone.exe "artifacts\$win"
           # Ship the optional VOD-unlocker OBS script under a version-less
           # name so `releases/latest/download/optional-vod-unlocker.lua`
           # always resolves for the in-app auto-downloader.
           Copy-Item .\obs\instantclone-vod-track.lua "artifacts\optional-vod-unlocker.lua"
-          $hash = (Get-FileHash "artifacts\instantclone-$tag-windows-x64.exe" -Algorithm SHA256).Hash.ToLower()
+          # One SHA256SUMS covering every published file. self_update.rs looks
+          # up its line by the exact asset name, so these MUST match
+          # release_asset_name() (locked by a unit test).
+          $winHash = (Get-FileHash "artifacts\$win" -Algorithm SHA256).Hash.ToLower()
           $luaHash = (Get-FileHash "artifacts\optional-vod-unlocker.lua" -Algorithm SHA256).Hash.ToLower()
-          "$hash  instantclone-$tag-windows-x64.exe" | Out-File -FilePath "artifacts\SHA256SUMS.txt" -Encoding ascii
+          "$winHash  $win" | Out-File -FilePath "artifacts\SHA256SUMS.txt" -Encoding ascii
+          if (Test-Path "artifacts\$lin") {
+            $linHash = (Get-FileHash "artifacts\$lin" -Algorithm SHA256).Hash.ToLower()
+            "$linHash  $lin" | Out-File -FilePath "artifacts\SHA256SUMS.txt" -Encoding ascii -Append
+          }
           "$luaHash  optional-vod-unlocker.lua" | Out-File -FilePath "artifacts\SHA256SUMS.txt" -Encoding ascii -Append
           Get-ChildItem artifacts
 
@@ -77,6 +141,7 @@ jobs:
           # v0.1.0-rc.2) is a pre-release. Stable tags (v0.1.0) ship as full.
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
-            artifacts/instantclone-*.exe
+            artifacts/instantclone-*-windows-x64.exe
+            artifacts/instantclone-*-linux-x64
             artifacts/optional-vod-unlocker.lua
             artifacts/SHA256SUMS.txt

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 #  - instantclone.config.json: per-user settings (may contain stream keys)
 /instantclone.buf
 /instantclone.config.json
+# Any ring-buffer file (custom buffer_path names used in local/e2e runs).
+*.buf
 
 # Editor / IDE
 /.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ version = "0.1.13"
 dependencies = [
  "bytes",
  "flate2",
+ "libc",
  "native-tls",
  "tokio",
  "tokio-native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Console",
     "Win32_System_Registry",
     "Win32_System_LibraryLoader",
+    "Win32_Security_Cryptography",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_DataExchange",
@@ -66,6 +67,13 @@ windows-sys = { version = "0.61", features = [
     "Win32_NetworkManagement_IpHelper",
     "Win32_Networking_WinSock",
 ] }
+
+# Unix-only: `statvfs` for the free-space query and `/proc` sampling for the
+# dashboard metric grid. Windows uses its own kernel32 FFI for the same,
+# declared inline. Directly used by config.rs / sysstat.rs, so it's declared
+# here rather than leaned on transitively.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 # Build-time only: minify + gzip the dashboard HTML so the binary embeds
 # only the compressed bytes. Does NOT add to the release binary.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <a href="https://github.com/Soulhackzlol/InstantClone/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Soulhackzlol/InstantClone/ci.yml?branch=main&style=flat-square&label=ci&color=34c759&labelColor=11141a"/></a>
 <a href="https://github.com/Soulhackzlol/InstantClone/releases"><img alt="release" src="https://img.shields.io/github/v/release/Soulhackzlol/InstantClone?include_prereleases&style=flat-square&color=5ac8fa&labelColor=11141a&display_name=tag&sort=semver"/></a>
 <a href="LICENSE"><img alt="GPL-3.0" src="https://img.shields.io/badge/license-GPL--3.0-d4d8e1?style=flat-square&labelColor=11141a"/></a>
-<img alt="Windows only" src="https://img.shields.io/badge/windows-only-7a7d8a?style=flat-square&labelColor=11141a"/>
+<img alt="Windows and Linux" src="https://img.shields.io/badge/platform-windows%20%7C%20linux-7a7d8a?style=flat-square&labelColor=11141a"/>
 <a href="https://alternativeto.net/software/instantclone/about/"><img alt="Listed on AlternativeTo" src="https://img.shields.io/badge/AlternativeTo-listed-5ac8fa?style=flat-square&labelColor=11141a&logo=alternativeto&logoColor=white"/></a>
 
 </div>
@@ -107,8 +107,8 @@ Multi-track "Auto" works out of the box. Your real platform keys go into the **D
 > [!IMPORTANT]
 > Windows Firewall prompts on first launch because the proxy listens on <code>:1935</code> (RTMP) and <code>:7799</code> (web). Allow it on **Private networks** only.
 
-> [!WARNING]
-> Windows 10/11 only. macOS and Linux are not supported, tested, or packaged.
+> [!NOTE]
+> Windows 10/11 and Linux (x86-64) are supported. On Linux it runs headless on a VPS or on an Ubuntu desktop; the browser dashboard is the control surface (there is no native tray). macOS is not supported yet.
 
 <br/>
 
@@ -334,7 +334,7 @@ The dashboard HTML is minified + gzipped at build time by `build.rs` (`flate2`, 
 
 **What's rough, honestly**
 
-- **Windows only today.** Several modules (tray, port pre-flight, RSS sampler) use Windows-specific paths. A Linux build (including a headless/terminal server version) is on the roadmap; macOS isn't planned yet.
+- **No native tray on Linux.** Windows has a system-tray icon; on Linux the control surface is the web dashboard (Quit and Restart live in its System tab). macOS isn't supported yet.
 - **Transcoded ladder isn't guaranteed without EB.** Only Twitch Partners get a transcode slot every time; everyone else stays Source-Only, where some hardware decoders fail above ~8 Mbps (Twitch's allocation behaviour, not the proxy). For a guaranteed ladder use Enhanced Broadcasting; otherwise keep bitrate near ~6000 Kbps.
 - **Hand-rolled HTTP server.** Smaller binary than `hyper`, but I own the entire HTTP surface. Worth re-evaluating if it grows.
 
@@ -399,7 +399,7 @@ In InstantClone's **Destinations** tab, never in OBS. OBS only ever points at In
 
 <br/>
 
-Windows 10/11 today. A **Linux build is on the roadmap**, including a headless/terminal server version for boxes with no desktop. macOS isn't planned yet. A few parts (tray, port pre-flight, memory sampling) use Windows-specific code that needs porting first.
+Windows 10/11 and **Linux (x86-64)** both run it. On Linux it works headless on a VPS or on an Ubuntu desktop, driven by the browser dashboard (there is no native tray, so Quit and Restart live in the dashboard's System tab). For a network-exposed setup, turn on the optional dashboard password and pair it with TLS via a reverse proxy. macOS isn't supported yet.
 
 </details>
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# End-to-end smoke tests: ffmpeg -> instantclone (ingest :1935) -> sink(s).
+# Linux port of e2e.ps1 - same six scenarios, so the wire path (handshake,
+# AMF0, chunking, h264 classification, delay+cut) is proven on Linux too.
+#
+# Runs in CI and locally. Locally, point $INSTANTCLONE_EXE at the built binary
+# or this script looks for ./target/release/instantclone. Needs ffmpeg + jq
+# + curl on PATH (all preinstalled on GitHub's ubuntu-latest).
+#
+# Scenarios: A basic passthrough, B publisher reconnect (seq-header leak),
+# C multi-destination, D HTTP API smoke, E delay + IDR-aligned cut,
+# F scheduled "cut after this airs".
+
+set -u
+
+EXE="${INSTANTCLONE_EXE:-./target/release/instantclone}"
+[ -x "$EXE" ] || { echo "instantclone not found/executable at '$EXE' - build it first (cargo build --release)"; exit 1; }
+for tool in ffmpeg jq curl; do
+  command -v "$tool" >/dev/null || { echo "$tool not on PATH"; exit 1; }
+done
+
+# --- Helpers ----------------------------------------------------------
+
+wait_port() { # host-less: $1=port $2=timeout_sec
+  local end=$((SECONDS + $2))
+  while [ $SECONDS -lt $end ]; do
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_http() { # $1=url $2=timeout_sec
+  local end=$((SECONDS + $2))
+  while [ $SECONDS -lt $end ]; do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$1")" = "200" ] && return 0
+    sleep 0.25
+  done
+  return 1
+}
+
+get_state() { curl -s --max-time 2 http://127.0.0.1:7799/state; }
+
+# Poll GET /state until the jq boolean filter in $1 is true (or timeout $2).
+wait_state() {
+  local end=$((SECONDS + $2)) s
+  while [ $SECONDS -lt $end ]; do
+    s=$(get_state)
+    [ -n "$s" ] && [ "$(echo "$s" | jq -r "$1" 2>/dev/null)" = "true" ] && return 0
+    sleep 0.3
+  done
+  return 1
+}
+
+stop_safe() { [ -n "${1:-}" ] && kill "$1" 2>/dev/null; wait "$1" 2>/dev/null; return 0; }
+
+push_ffmpeg() { # $1=duration_sec ; blocking
+  ffmpeg -loglevel error -re \
+    -f lavfi -i "testsrc=size=320x240:rate=15:duration=$1" \
+    -f lavfi -i "sine=frequency=440:duration=$1" \
+    -c:v libx264 -preset ultrafast -g 15 -b:v 400k \
+    -c:a aac -b:a 64k \
+    -f flv rtmp://127.0.0.1:1935/live/stream >/dev/null 2>&1
+}
+
+start_ffmpeg() { # $1=duration_sec ; non-blocking, echoes PID
+  ffmpeg -loglevel error -re \
+    -f lavfi -i "testsrc=size=320x240:rate=15:duration=$1" \
+    -f lavfi -i "sine=frequency=440:duration=$1" \
+    -c:v libx264 -preset ultrafast -g 15 -b:v 400k \
+    -c:a aac -b:a 64k \
+    -f flv rtmp://127.0.0.1:1935/live/stream >ffsrc.out 2>ffsrc.err &
+  echo $!
+}
+
+start_sink() { # $1=port $2=logfile ; echoes PID
+  "$EXE" sink --port "$1" --web-port 0 --temp --max-mb 50 >"$2" 2>&1 &
+  echo $!
+}
+
+start_ic() { # $1=logfile ; echoes PID
+  INSTANTCLONE_NO_BROWSER=1 CONFIG_PATH="$PWD/instantclone.config.json" \
+    "$EXE" --no-browser >"$1" 2>&1 &
+  echo $!
+}
+
+# write_config "id|name|platform|url|key" ["..."]...
+write_config() {
+  {
+    cat <<'EOF'
+configured=true
+ingest_port=1935
+ingest_bind_all=false
+web_port=7799
+web_bind_all=false
+buffer_mb=50
+buffer_path=./instantclone.buf
+target_delay_ms=0
+armed_delay_ms=0
+initial_delay_ms=0
+EOF
+    local i=0 d id name platform url key
+    for d in "$@"; do
+      IFS='|' read -r id name platform url key <<<"$d"
+      printf 'destination.%s.id=%s\n' "$i" "$id"
+      printf 'destination.%s.name=%s\n' "$i" "$name"
+      printf 'destination.%s.enabled=true\n' "$i"
+      printf 'destination.%s.platform=%s\n' "$i" "$platform"
+      printf 'destination.%s.stream_key=%s\n' "$i" "$key"
+      printf 'destination.%s.custom_egress_url=%s\n' "$i" "$url"
+      i=$((i + 1))
+    done
+  } >instantclone.config.json
+}
+
+# --- Scenario harness -------------------------------------------------
+
+FAILS=()        # failures for the current scenario
+PASS_COUNT=0
+FAIL_COUNT=0
+REPORT=()
+
+fail() { FAILS+=("$1"); }
+assert() { [ "$1" = "0" ] || fail "$2"; }  # $1: 0/1 result of a test, $2: message
+
+run_scenario() {
+  local name="$1"; shift
+  FAILS=()
+  echo ""
+  echo "==========================================================="
+  echo "> Scenario: $name"
+  echo "==========================================================="
+  "$@"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    echo "PASS  $name"
+    REPORT+=("PASS  $name")
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL  $name"
+    for f in "${FAILS[@]}"; do echo "      * $f"; done
+    REPORT+=("FAIL  $name")
+    for f in "${FAILS[@]}"; do REPORT+=("        * $f"); done
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ic-e2e-XXXXXX")"
+echo "e2e work dir: $WORKDIR"
+cd "$WORKDIR"
+
+# --- Scenario A: basic passthrough -----------------------------------
+
+scenario_a() {
+  write_config "e2e|Sink|custom|rtmp://127.0.0.1:1936/live|stream"
+  local sink ic
+  sink=$(start_sink 1936 A.sink.log)
+  ic=$(start_ic A.ic.log)
+  wait_port 1936 15; assert $? "sink never opened :1936"
+  wait_port 1935 15; assert $? "instantclone never opened :1935"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    push_ffmpeg 6
+    sleep 3
+    grep -q "publish accepted" A.sink.log; assert $? "sink never accepted publish"
+    grep -Eq "[1-9][0-9]* IDR" A.sink.log; assert $? "sink saw zero IDRs"
+    grep -Eq "audio=[1-9][0-9]*" A.sink.log; assert $? "sink saw zero audio frames"
+  fi
+  stop_safe "$ic"; stop_safe "$sink"; sleep 1
+}
+
+# --- Scenario B: publisher reconnect ---------------------------------
+
+scenario_b() {
+  write_config "e2e|Sink|custom|rtmp://127.0.0.1:1936/live|stream"
+  local sink ic accepts
+  sink=$(start_sink 1936 B.sink.log)
+  ic=$(start_ic B.ic.log)
+  wait_port 1936 15; assert $? "sink never opened :1936"
+  wait_port 1935 15; assert $? "instantclone never opened :1935"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    push_ffmpeg 3          # session 1
+    sleep 2
+    sleep 2               # let ingest mark dead + supervisor tick
+    push_ffmpeg 3          # session 2 - must reach the sink cleanly
+    sleep 3
+    accepts=$(grep -c "publish accepted" B.sink.log)
+    assert "$([ "$accepts" -ge 2 ] && echo 0 || echo 1)" "sink only saw $accepts publish accepts (expected >= 2)"
+    grep -Eq "[1-9][0-9]* IDR" B.sink.log; assert $? "sink saw zero IDRs across the two sessions"
+  fi
+  stop_safe "$ic"; stop_safe "$sink"; sleep 1
+}
+
+# --- Scenario C: multi-destination ------------------------------------
+
+scenario_c() {
+  write_config \
+    "d1|SinkOne|custom|rtmp://127.0.0.1:1936/live|s1" \
+    "d2|SinkTwo|custom|rtmp://127.0.0.1:1937/live|s2"
+  local sink1 sink2 ic
+  sink1=$(start_sink 1936 C.sink1.log)
+  sink2=$(start_sink 1937 C.sink2.log)
+  ic=$(start_ic C.ic.log)
+  wait_port 1936 15; assert $? "sink1 never opened :1936"
+  wait_port 1937 15; assert $? "sink2 never opened :1937"
+  wait_port 1935 15; assert $? "instantclone never opened :1935"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    push_ffmpeg 6
+    sleep 3
+    grep -q "publish accepted" C.sink1.log; assert $? "sink1 never accepted publish"
+    grep -q "publish accepted" C.sink2.log; assert $? "sink2 never accepted publish"
+    grep -Eq "[1-9][0-9]* IDR" C.sink1.log; assert $? "sink1 saw zero IDRs"
+    grep -Eq "[1-9][0-9]* IDR" C.sink2.log; assert $? "sink2 saw zero IDRs"
+  fi
+  stop_safe "$ic"; stop_safe "$sink1"; stop_safe "$sink2"; sleep 1
+}
+
+# --- Scenario D: HTTP API smoke ---------------------------------------
+
+scenario_d() {
+  write_config "e2e|Sink|custom|rtmp://127.0.0.1:1936/live|stream"
+  local ic cfg
+  ic=$(start_ic D.ic.log)
+  wait_http "http://127.0.0.1:7799/state" 15; assert $? "web UI never came up on :7799"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    local s; s=$(get_state)
+    for k in phase ingest_alive destinations stats; do
+      [ "$(echo "$s" | jq "has(\"$k\")")" = "true" ]; assert $? "GET /state missing key '$k'"
+    done
+
+    curl -s -X POST --data "ms=2000" -H "Content-Type: application/x-www-form-urlencoded" http://127.0.0.1:7799/arm >/dev/null
+    sleep 0.3
+    [ "$(get_state | jq -r .phase)" != "idle" ]; assert $? "phase still 'idle' after /arm ms=2000"
+
+    curl -s -X POST http://127.0.0.1:7799/disarm >/dev/null
+    sleep 0.3
+    [ "$(get_state | jq -r .phase)" = "idle" ]; assert $? "phase not 'idle' after /disarm"
+
+    curl -s -X POST "http://127.0.0.1:7799/config/reset?scope=settings" >/dev/null
+    sleep 0.3
+    cfg=$(curl -s http://127.0.0.1:7799/config)
+    [ "$(echo "$cfg" | jq -r .ingest_port)" = "1935" ]; assert $? "ingest_port not reset to default"
+    [ "$(echo "$cfg" | jq -r .web_port)" = "7799" ]; assert $? "web_port not reset to default"
+    [ "$(echo "$cfg" | jq '.destinations | length')" -ge 1 ]; assert $? "destinations wiped by scope=settings reset"
+
+    curl -s -X POST "http://127.0.0.1:7799/config/reset?scope=all" >/dev/null
+    sleep 0.3
+    cfg=$(curl -s http://127.0.0.1:7799/config)
+    [ "$(echo "$cfg" | jq '.destinations | length')" -eq 0 ]; assert $? "destinations not wiped by scope=all reset"
+    [ "$(echo "$cfg" | jq -r .configured)" = "false" ]; assert $? "configured not flipped to false by scope=all reset"
+  fi
+  stop_safe "$ic"; sleep 1
+}
+
+# --- Scenario E: delay + IDR-aligned cut ------------------------------
+
+scenario_e() {
+  write_config "e2e|Sink|custom|rtmp://127.0.0.1:1936/live|stream"
+  local sink ic ff before after accepts
+  sink=$(start_sink 1936 E.sink.log)
+  ic=$(start_ic E.ic.log)
+  wait_port 1936 15; assert $? "sink never opened :1936"
+  wait_port 1935 15; assert $? "instantclone never opened :1935"
+  wait_http "http://127.0.0.1:7799/state" 15; assert $? "web UI never came up on :7799"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    ff=$(start_ffmpeg 18)
+    wait_state '.ingest_alive == true' 15; assert $? "ingest never went live"
+  fi
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    curl -s -X POST --data "ms=2000" -H "Content-Type: application/x-www-form-urlencoded" http://127.0.0.1:7799/arm >/dev/null
+    wait_state '.phase == "ready"' 15; assert $? "phase never reached 'ready' after arming 2 s (ring did not fill)"
+  fi
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    sleep 0.5
+    before=$(grep -oE '\([0-9]+ IDR\)' E.sink.log | wc -l)
+    curl -s -X POST http://127.0.0.1:7799/activate >/dev/null
+    wait_state '.phase=="active" and .current_delay_ms>0' 10; assert $? "delay never engaged after /activate"
+    sleep 4
+    after=$(grep -oE '\([0-9]+ IDR\)' E.sink.log | wc -l)
+    accepts=$(grep -c "publish accepted" E.sink.log)
+    assert "$([ "$accepts" -eq 1 ] && echo 0 || echo 1)" "sink saw $accepts publish accepts (expected exactly 1 - the cut broke the downstream)"
+    assert "$([ "$after" -gt "$before" ] && echo 0 || echo 1)" "sink stopped receiving after the cut ($before -> $after windows)"
+    grep -Eq '\([1-9][0-9]* IDR\)' E.sink.log; assert $? "sink saw no IDR windows across the delayed stream"
+  fi
+  stop_safe "$ff"; stop_safe "$ic"; stop_safe "$sink"; sleep 1
+}
+
+# --- Scenario F: scheduled cut ("cut after this airs") ----------------
+
+scenario_f() {
+  write_config "e2e|Sink|custom|rtmp://127.0.0.1:1936/live|stream"
+  local sink ic ff code r s accepts
+  sink=$(start_sink 1936 F.sink.log)
+  ic=$(start_ic F.ic.log)
+  wait_port 1936 15; assert $? "sink never opened :1936"
+  wait_port 1935 15; assert $? "instantclone never opened :1935"
+  wait_http "http://127.0.0.1:7799/state" 15; assert $? "web UI never came up on :7799"
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    code=$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:7799/cut-after)
+    assert "$([ "$code" = "409" ] && echo 0 || echo 1)" "POST /cut-after with no active delay returned $code (want 409)"
+
+    ff=$(start_ffmpeg 25)
+    wait_state '.ingest_alive == true' 15; assert $? "ingest never went live"
+  fi
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    curl -s -X POST --data "ms=2000" -H "Content-Type: application/x-www-form-urlencoded" http://127.0.0.1:7799/arm >/dev/null
+    wait_state '.phase == "ready"' 15; assert $? "phase never reached 'ready' after arming 2 s"
+    curl -s -X POST http://127.0.0.1:7799/activate >/dev/null
+    wait_state '.phase=="active" and .current_delay_ms>0' 10; assert $? "delay never engaged after /activate"
+  fi
+  if [ ${#FAILS[@]} -eq 0 ]; then
+    # Schedule then cancel: the mark must drop WITHOUT cutting.
+    r=$(curl -s -X POST http://127.0.0.1:7799/cut-after)
+    [ "$(echo "$r" | jq -r .safe_cut_pending)" = "true" ]; assert $? "/cut-after did not set safe_cut_pending"
+    [ "$(echo "$r" | jq -r .safe_cut_remaining_ms)" -gt 0 ] 2>/dev/null; assert $? "/cut-after reported a zero countdown"
+    curl -s -X POST http://127.0.0.1:7799/cut-after/cancel >/dev/null
+    s=$(get_state)
+    [ "$(echo "$s" | jq -r .safe_cut_pending)" = "false" ]; assert $? "cancel did not clear the pending mark"
+    [ "$(echo "$s" | jq -r .phase)" = "active" ]; assert $? "cancel cut the delay (want 'active')"
+
+    # Re-schedule and let it fire: proxy must auto-cut back to passthrough.
+    curl -s -X POST http://127.0.0.1:7799/cut-after >/dev/null
+    wait_state '.safe_cut_pending==false and .phase=="ready"' 12; assert $? "scheduled cut never fired (want pending=false + phase 'ready')"
+    sleep 2
+    accepts=$(grep -c "publish accepted" F.sink.log)
+    assert "$([ "$accepts" -eq 1 ] && echo 0 || echo 1)" "sink saw $accepts publish accepts (expected exactly 1 - the scheduled cut broke the downstream)"
+  fi
+  stop_safe "$ff"; stop_safe "$ic"; stop_safe "$sink"; sleep 1
+}
+
+# --- Run --------------------------------------------------------------
+
+run_scenario "A -basic passthrough (1 sink, 1 publisher)" scenario_a
+run_scenario "B -publisher reconnect (catches seq-header leak)" scenario_b
+run_scenario "C -multi-destination (1 publisher, 2 sinks)" scenario_c
+run_scenario "D -HTTP API smoke (arm/state/disarm/reset)" scenario_d
+run_scenario "E -delay + IDR-aligned cut (arm/ready/activate)" scenario_e
+run_scenario "F -scheduled cut (/cut-after fires once the mark airs)" scenario_f
+
+# --- Report -----------------------------------------------------------
+
+echo ""
+echo "==========================================================="
+echo "  E2E REPORT"
+echo "==========================================================="
+for line in "${REPORT[@]}"; do echo "  $line"; done
+echo ""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "e2e: $FAIL_COUNT of $((PASS_COUNT + FAIL_COUNT)) scenarios failed"
+  exit 1
+fi
+echo "e2e: all $PASS_COUNT scenarios passed"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -15,6 +15,9 @@ set -u
 
 EXE="${INSTANTCLONE_EXE:-./target/release/instantclone}"
 [ -x "$EXE" ] || { echo "instantclone not found/executable at '$EXE' - build it first (cargo build --release)"; exit 1; }
+# Pin EXE to an absolute path now: each scenario cd's into a fresh temp work
+# dir, so the relative default would stop resolving once the cwd changes.
+EXE="$(cd "$(dirname "$EXE")" && pwd)/$(basename "$EXE")"
 for tool in ffmpeg jq curl; do
   command -v "$tool" >/dev/null || { echo "$tool not on PATH"; exit 1; }
 done

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -81,11 +81,7 @@ impl RateLimiter {
         if a.len() >= MAX_TRACKED {
             a.retain(|_, e| now.duration_since(e.last) <= self.window);
             if a.len() >= MAX_TRACKED {
-                if let Some(oldest) = a
-                    .iter()
-                    .min_by_key(|(_, e)| e.last)
-                    .map(|(k, _)| k.clone())
-                {
+                if let Some(oldest) = a.iter().min_by_key(|(_, e)| e.last).map(|(k, _)| k.clone()) {
                     a.remove(&oldest);
                 }
             }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -68,11 +68,40 @@ impl RateLimiter {
         Ok(())
     }
 
+    /// Reject if `client` is locked out; otherwise count this attempt and arm
+    /// the lockout if it crosses the threshold - all under a single lock. Use
+    /// this when the check and the verification it guards are separated by an
+    /// `.await` (login runs PBKDF2 on a blocking thread): counting at check time
+    /// stops a burst of concurrent requests from all clearing the gate before
+    /// any failure is recorded. Clear on success with `record_success`; a plain
+    /// failure needs no further call.
+    pub fn check_and_count(&self, client: &str) -> Result<(), Duration> {
+        let now = Instant::now();
+        let mut a = self.attempts.lock();
+        if let Some(e) = a.get(client) {
+            if now.duration_since(e.last) > self.window {
+                a.remove(client);
+            } else if let Some(until) = e.locked_until {
+                if until > now {
+                    return Err(until - now);
+                }
+            }
+        }
+        self.bump_failure(&mut a, client, now);
+        Ok(())
+    }
+
     /// Record a failed attempt and (re)arm the lockout: exponential in the
     /// number of failures past the threshold, capped at `max_lockout`.
     pub fn record_failure(&self, client: &str) {
         let now = Instant::now();
         let mut a = self.attempts.lock();
+        self.bump_failure(&mut a, client, now);
+    }
+
+    /// Increment a client's failure count under an already-held lock, arming the
+    /// exponential lockout past the threshold and keeping the map bounded.
+    fn bump_failure(&self, a: &mut HashMap<String, Attempt>, client: &str, now: Instant) {
         // Bound the map so an attacker cycling source IPs (a whole IPv6 /64 is
         // routable to one host) can't grow it without limit. Drop entries past
         // the forgiveness window first; if a genuine flood keeps it full, evict
@@ -94,8 +123,14 @@ impl RateLimiter {
         e.fails = e.fails.saturating_add(1);
         e.last = now;
         if e.fails >= self.max_fails {
-            let over = (e.fails - self.max_fails).min(6); // cap the shift
-            let lock = (self.base_lockout * (1u32 << over)).min(self.max_lockout);
+            // Cap the shift so the doubling can't overflow.
+            let over = (e.fails - self.max_fails).min(6);
+            // Never lock past the forgiveness window: `check` frees an entry once
+            // it's older than `window`, so a lockout longer than that could be
+            // wiped early. Clamp to keep the two consistent regardless of config.
+            let lock = (self.base_lockout * (1u32 << over))
+                .min(self.max_lockout)
+                .min(self.window);
             e.locked_until = Some(now + lock);
         }
     }
@@ -168,12 +203,12 @@ impl AuthState {
         self.sessions.lock().clear();
     }
 
-    // Login limiter, delegated so web.rs keeps its small surface.
-    pub fn check_login_allowed(&self, client: &str) -> Result<(), Duration> {
-        self.login.check(client)
-    }
-    pub fn record_failure(&self, client: &str) {
-        self.login.record_failure(client)
+    // Login limiter, delegated so web.rs keeps its small surface. The gate
+    // counts the attempt as it checks (`check_and_count`) so a burst of
+    // concurrent logins can't slip past the lockout before the async password
+    // hash resolves; a success clears the record.
+    pub fn begin_login_attempt(&self, client: &str) -> Result<(), Duration> {
+        self.login.check_and_count(client)
     }
     pub fn record_success(&self, client: &str) {
         self.login.record_success(client)
@@ -209,13 +244,33 @@ mod tests {
     fn lockout_after_threshold_and_cleared_on_success() {
         let a = AuthState::new();
         let ip = "10.0.0.1";
-        assert!(a.check_login_allowed(ip).is_ok());
+        // Each attempt counts as it's checked. Five are allowed, the sixth is
+        // locked out; a success clears the record.
         for _ in 0..5 {
-            a.record_failure(ip);
+            assert!(a.begin_login_attempt(ip).is_ok());
         }
-        assert!(a.check_login_allowed(ip).is_err());
+        assert!(a.begin_login_attempt(ip).is_err());
         a.record_success(ip);
-        assert!(a.check_login_allowed(ip).is_ok());
+        assert!(a.begin_login_attempt(ip).is_ok());
+    }
+
+    #[test]
+    fn check_and_count_counts_at_check_time() {
+        // The gate must count the attempt itself, so concurrent callers can't
+        // all pass before any failure lands (the TOCTOU the login await opened).
+        let r = RateLimiter::new(
+            3,
+            Duration::from_secs(30),
+            Duration::from_secs(600),
+            Duration::from_secs(600),
+        );
+        let c = "peer";
+        assert!(r.check_and_count(c).is_ok()); // 1
+        assert!(r.check_and_count(c).is_ok()); // 2
+        assert!(r.check_and_count(c).is_ok()); // 3 -> arms the lock
+        assert!(r.check_and_count(c).is_err()); // 4 -> locked, no verify happens
+        r.record_success(c);
+        assert!(r.check_and_count(c).is_ok()); // cleared
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,243 @@
+//! Optional dashboard-auth runtime state: live session tokens plus a reusable
+//! failed-attempt rate limiter. Only exercised when a password / ingest key is
+//! set; a default install never constructs a session or records an attempt.
+//!
+//! Held as an `Arc<AuthState>` created in `main`, so sessions survive a web
+//! supervisor restart (port change). The password hash and dock token live in
+//! `Settings`; this holds only the ephemeral state.
+
+use crate::crypto;
+use crate::sync::Mutex;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Session lifetime. Long enough that a streamer is not re-prompted mid-stream,
+/// short enough that a stolen cookie does not live forever.
+const SESSION_TTL: Duration = Duration::from_secs(30 * 24 * 3600);
+
+struct Attempt {
+    fails: u32,
+    last: Instant,
+    locked_until: Option<Instant>,
+}
+
+/// Per-client failed-attempt limiter with exponential lockout. Shared by the
+/// dashboard login and the RTMP ingest-key check so both throttle guessing the
+/// same way. `check` is O(1) and must be called BEFORE any expensive work
+/// (a password hash, a wire round-trip) so a locked-out client costs nothing.
+pub struct RateLimiter {
+    attempts: Mutex<HashMap<String, Attempt>>,
+    max_fails: u32,
+    base_lockout: Duration,
+    max_lockout: Duration,
+    window: Duration,
+}
+
+impl RateLimiter {
+    pub fn new(
+        max_fails: u32,
+        base_lockout: Duration,
+        max_lockout: Duration,
+        window: Duration,
+    ) -> Self {
+        Self {
+            attempts: Mutex::new(HashMap::new()),
+            max_fails,
+            base_lockout,
+            max_lockout,
+            window,
+        }
+    }
+
+    /// `Err(remaining)` when `client` is currently locked out, else `Ok`.
+    pub fn check(&self, client: &str) -> Result<(), Duration> {
+        let now = Instant::now();
+        let mut a = self.attempts.lock();
+        if let Some(e) = a.get(client) {
+            // A quiet window forgives an honest user who fumbled earlier.
+            if now.duration_since(e.last) > self.window {
+                a.remove(client);
+                return Ok(());
+            }
+            if let Some(until) = e.locked_until {
+                if until > now {
+                    return Err(until - now);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a failed attempt and (re)arm the lockout: exponential in the
+    /// number of failures past the threshold, capped at `max_lockout`.
+    pub fn record_failure(&self, client: &str) {
+        let now = Instant::now();
+        let mut a = self.attempts.lock();
+        // Bound the map so an attacker cycling source IPs (a whole IPv6 /64 is
+        // routable to one host) can't grow it without limit. Drop entries past
+        // the forgiveness window first; if a genuine flood keeps it full, evict
+        // the single oldest to make room. Caps memory at ~MAX_TRACKED entries.
+        const MAX_TRACKED: usize = 8192;
+        if a.len() >= MAX_TRACKED {
+            a.retain(|_, e| now.duration_since(e.last) <= self.window);
+            if a.len() >= MAX_TRACKED {
+                if let Some(oldest) = a
+                    .iter()
+                    .min_by_key(|(_, e)| e.last)
+                    .map(|(k, _)| k.clone())
+                {
+                    a.remove(&oldest);
+                }
+            }
+        }
+        let e = a.entry(client.to_string()).or_insert(Attempt {
+            fails: 0,
+            last: now,
+            locked_until: None,
+        });
+        e.fails = e.fails.saturating_add(1);
+        e.last = now;
+        if e.fails >= self.max_fails {
+            let over = (e.fails - self.max_fails).min(6); // cap the shift
+            let lock = (self.base_lockout * (1u32 << over)).min(self.max_lockout);
+            e.locked_until = Some(now + lock);
+        }
+    }
+
+    /// Clear a client's record after a success.
+    pub fn record_success(&self, client: &str) {
+        self.attempts.lock().remove(client);
+    }
+}
+
+pub struct AuthState {
+    sessions: Mutex<HashMap<String, Instant>>, // token -> expiry
+    login: RateLimiter,
+}
+
+impl Default for AuthState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthState {
+    pub fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            // 5 failures then an exponential lockout, 15s base up to 15min,
+            // forgiven after a 15min quiet window. Paired with the ~230ms
+            // PBKDF2 cost this throttles online guessing to a crawl.
+            login: RateLimiter::new(
+                5,
+                Duration::from_secs(15),
+                Duration::from_secs(15 * 60),
+                Duration::from_secs(15 * 60),
+            ),
+        }
+    }
+
+    /// Mint a fresh 256-bit session token valid for `SESSION_TTL`.
+    pub fn create_session(&self) -> String {
+        let token = crypto::random_token();
+        let mut s = self.sessions.lock();
+        s.insert(token.clone(), Instant::now() + SESSION_TTL);
+        // Opportunistic prune so the map cannot grow without bound.
+        let now = Instant::now();
+        s.retain(|_, exp| *exp > now);
+        token
+    }
+
+    /// True only if `token` names a live, unexpired session. Tokens are 256-bit
+    /// CSPRNG output, so a HashMap lookup here is not a meaningful timing oracle
+    /// (there is nothing to guess byte-by-byte); constant-time would only cost
+    /// the O(1) lookup for no security gain.
+    pub fn validate_session(&self, token: &str) -> bool {
+        if token.is_empty() {
+            return false;
+        }
+        match self.sessions.lock().get(token) {
+            Some(exp) => *exp > Instant::now(),
+            None => false,
+        }
+    }
+
+    pub fn revoke_session(&self, token: &str) {
+        self.sessions.lock().remove(token);
+    }
+
+    /// Drop every session. Used on password change / disable so old cookies
+    /// stop working immediately.
+    pub fn revoke_all(&self) {
+        self.sessions.lock().clear();
+    }
+
+    // Login limiter, delegated so web.rs keeps its small surface.
+    pub fn check_login_allowed(&self, client: &str) -> Result<(), Duration> {
+        self.login.check(client)
+    }
+    pub fn record_failure(&self, client: &str) {
+        self.login.record_failure(client)
+    }
+    pub fn record_success(&self, client: &str) {
+        self.login.record_success(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_lifecycle() {
+        let a = AuthState::new();
+        let t = a.create_session();
+        assert!(a.validate_session(&t));
+        assert!(!a.validate_session("not-a-token"));
+        assert!(!a.validate_session(""));
+        a.revoke_session(&t);
+        assert!(!a.validate_session(&t));
+    }
+
+    #[test]
+    fn revoke_all_drops_every_session() {
+        let a = AuthState::new();
+        let t1 = a.create_session();
+        let t2 = a.create_session();
+        a.revoke_all();
+        assert!(!a.validate_session(&t1));
+        assert!(!a.validate_session(&t2));
+    }
+
+    #[test]
+    fn lockout_after_threshold_and_cleared_on_success() {
+        let a = AuthState::new();
+        let ip = "10.0.0.1";
+        assert!(a.check_login_allowed(ip).is_ok());
+        for _ in 0..5 {
+            a.record_failure(ip);
+        }
+        assert!(a.check_login_allowed(ip).is_err());
+        a.record_success(ip);
+        assert!(a.check_login_allowed(ip).is_ok());
+    }
+
+    #[test]
+    fn rate_limiter_locks_and_forgives_on_success() {
+        let r = RateLimiter::new(
+            3,
+            Duration::from_secs(30),
+            Duration::from_secs(600),
+            Duration::from_secs(600),
+        );
+        let c = "peer";
+        assert!(r.check(c).is_ok());
+        r.record_failure(c);
+        r.record_failure(c);
+        assert!(r.check(c).is_ok()); // 2 < 3, still allowed
+        r.record_failure(c);
+        assert!(r.check(c).is_err()); // 3rd failure locks
+        r.record_success(c);
+        assert!(r.check(c).is_ok()); // success clears the lock
+    }
+}

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -108,16 +108,169 @@ pub fn set(enabled: bool) -> io::Result<()> {
     }
 }
 
-#[cfg(not(windows))]
+// ── Linux: a freedesktop autostart entry ────────────────────────────
+//
+// The XDG spec's equivalent of the Run key is a `.desktop` file dropped in
+// `$XDG_CONFIG_HOME/autostart` (default `~/.config/autostart`). Its presence
+// is the source of truth, mirroring the Windows design: no copy in Settings,
+// so the desktop environment's own "Startup Applications" toggle can never
+// disagree with us. Launched with `--no-browser` for the same reason.
+
+/// The autostart directory for the given env inputs. Pure (no env reads) so
+/// the XDG-over-HOME precedence is unit-testable. `xdg` wins only when it is
+/// an absolute path, matching the XDG base-dir spec.
+#[cfg(target_os = "linux")]
+fn autostart_dir_from(
+    xdg: Option<std::path::PathBuf>,
+    home: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    xdg.filter(|p| p.is_absolute())
+        .or_else(|| home.map(|h| h.join(".config")))
+        .map(|base| base.join("autostart"))
+}
+
+/// Path to our autostart `.desktop` file, or None when no home dir resolves.
+#[cfg(target_os = "linux")]
+fn desktop_entry_path() -> Option<std::path::PathBuf> {
+    let xdg = std::env::var_os("XDG_CONFIG_HOME").map(std::path::PathBuf::from);
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+    autostart_dir_from(xdg, home).map(|d| d.join("instantclone.desktop"))
+}
+
+/// Brand icon as SVG (vector, so no image codec and it stays crisp at any
+/// size). Matches the Windows tray glyph: a cyan rounded square with two white
+/// pause bars, where "pause" stands for the delay.
+#[cfg(target_os = "linux")]
+const ICON_SVG: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48"><rect x="3" y="3" width="42" height="42" rx="10" fill="#5ac8fa"/><rect x="17" y="14" width="5" height="20" rx="1.5" fill="#f4f6f9"/><rect x="26" y="14" width="5" height="20" rx="1.5" fill="#f4f6f9"/></svg>"##;
+
+/// Write the brand icon into the user's icon dir and return its path, so a
+/// `.desktop` entry can point `Icon=` at a real file instead of a generic
+/// launcher glyph. Best effort: None when no home resolves or the write fails
+/// (the entry then just omits Icon=). Idempotent, and only rewrites on change.
+#[cfg(target_os = "linux")]
+pub(crate) fn ensure_icon() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from)?;
+    let dir = std::env::var_os("XDG_DATA_HOME")
+        .map(std::path::PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home.join(".local/share"))
+        .join("icons");
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join("instantclone.svg");
+    let fresh = std::fs::read_to_string(&path)
+        .map(|c| c == ICON_SVG)
+        .unwrap_or(false);
+    if !fresh {
+        std::fs::write(&path, ICON_SVG).ok()?;
+    }
+    Some(path)
+}
+
+/// The `.desktop` file body. Pure so the Exec-quoting (an install path with
+/// spaces must still launch), the `--no-browser` flag, and the optional
+/// `Icon=` line are unit-testable without touching disk.
+#[cfg(target_os = "linux")]
+fn desktop_entry(exe: &std::path::Path, icon: Option<&str>) -> String {
+    let icon_line = icon.map(|i| format!("Icon={i}\n")).unwrap_or_default();
+    format!(
+        "[Desktop Entry]\n\
+         Type=Application\n\
+         Name=InstantClone\n\
+         Comment=RTMP delay proxy\n\
+         {icon_line}\
+         Exec=\"{}\" --no-browser\n\
+         Terminal=false\n\
+         X-GNOME-Autostart-enabled=true\n",
+        exe.display()
+    )
+}
+
+#[cfg(target_os = "linux")]
+pub fn is_enabled() -> bool {
+    desktop_entry_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+pub fn set(enabled: bool) -> io::Result<()> {
+    let path = desktop_entry_path().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "no HOME / XDG_CONFIG_HOME to place the autostart entry",
+        )
+    })?;
+    if enabled {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let exe = std::env::current_exe()?;
+        let icon = ensure_icon();
+        let icon_ref = icon.as_ref().and_then(|p| p.to_str());
+        std::fs::write(&path, desktop_entry(&exe, icon_ref))
+    } else {
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            // Already absent is the state the caller asked for, not an error.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_tests {
+    use super::{autostart_dir_from, desktop_entry};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn xdg_config_home_wins_when_absolute() {
+        let dir = autostart_dir_from(Some(PathBuf::from("/xdg")), Some(PathBuf::from("/home/u")));
+        assert_eq!(dir, Some(PathBuf::from("/xdg/autostart")));
+    }
+
+    #[test]
+    fn falls_back_to_home_config_when_xdg_missing_or_relative() {
+        assert_eq!(
+            autostart_dir_from(None, Some(PathBuf::from("/home/u"))),
+            Some(PathBuf::from("/home/u/.config/autostart"))
+        );
+        // A relative XDG value is ignored per the base-dir spec.
+        assert_eq!(
+            autostart_dir_from(Some(PathBuf::from("rel/ative")), Some(PathBuf::from("/home/u"))),
+            Some(PathBuf::from("/home/u/.config/autostart"))
+        );
+    }
+
+    #[test]
+    fn none_when_no_home() {
+        assert_eq!(autostart_dir_from(None, None), None);
+    }
+
+    #[test]
+    fn entry_quotes_exec_and_stays_headless() {
+        let body = desktop_entry(Path::new("/opt/My Apps/instantclone"), None);
+        assert!(body.contains("Exec=\"/opt/My Apps/instantclone\" --no-browser"));
+        assert!(body.contains("Type=Application"));
+        // No icon supplied -> no Icon= line at all.
+        assert!(!body.contains("Icon="));
+    }
+
+    #[test]
+    fn entry_includes_icon_when_supplied() {
+        let body = desktop_entry(Path::new("/usr/bin/instantclone"), Some("/x/instantclone.svg"));
+        assert!(body.contains("Icon=/x/instantclone.svg\n"));
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn is_enabled() -> bool {
     false
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn set(_enabled: bool) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
-        "start with Windows is only available on Windows",
+        "start-at-login is not supported on this platform",
     ))
 }
 

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -235,7 +235,10 @@ mod linux_tests {
         );
         // A relative XDG value is ignored per the base-dir spec.
         assert_eq!(
-            autostart_dir_from(Some(PathBuf::from("rel/ative")), Some(PathBuf::from("/home/u"))),
+            autostart_dir_from(
+                Some(PathBuf::from("rel/ative")),
+                Some(PathBuf::from("/home/u"))
+            ),
             Some(PathBuf::from("/home/u/.config/autostart"))
         );
     }
@@ -256,7 +259,10 @@ mod linux_tests {
 
     #[test]
     fn entry_includes_icon_when_supplied() {
-        let body = desktop_entry(Path::new("/usr/bin/instantclone"), Some("/x/instantclone.svg"));
+        let body = desktop_entry(
+            Path::new("/usr/bin/instantclone"),
+            Some("/x/instantclone.svg"),
+        );
         assert!(body.contains("Icon=/x/instantclone.svg\n"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -557,7 +557,11 @@ impl Settings {
         // Auth secrets: only written when set (auth on), so a default install's
         // config carries neither and a downgrade stays clean.
         if !self.dashboard_password_hash.is_empty() {
-            writeln!(f, "dashboard_password_hash={}", self.dashboard_password_hash)?;
+            writeln!(
+                f,
+                "dashboard_password_hash={}",
+                self.dashboard_password_hash
+            )?;
         }
         if !self.dock_token.is_empty() {
             writeln!(f, "dock_token={}", self.dock_token)?;
@@ -1379,7 +1383,10 @@ mod tests {
         let plain_text = std::fs::read_to_string(&plain_path).unwrap();
         assert!(!plain_text.contains("dashboard_password_hash"));
         assert!(!plain_text.contains("ingest_key"));
-        assert!(Settings::load(&plain_path).unwrap().dashboard_password_hash.is_empty());
+        assert!(Settings::load(&plain_path)
+            .unwrap()
+            .dashboard_password_hash
+            .is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1389,7 +1396,11 @@ mod tests {
     #[test]
     fn to_json_carries_the_os_tag() {
         let json = Settings::defaults().to_json(false);
-        assert!(json.contains(r#""os":"windows""#) || json.contains(r#""os":"linux""#) || json.contains(r#""os":"macos""#));
+        assert!(
+            json.contains(r#""os":"windows""#)
+                || json.contains(r#""os":"linux""#)
+                || json.contains(r#""os":"macos""#)
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,11 @@ pub const SINK_WEB_PORT: u16 = 19351;
 pub struct Settings {
     pub ingest_port: u16,
     pub ingest_bind_all: bool, // true → 0.0.0.0, false → 127.0.0.1
+    /// Optional shared secret an RTMP publisher must use as its stream key.
+    /// Empty (the default) accepts any key, which is the right behaviour on a
+    /// local machine. Set it to lock the ingest down when it is exposed to a
+    /// network, so only OBS configured with this exact key can publish.
+    pub ingest_key: String,
 
     // Legacy single-destination fields. Still present on disk for backward
     // compatibility - on load they get migrated into destinations[0] if
@@ -53,6 +58,15 @@ pub struct Settings {
 
     pub web_port: u16,
     pub web_bind_all: bool,
+    /// Optional PBKDF2 hash of the dashboard password. Empty (the default)
+    /// means auth is OFF and the dashboard/API are open exactly as before. Set
+    /// means a login is required. Never sent to the client; the wire only
+    /// carries an `auth_enabled` bool.
+    pub dashboard_password_hash: String,
+    /// Secret that lets the OBS dock (which cannot show a login form) through
+    /// the gate for delay CONTROL only, never settings. Generated when auth is
+    /// enabled, regenerable, empty when auth is off.
+    pub dock_token: String,
     pub buffer_mb: u64,
     pub buffer_path: PathBuf,
     pub target_delay_ms: u32,
@@ -295,11 +309,14 @@ impl Settings {
         Self {
             ingest_port: 1935,
             ingest_bind_all: false,
+            ingest_key: String::new(),
             platform: "twitch".into(),
             stream_key: String::new(),
             custom_egress_url: String::new(),
             web_port: 7799,
             web_bind_all: false,
+            dashboard_password_hash: String::new(),
+            dock_token: String::new(),
             // 500 MB ≈ 6m 50s at 10 Mbps, ~11 min at 6 Mbps. The cap on
             // what the user could ever arm at the current bitrate; with
             // the trim logic the *actual* used portion matches the armed
@@ -530,8 +547,21 @@ impl Settings {
         )?;
         writeln!(f, "ingest_port={}", self.ingest_port)?;
         writeln!(f, "ingest_bind_all={}", self.ingest_bind_all)?;
+        // Secret: only written when set, so a default install's config never
+        // carries an empty key line and a downgrade stays clean.
+        if !self.ingest_key.is_empty() {
+            writeln!(f, "ingest_key={}", self.ingest_key)?;
+        }
         writeln!(f, "web_port={}", self.web_port)?;
         writeln!(f, "web_bind_all={}", self.web_bind_all)?;
+        // Auth secrets: only written when set (auth on), so a default install's
+        // config carries neither and a downgrade stays clean.
+        if !self.dashboard_password_hash.is_empty() {
+            writeln!(f, "dashboard_password_hash={}", self.dashboard_password_hash)?;
+        }
+        if !self.dock_token.is_empty() {
+            writeln!(f, "dock_token={}", self.dock_token)?;
+        }
         writeln!(f, "buffer_mb={}", self.buffer_mb)?;
         writeln!(f, "buffer_path={}", self.buffer_path.display())?;
         writeln!(f, "target_delay_ms={}", self.target_delay_ms)?;
@@ -623,12 +653,23 @@ impl Settings {
                 }
             }
             "ingest_bind_all" => self.ingest_bind_all = value == "true",
+            "ingest_key" => self.ingest_key = value.into(),
             "web_port" => {
                 if let Ok(v) = value.parse() {
                     self.web_port = v;
                 }
             }
             "web_bind_all" => self.web_bind_all = value == "true",
+            "dashboard_password_hash" => self.dashboard_password_hash = value.into(),
+            // Only accept a hex token from disk: it is written into a Set-Cookie
+            // header, so a hand-edited value with CR/LF (or anything non-hex)
+            // must never reach header construction. Generated tokens are always
+            // hex, so this rejects only tampering.
+            "dock_token" => {
+                if !value.is_empty() && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    self.dock_token = value.into();
+                }
+            }
             "buffer_mb" => {
                 if let Ok(v) = value.parse() {
                     self.buffer_mb = v;
@@ -862,9 +903,14 @@ impl Settings {
         }
         dests.push(']');
         format!(
-            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"destinations":{dests}}}"#,
+            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"ingest_key":{ik},"auth_enabled":{ae},"dock_token":{dt},"os":{osname},"version":{ver},"destinations":{dests}}}"#,
             c = self.configured,
             sww = start_with_windows,
+            ik = json_str(&self.ingest_key),
+            ae = !self.dashboard_password_hash.is_empty(),
+            dt = json_str(&self.dock_token),
+            osname = json_str(os_name()),
+            ver = json_str(crate::update_check::current_version()),
             ip = self.ingest_port,
             iba = self.ingest_bind_all,
             wp = self.web_port,
@@ -1134,6 +1180,23 @@ fn non_empty(s: &String) -> Option<&String> {
     }
 }
 
+/// Compile-time OS tag the dashboard reads to pick platform-correct copy
+/// (the start-at-login wording, the file-manager name, the tray mention).
+fn os_name() -> &'static str {
+    #[cfg(windows)]
+    {
+        "windows"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "macos"
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        "linux"
+    }
+}
+
 fn json_str(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
@@ -1230,14 +1293,21 @@ fn url_decode(s: &str) -> String {
                 out.push(b' ');
                 i += 1;
             }
+            // Decode `%XX` straight from the raw bytes. NEVER slice `s` here:
+            // `&s[i+1..i+3]` panics when the offset lands inside a multi-byte
+            // UTF-8 char (e.g. a `%` before `€`), which under panic=abort is a
+            // remote process kill from any form field.
             b'%' if i + 2 < bytes.len() => {
-                let hex = &s[i + 1..i + 3];
-                if let Ok(b) = u8::from_str_radix(hex, 16) {
-                    out.push(b);
-                    i += 3;
-                } else {
-                    out.push(bytes[i]);
-                    i += 1;
+                match (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2])) {
+                    (Some(hi), Some(lo)) => {
+                        out.push((hi << 4) | lo);
+                        i += 3;
+                    }
+                    // Not a valid `%XX`; keep the literal `%` and move on.
+                    _ => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
                 }
             }
             b => {
@@ -1247,6 +1317,17 @@ fn url_decode(s: &str) -> String {
         }
     }
     String::from_utf8(out).unwrap_or_default()
+}
+
+/// Value of a single ASCII hex digit, or None. Used by `url_decode` so it can
+/// decode `%XX` from bytes without ever slicing a `&str` on a non-char boundary.
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -1262,6 +1343,53 @@ mod tests {
         let s = Settings::defaults();
         assert!(s.to_json(true).contains(r#""start_with_windows":true"#));
         assert!(s.to_json(false).contains(r#""start_with_windows":false"#));
+    }
+
+    /// The auth + ingest secrets must survive a save/load round-trip, and the
+    /// hash must NEVER appear in the client-facing JSON (only `auth_enabled`).
+    #[test]
+    fn secret_fields_round_trip_and_hash_stays_server_side() {
+        let dir = std::env::temp_dir().join(format!("ic-cfg-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sec.config.json");
+
+        let mut s = Settings::defaults();
+        s.ingest_key = "streamsecret".into();
+        s.dashboard_password_hash = "pbkdf2-sha256$210000$aa$bb".into();
+        s.dock_token = "a1b2c3d4e5f60718".into();
+        s.save(&path).unwrap();
+
+        let loaded = Settings::load(&path).unwrap();
+        assert_eq!(loaded.ingest_key, "streamsecret");
+        assert_eq!(loaded.dashboard_password_hash, "pbkdf2-sha256$210000$aa$bb");
+        assert_eq!(loaded.dock_token, "a1b2c3d4e5f60718");
+
+        // Wire JSON: auth_enabled true, ingest_key + dock_token present, but
+        // the password hash must not leak.
+        let json = loaded.to_json(false);
+        assert!(json.contains(r#""auth_enabled":true"#));
+        assert!(json.contains(r#""dock_token":"a1b2c3d4e5f60718""#));
+        assert!(!json.contains("pbkdf2-sha256"));
+        assert!(!json.contains("dashboard_password_hash"));
+
+        // A default install writes neither secret line and reads auth as off.
+        let plain = Settings::defaults();
+        let plain_path = dir.join("plain.config.json");
+        plain.save(&plain_path).unwrap();
+        let plain_text = std::fs::read_to_string(&plain_path).unwrap();
+        assert!(!plain_text.contains("dashboard_password_hash"));
+        assert!(!plain_text.contains("ingest_key"));
+        assert!(Settings::load(&plain_path).unwrap().dashboard_password_hash.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The dashboard swaps platform-specific copy off this field, so it must
+    /// always be present and non-empty.
+    #[test]
+    fn to_json_carries_the_os_tag() {
+        let json = Settings::defaults().to_json(false);
+        assert!(json.contains(r#""os":"windows""#) || json.contains(r#""os":"linux""#) || json.contains(r#""os":"macos""#));
     }
 
     #[test]
@@ -1293,6 +1421,19 @@ mod tests {
         assert_eq!(h.get("a"), Some(&"hello world".to_string()));
         assert_eq!(h.get("b"), Some(&"!".to_string()));
         assert_eq!(h.get("c"), Some(&"é".to_string()));
+    }
+
+    /// Regression: a bare `%` before a multi-byte UTF-8 char used to slice the
+    /// `&str` on a non-char boundary and panic (a remote process abort under
+    /// panic=abort). It must now decode losslessly and never panic.
+    #[test]
+    fn url_decode_survives_percent_before_multibyte_char() {
+        // `%€`, a stray `%` at the very end, and a truncated `%A`.
+        assert_eq!(url_decode("%€"), "%€");
+        assert_eq!(url_decode("abc%"), "abc%");
+        assert_eq!(url_decode("x%Ay"), "x%Ay");
+        // A real escape still works, and mixed content round-trips.
+        assert_eq!(url_decode("a%20b%E2%82%ACc"), "a b€c");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -910,13 +910,25 @@ impl Settings {
             ));
         }
         dests.push(']');
+        // The two raw credentials are emitted only for a full session; a
+        // dock-token caller gets them blanked (see the doc comment above).
+        let ik_shown = if include_secrets {
+            self.ingest_key.as_str()
+        } else {
+            ""
+        };
+        let dt_shown = if include_secrets {
+            self.dock_token.as_str()
+        } else {
+            ""
+        };
         format!(
             r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"ingest_key":{ik},"auth_enabled":{ae},"dock_token":{dt},"os":{osname},"version":{ver},"destinations":{dests}}}"#,
             c = self.configured,
             sww = start_with_windows,
-            ik = json_str(if include_secrets { self.ingest_key.as_str() } else { "" }),
+            ik = json_str(ik_shown),
             ae = !self.dashboard_password_hash.is_empty(),
-            dt = json_str(if include_secrets { self.dock_token.as_str() } else { "" }),
+            dt = json_str(dt_shown),
             osname = json_str(os_name()),
             ver = json_str(crate::update_check::current_version()),
             ip = self.ingest_port,
@@ -1349,8 +1361,12 @@ mod tests {
     #[test]
     fn to_json_reflects_the_passed_autostart_state() {
         let s = Settings::defaults();
-        assert!(s.to_json(true, true).contains(r#""start_with_windows":true"#));
-        assert!(s.to_json(false, true).contains(r#""start_with_windows":false"#));
+        assert!(s
+            .to_json(true, true)
+            .contains(r#""start_with_windows":true"#));
+        assert!(s
+            .to_json(false, true)
+            .contains(r#""start_with_windows":false"#));
     }
 
     /// The auth + ingest secrets must survive a save/load round-trip, and the

--- a/src/config.rs
+++ b/src/config.rs
@@ -881,7 +881,11 @@ impl Settings {
     /// does not live in `Settings` at all - the Run-key entry is its own
     /// source of truth (see `crate::autostart`). Taking it as an argument
     /// keeps this function free of hidden I/O.
-    pub fn to_json(&self, start_with_windows: bool) -> String {
+    /// `include_secrets` gates the two raw credentials in the payload: the
+    /// ingest key and the dock token. A full dashboard session gets them (the
+    /// Network settings UI needs to show them); a dock-token caller does not,
+    /// so the dock can render without ever learning a secret it could leak.
+    pub fn to_json(&self, start_with_windows: bool, include_secrets: bool) -> String {
         // Build the destinations array. Stream keys are NEVER echoed back
         // (security); we expose a redacted form of the resolved URL plus
         // a `stream_key_set` boolean per destination.
@@ -910,9 +914,9 @@ impl Settings {
             r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"ingest_key":{ik},"auth_enabled":{ae},"dock_token":{dt},"os":{osname},"version":{ver},"destinations":{dests}}}"#,
             c = self.configured,
             sww = start_with_windows,
-            ik = json_str(&self.ingest_key),
+            ik = json_str(if include_secrets { self.ingest_key.as_str() } else { "" }),
             ae = !self.dashboard_password_hash.is_empty(),
-            dt = json_str(&self.dock_token),
+            dt = json_str(if include_secrets { self.dock_token.as_str() } else { "" }),
             osname = json_str(os_name()),
             ver = json_str(crate::update_check::current_version()),
             ip = self.ingest_port,
@@ -1345,8 +1349,8 @@ mod tests {
     #[test]
     fn to_json_reflects_the_passed_autostart_state() {
         let s = Settings::defaults();
-        assert!(s.to_json(true).contains(r#""start_with_windows":true"#));
-        assert!(s.to_json(false).contains(r#""start_with_windows":false"#));
+        assert!(s.to_json(true, true).contains(r#""start_with_windows":true"#));
+        assert!(s.to_json(false, true).contains(r#""start_with_windows":false"#));
     }
 
     /// The auth + ingest secrets must survive a save/load round-trip, and the
@@ -1368,13 +1372,22 @@ mod tests {
         assert_eq!(loaded.dashboard_password_hash, "pbkdf2-sha256$210000$aa$bb");
         assert_eq!(loaded.dock_token, "a1b2c3d4e5f60718");
 
-        // Wire JSON: auth_enabled true, ingest_key + dock_token present, but
-        // the password hash must not leak.
-        let json = loaded.to_json(false);
+        // Admin wire JSON: auth_enabled true, ingest_key + dock_token present,
+        // but the password hash must not leak.
+        let json = loaded.to_json(false, true);
         assert!(json.contains(r#""auth_enabled":true"#));
         assert!(json.contains(r#""dock_token":"a1b2c3d4e5f60718""#));
         assert!(!json.contains("pbkdf2-sha256"));
         assert!(!json.contains("dashboard_password_hash"));
+
+        // Dock-token wire JSON: same shape, but the two raw secrets are blanked
+        // so a dock-only caller can never read them.
+        let redacted = loaded.to_json(false, false);
+        assert!(redacted.contains(r#""auth_enabled":true"#));
+        assert!(!redacted.contains("streamsecret"));
+        assert!(!redacted.contains("a1b2c3d4e5f60718"));
+        assert!(redacted.contains(r#""ingest_key":"""#));
+        assert!(redacted.contains(r#""dock_token":"""#));
 
         // A default install writes neither secret line and reads auth as off.
         let plain = Settings::defaults();
@@ -1395,7 +1408,7 @@ mod tests {
     /// always be present and non-empty.
     #[test]
     fn to_json_carries_the_os_tag() {
-        let json = Settings::defaults().to_json(false);
+        let json = Settings::defaults().to_json(false, true);
         assert!(
             json.contains(r#""os":"windows""#)
                 || json.contains(r#""os":"linux""#)

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub const MAX_DOCK_LAYOUT_LEN: usize = 8 * 1024;
 /// Also guards against the `% 0` panic in `DiskRing::append` if a
 /// hand-edited config sets `buffer_mb=0`.
 const MIN_BUFFER_MB: u64 = 50;
+// 1 TiB. Guards `buffer_bytes()` against overflow from a hand-edited config.
+const MAX_BUFFER_MB: u64 = 1024 * 1024;
 
 /// Ports for the built-in "Local test sink" destination (platform
 /// `"sink"`). The egress supervisor spawns `instantclone sink` as a
@@ -435,6 +437,10 @@ impl Settings {
         if self.buffer_mb < MIN_BUFFER_MB {
             self.buffer_mb = MIN_BUFFER_MB;
         }
+        // Ceiling as well as floor: a hand-edited absurd value would overflow
+        // `buffer_bytes()` (buffer_mb * 1024 * 1024) and hand DiskRing a
+        // nonsensical size. 1 TiB is far past any real delay buffer.
+        self.buffer_mb = self.buffer_mb.min(MAX_BUFFER_MB);
         if self.ingest_port == 0 {
             self.ingest_port = 1935;
         }
@@ -527,30 +533,36 @@ impl Settings {
         writeln!(
             f,
             "platform={}",
-            mirror
-                .map(|d| d.platform.as_str())
-                .unwrap_or(&self.platform)
+            one_line(
+                mirror
+                    .map(|d| d.platform.as_str())
+                    .unwrap_or(&self.platform)
+            )
         )?;
         writeln!(
             f,
             "stream_key={}",
-            mirror
-                .map(|d| d.stream_key.as_str())
-                .unwrap_or(&self.stream_key)
+            one_line(
+                mirror
+                    .map(|d| d.stream_key.as_str())
+                    .unwrap_or(&self.stream_key)
+            )
         )?;
         writeln!(
             f,
             "custom_egress_url={}",
-            mirror
-                .map(|d| d.custom_egress_url.as_str())
-                .unwrap_or(&self.custom_egress_url)
+            one_line(
+                mirror
+                    .map(|d| d.custom_egress_url.as_str())
+                    .unwrap_or(&self.custom_egress_url)
+            )
         )?;
         writeln!(f, "ingest_port={}", self.ingest_port)?;
         writeln!(f, "ingest_bind_all={}", self.ingest_bind_all)?;
         // Secret: only written when set, so a default install's config never
         // carries an empty key line and a downgrade stays clean.
         if !self.ingest_key.is_empty() {
-            writeln!(f, "ingest_key={}", self.ingest_key)?;
+            writeln!(f, "ingest_key={}", one_line(&self.ingest_key))?;
         }
         writeln!(f, "web_port={}", self.web_port)?;
         writeln!(f, "web_bind_all={}", self.web_bind_all)?;
@@ -567,11 +579,23 @@ impl Settings {
             writeln!(f, "dock_token={}", self.dock_token)?;
         }
         writeln!(f, "buffer_mb={}", self.buffer_mb)?;
-        writeln!(f, "buffer_path={}", self.buffer_path.display())?;
+        writeln!(
+            f,
+            "buffer_path={}",
+            one_line(&self.buffer_path.to_string_lossy())
+        )?;
         writeln!(f, "target_delay_ms={}", self.target_delay_ms)?;
         writeln!(f, "armed_delay_ms={}", self.armed_delay_ms)?;
-        writeln!(f, "discord_webhook_url={}", self.discord_webhook_url)?;
-        writeln!(f, "overlays_dir={}", self.overlays_dir.display())?;
+        writeln!(
+            f,
+            "discord_webhook_url={}",
+            one_line(&self.discord_webhook_url)
+        )?;
+        writeln!(
+            f,
+            "overlays_dir={}",
+            one_line(&self.overlays_dir.to_string_lossy())
+        )?;
         writeln!(f, "tracing_enabled={}", self.tracing_enabled)?;
         // Behaviour. Only emit when non-default so a downgrade to a
         // pre-v0.2 build that doesn't know these keys keeps parsing
@@ -601,22 +625,28 @@ impl Settings {
         // compact JSON), so it round-trips through the line-based parser
         // even though it is opaque to us.
         for (id, layout) in &self.docks {
-            writeln!(f, "dock.{}={}", id, layout)?;
+            writeln!(f, "dock.{}={}", one_line(id), one_line(layout))?;
         }
         for (i, p) in self.profiles.iter().enumerate() {
-            writeln!(f, "profile.{}.name={}", i, p.name)?;
+            writeln!(f, "profile.{}.name={}", i, one_line(&p.name))?;
             writeln!(f, "profile.{}.delay_ms={}", i, p.delay_ms)?;
         }
         for (i, d) in self.destinations.iter().enumerate() {
-            writeln!(f, "destination.{}.id={}", i, d.id)?;
-            writeln!(f, "destination.{}.name={}", i, d.name)?;
+            writeln!(f, "destination.{}.id={}", i, one_line(&d.id))?;
+            writeln!(f, "destination.{}.name={}", i, one_line(&d.name))?;
             writeln!(f, "destination.{}.enabled={}", i, d.enabled)?;
-            writeln!(f, "destination.{}.platform={}", i, d.platform)?;
-            writeln!(f, "destination.{}.stream_key={}", i, d.stream_key)?;
+            writeln!(f, "destination.{}.platform={}", i, one_line(&d.platform))?;
+            writeln!(
+                f,
+                "destination.{}.stream_key={}",
+                i,
+                one_line(&d.stream_key)
+            )?;
             writeln!(
                 f,
                 "destination.{}.custom_egress_url={}",
-                i, d.custom_egress_url
+                i,
+                one_line(&d.custom_egress_url)
             )?;
             writeln!(f, "destination.{}.twitch_ingest={}", i, d.twitch_ingest)?;
             writeln!(f, "destination.{}.youtube_ingest={}", i, d.youtube_ingest)?;
@@ -638,7 +668,12 @@ impl Settings {
             }
             // Only emit when non-default ("auto"), same downgrade-safe reason.
             if d.audio_track != "auto" && !d.audio_track.is_empty() {
-                writeln!(f, "destination.{}.audio_track={}", i, d.audio_track)?;
+                writeln!(
+                    f,
+                    "destination.{}.audio_track={}",
+                    i,
+                    one_line(&d.audio_track)
+                )?;
             }
         }
         f.sync_all()?;
@@ -895,13 +930,23 @@ impl Settings {
                 dests.push(',');
             }
             let url = d.egress_url().unwrap_or_default();
+            // A custom URL can carry the stream key in its path
+            // (rtmp://host/app/SECRET), so it's a credential: show it only to a
+            // full session (the edit form needs it), never to a dock-token
+            // caller - the redacted `egress_url_redacted` below is enough to
+            // render. Consistent with how ingest_key / dock_token are gated.
+            let custom_url_shown = if include_secrets {
+                d.custom_egress_url.as_str()
+            } else {
+                ""
+            };
             dests.push_str(&format!(
                 r#"{{"id":{id},"name":{n},"enabled":{en},"platform":{p},"custom_egress_url":{cu},"twitch_ingest":{ti},"youtube_ingest":{yi},"stream_format":{sf},"stream_key_set":{ks},"egress_url_redacted":{red}}}"#,
                 id  = json_str(&d.id),
                 n   = json_str(&d.name),
                 en  = d.enabled,
                 p   = json_str(&d.platform),
-                cu  = json_str(&d.custom_egress_url),
+                cu  = json_str(custom_url_shown),
                 ti  = json_str(&d.twitch_ingest),
                 yi  = json_str(&d.youtube_ingest),
                 sf  = json_str(&d.stream_format),
@@ -966,6 +1011,22 @@ impl Settings {
         }
         if self.buffer_mb < MIN_BUFFER_MB {
             errs.push(format!("buffer_mb must be at least {}", MIN_BUFFER_MB));
+        }
+        // The ingest key travels as an RTMP stream key and is matched after the
+        // playpath query is stripped (OBS appends `?clientConfigId=...` under
+        // Enhanced Broadcasting). A key with a '?', whitespace, or other char an
+        // RTMP client can't carry verbatim could never match - reject it up front
+        // rather than let it silently lock the owner out of their own ingest.
+        if !self.ingest_key.is_empty()
+            && !self
+                .ingest_key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            errs.push(
+                "ingest key may only contain letters, numbers, '-' and '_' (no spaces or '?')"
+                    .into(),
+            );
         }
         if self.destinations.len() > MAX_DESTINATIONS {
             errs.push(format!("too many destinations (max {})", MAX_DESTINATIONS));
@@ -1217,6 +1278,21 @@ fn os_name() -> &'static str {
     }
 }
 
+/// Strip control characters (notably CR/LF) from a value bound for the
+/// line-based config file. The format is `key=value` per line, so a newline in
+/// a value would inject a spurious second setting on the next load - e.g. a
+/// webhook URL carrying `\ningest_bind_all=true` could flip an unrelated flag
+/// and expose the ingest port. No legitimate config value is multi-line, so
+/// dropping control chars on write is loss-free and closes the injection at the
+/// serializer. Borrows unchanged when already clean.
+fn one_line(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.chars().any(|c| c.is_control()) {
+        std::borrow::Cow::Owned(s.chars().filter(|c| !c.is_control()).collect())
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
 fn json_str(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
@@ -1418,6 +1494,78 @@ mod tests {
             .is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A newline smuggled into a string setting must not inject a second
+    /// `key=value` line on reload (which could flip an unrelated flag like
+    /// ingest_bind_all). The writer strips control chars.
+    #[test]
+    fn config_write_blocks_newline_injection() {
+        let dir = std::env::temp_dir().join(format!("ic-inj-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("inj.config.json");
+
+        let mut s = Settings::defaults();
+        assert!(!s.ingest_bind_all);
+        // The classic payload: try to append an unrelated setting via a newline.
+        s.discord_webhook_url = "https://x/y\ningest_bind_all=true".into();
+        s.save(&path).unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        // No standalone injected line, and the value is now single-line.
+        assert!(!text.contains("\ningest_bind_all=true\n"));
+        let loaded = Settings::load(&path).unwrap();
+        assert!(!loaded.ingest_bind_all, "injection flipped ingest_bind_all");
+        assert!(!loaded.discord_webhook_url.contains('\n'));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn validate_rejects_unsafe_ingest_key() {
+        let mut s = Settings::defaults();
+        s.ingest_key = "good-key_123".into();
+        assert!(!s.validate().iter().any(|e| e.contains("ingest key")));
+        for bad in ["has space", "has?query", "tab\tinside"] {
+            s.ingest_key = bad.into();
+            assert!(
+                s.validate().iter().any(|e| e.contains("ingest key")),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_egress_url_hidden_from_non_admin() {
+        // A custom URL can carry the key in its path, so a dock-token caller
+        // must not see it; a full session (the edit form) may.
+        let mut s = Settings::defaults();
+        s.destinations.push(Destination {
+            id: "d1".into(),
+            name: "Custom".into(),
+            enabled: true,
+            platform: "custom".into(),
+            stream_key: String::new(),
+            custom_egress_url: "rtmp://host/app/SECRETKEY".into(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: "horizontal".into(),
+            audio_track: "auto".into(),
+        });
+        assert!(s.to_json(false, true).contains("SECRETKEY")); // admin sees it
+        assert!(!s.to_json(false, false).contains("SECRETKEY")); // dock does not
+    }
+
+    #[test]
+    fn buffer_mb_is_clamped_to_a_sane_ceiling() {
+        let mut s = Settings::defaults();
+        s.buffer_mb = u64::MAX;
+        s.sanitize_load();
+        assert_eq!(s.buffer_mb, MAX_BUFFER_MB);
+        // And buffer_bytes no longer overflows.
+        assert_eq!(s.buffer_bytes(), MAX_BUFFER_MB * 1024 * 1024);
     }
 
     /// The dashboard swaps platform-specific copy off this field, so it must

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2736,7 +2736,11 @@ mod tests {
     #[tokio::test]
     async fn empty_ingest_key_accepts_any_publisher() {
         let h = harness(0);
-        assert!(h.ctrl.begin_publish("literally-anything", "127.0.0.1").await.is_ok());
+        assert!(h
+            .ctrl
+            .begin_publish("literally-anything", "127.0.0.1")
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
@@ -2745,7 +2749,11 @@ mod tests {
         h.ctrl.update_ingest_key("secret123".into());
         // Wrong key is rejected by the auth check, before the slot is taken,
         // so a following correct publish still succeeds.
-        let err = h.ctrl.begin_publish("wrong", "127.0.0.1").await.unwrap_err();
+        let err = h
+            .ctrl
+            .begin_publish("wrong", "127.0.0.1")
+            .await
+            .unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
         assert!(h.ctrl.begin_publish("secret123", "127.0.0.1").await.is_ok());
     }
@@ -2845,7 +2853,10 @@ mod tests {
         // Fresh publisher: the mark's timestamp belongs to the OLD
         // session's timeline (the new one restarts near 0), so keeping
         // it would leave an unreachable mark pending forever.
-        h.ctrl.begin_publish("key", "127.0.0.1").await.expect("slot is free");
+        h.ctrl
+            .begin_publish("key", "127.0.0.1")
+            .await
+            .expect("slot is free");
         assert!(!h.ctrl.safe_cut_pending());
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1291,8 +1291,18 @@ impl Controller {
         {
             let required = self.ingest_key.lock().clone();
             if !required.is_empty() {
+                // The wrong-key throttle defends a network-exposed ingest port.
+                // A loopback publisher is a local process - RTMP ingest is never
+                // behind an HTTP reverse proxy that could mask its IP - so it is
+                // no brute-force threat and must not be locked out of its own
+                // machine for a mistyped key. Apply the limiter to remote peers
+                // only; an unparseable IP is treated as remote (fail-safe).
+                let remote = !peer_ip
+                    .parse::<std::net::IpAddr>()
+                    .map(|a| a.is_loopback())
+                    .unwrap_or(false);
                 // Throttle first so a locked-out guesser burns no work.
-                if self.ingest_limiter.check(peer_ip).is_err() {
+                if remote && self.ingest_limiter.check(peer_ip).is_err() {
                     self.log("ingest: rejected publisher (rate limited)");
                     return Err(io::Error::new(
                         io::ErrorKind::PermissionDenied,
@@ -1303,14 +1313,18 @@ impl Controller {
                 // token: a plain `!=` early-exits on the first differing byte
                 // and leaks the match length to a timing attacker.
                 if !crate::crypto::constant_time_eq(stream_key.as_bytes(), required.as_bytes()) {
-                    self.ingest_limiter.record_failure(peer_ip);
+                    if remote {
+                        self.ingest_limiter.record_failure(peer_ip);
+                    }
                     self.log("ingest: rejected publisher (wrong stream key)");
                     return Err(io::Error::new(
                         io::ErrorKind::PermissionDenied,
                         "invalid stream key",
                     ));
                 }
-                self.ingest_limiter.record_success(peer_ip);
+                if remote {
+                    self.ingest_limiter.record_success(peer_ip);
+                }
             }
         }
         let _g = self.publish_lock.lock().await;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -490,6 +490,12 @@ pub struct Controller {
     // Per-peer wrong-key throttle so a weak ingest key can't be brute-forced at
     // wire speed. Only engages once a key is configured.
     ingest_limiter: crate::auth::RateLimiter,
+    // Stream keys from Enhanced Broadcasting sessions we brokered via
+    // /obs/multitrack-config. OBS publishes an EB stream with the Twitch session
+    // token (not the configured ingest key), and we are the one that handed that
+    // token out, so `begin_publish` trusts it alongside the ingest key. Bounded
+    // and TTL'd (see remember_eb_key) so tokens never accumulate.
+    eb_keys: crate::sync::Mutex<Vec<(String, Instant)>>,
     // Wall-clock ms (since UNIX epoch) of last webhook fire. Throttles
     // rapid event sequences (e.g. reconnect flapping) so we never spawn
     // more than one curl every ~2 s.
@@ -617,6 +623,7 @@ impl Controller {
                 std::time::Duration::from_secs(10 * 60),
                 std::time::Duration::from_secs(10 * 60),
             ),
+            eb_keys: crate::sync::Mutex::new(Vec::new()),
             webhook_last_fire_ms: AtomicU64::new(0),
             publish_lock: Mutex::new(()),
             video_codec: AtomicU8::new(0),
@@ -1284,6 +1291,14 @@ impl Controller {
     // ---- Ingest entry points (called from rtmp::server) ----
 
     pub async fn begin_publish(&self, stream_key: &str, peer_ip: &str) -> io::Result<u64> {
+        // OBS's multitrack / Enhanced Broadcasting output appends query params to
+        // the stream key before publishing: always `?clientConfigId=<id>`, plus
+        // any query the user typed into their Stream Key field (e.g.
+        // `?bandwidthtest=1`). See create_service() in OBS's
+        // MultitrackVideoOutput.cpp. An RTMP playpath query is not part of the
+        // stream-key identity, so strip it here - otherwise the exact ingest key
+        // arrives as `mykey?clientConfigId=...` and gets rejected as a wrong key.
+        let stream_key = stream_key.split('?').next().unwrap_or(stream_key);
         // Ingest auth: when a key is configured, only a publisher using that
         // exact key gets in. Empty key (the default) accepts anyone, which is
         // the right behaviour on a local machine. Checked before the slot lock
@@ -1309,10 +1324,17 @@ impl Controller {
                         "too many attempts",
                     ));
                 }
-                // Constant-time compare, same as the dashboard password / dock
-                // token: a plain `!=` early-exits on the first differing byte
-                // and leaks the match length to a timing attacker.
-                if !crate::crypto::constant_time_eq(stream_key.as_bytes(), required.as_bytes()) {
+                // Accept the configured ingest key (constant-time compare, same
+                // as the dashboard password / dock token: a plain `!=` early
+                // exits on the first differing byte and leaks the match length)
+                // OR a stream key from an Enhanced Broadcasting session we
+                // brokered. In EB, OBS publishes with the Twitch session token,
+                // not the ingest key; we handed that token out via
+                // /obs/multitrack-config, so it is trusted.
+                let accepted =
+                    crate::crypto::constant_time_eq(stream_key.as_bytes(), required.as_bytes())
+                        || self.is_brokered_eb_key(stream_key);
+                if !accepted {
                     if remote {
                         self.ingest_limiter.record_failure(peer_ip);
                     }
@@ -1573,6 +1595,40 @@ impl Controller {
     /// check (any key accepted). Called on startup and on every settings edit.
     pub fn update_ingest_key(&self, key: String) {
         *self.ingest_key.lock() = key;
+    }
+
+    /// Remember a stream key from an Enhanced Broadcasting session we just
+    /// brokered - the Twitch session token OBS will publish with. `begin_publish`
+    /// accepts these alongside the configured ingest key, so an EB publish is not
+    /// rejected as a "wrong stream key" when an ingest key is set. Bounded and
+    /// TTL'd so tokens do not accumulate; only ever populated while EB is in use.
+    pub fn remember_eb_key(&self, key: String) {
+        if key.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        let ttl = Duration::from_secs(600);
+        let mut v = self.eb_keys.lock();
+        // Drop expired entries and any prior copy of this key, then re-add it.
+        v.retain(|(k, t)| k != &key && now.duration_since(*t) < ttl);
+        v.push((key, now));
+        const MAX_EB_KEYS: usize = 8;
+        if v.len() > MAX_EB_KEYS {
+            let drop = v.len() - MAX_EB_KEYS;
+            v.drain(0..drop);
+        }
+    }
+
+    /// True if `key` is a still-valid EB session token we brokered. Constant-time
+    /// compare per candidate, matching the ingest-key / password / dock-token
+    /// paths (a plain `==` leaks the match length to a timing attacker).
+    fn is_brokered_eb_key(&self, key: &str) -> bool {
+        let now = Instant::now();
+        let ttl = Duration::from_secs(600);
+        self.eb_keys.lock().iter().any(|(k, t)| {
+            now.duration_since(*t) < ttl
+                && crate::crypto::constant_time_eq(k.as_bytes(), key.as_bytes())
+        })
     }
 
     /// Snapshot the current webhook URL. Used by the test endpoint so it
@@ -2770,6 +2826,47 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
         assert!(h.ctrl.begin_publish("secret123", "127.0.0.1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ingest_key_ignores_obs_multitrack_query_suffix() {
+        // Under Enhanced Broadcasting, OBS publishes the stream key with a
+        // `?clientConfigId=<id>` suffix appended (see create_service in OBS's
+        // MultitrackVideoOutput.cpp). The exact ingest key must still be
+        // accepted despite that suffix - the query is not part of the identity.
+        let h = harness(0);
+        h.ctrl.update_ingest_key("secret123".into());
+        assert!(h
+            .ctrl
+            .begin_publish(
+                "secret123?clientConfigId=instantclone-1723300000",
+                "127.0.0.1"
+            )
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn ingest_accepts_a_brokered_eb_key() {
+        // Enhanced Broadcasting publishes with the Twitch session token, not the
+        // ingest key. With an ingest key set, that token is rejected until the
+        // /obs/multitrack-config proxy brokers it via remember_eb_key.
+        let h = harness(0);
+        h.ctrl.update_ingest_key("myingestkey".into());
+        let err = h
+            .ctrl
+            .begin_publish("v1_eb_session_token", "127.0.0.1")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        h.ctrl.remember_eb_key("v1_eb_session_token".into());
+        // OBS appends `?clientConfigId=<id>` to the token it publishes with;
+        // begin_publish strips that query before matching the brokered token.
+        assert!(h
+            .ctrl
+            .begin_publish("v1_eb_session_token?clientConfigId=abc123", "127.0.0.1")
+            .await
+            .is_ok());
     }
 
     // ── "Cut after this airs" (scheduled safe cut) ───────────────────

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 /// Process-anchored monotonic millisecond counter for hot-path
 /// bandwidth / throttle math. `SystemTime::now()` on Windows is a
@@ -415,6 +415,14 @@ impl DestinationState {
     }
 }
 
+/// What the main loop should do after a graceful shutdown: exit for good, or
+/// relaunch a fresh process in place.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ShutdownKind {
+    Quit,
+    Restart,
+}
+
 pub struct Controller {
     pub ring: Arc<DiskRing>,
 
@@ -475,6 +483,13 @@ pub struct Controller {
 
     // Discord webhook URL. Empty = disabled. Updated live via update_webhook.
     webhook_url: crate::sync::Mutex<String>,
+    // Required RTMP stream key. Empty = accept any publisher (local default).
+    // Mirrored from Settings via update_ingest_key so `begin_publish` can
+    // enforce it without the ingest task needing a settings handle.
+    ingest_key: crate::sync::Mutex<String>,
+    // Per-peer wrong-key throttle so a weak ingest key can't be brute-forced at
+    // wire speed. Only engages once a key is configured.
+    ingest_limiter: crate::auth::RateLimiter,
     // Wall-clock ms (since UNIX epoch) of last webhook fire. Throttles
     // rapid event sequences (e.g. reconnect flapping) so we never spawn
     // more than one curl every ~2 s.
@@ -555,6 +570,17 @@ pub struct Controller {
     /// AVC→HEVC switch) don't desync the downstream decoder.
     seq_header_gen: AtomicU32,
 
+    // --- Graceful shutdown signal -------------------------------------
+    // Fired by the web Quit/Restart routes and (on Windows) the tray Quit.
+    // The main loop parks on `shutdown_notify`; `shutdown_kind` carries the
+    // intent (0 = none, 1 = quit, 2 = restart). Unified here so every exit
+    // path runs the same clean egress teardown.
+    shutdown_notify: Notify,
+    shutdown_kind: AtomicU8,
+
+    // Process start, for the dashboard's uptime readout.
+    started: std::time::Instant,
+
     // In-process log ring (most recent N lines).
     pub logs: crate::sync::Mutex<std::collections::VecDeque<String>>,
 }
@@ -581,6 +607,16 @@ impl Controller {
             rate_window_bytes: AtomicU64::new(0),
             rate_window_start_ms: AtomicU64::new(0),
             webhook_url: crate::sync::Mutex::new(String::new()),
+            ingest_key: crate::sync::Mutex::new(String::new()),
+            // 5 wrong keys then a short exponential lockout. A legit OBS uses
+            // the right key and clears its record on the first accept, so this
+            // only ever bites a guesser.
+            ingest_limiter: crate::auth::RateLimiter::new(
+                5,
+                std::time::Duration::from_secs(10),
+                std::time::Duration::from_secs(10 * 60),
+                std::time::Duration::from_secs(10 * 60),
+            ),
             webhook_last_fire_ms: AtomicU64::new(0),
             publish_lock: Mutex::new(()),
             video_codec: AtomicU8::new(0),
@@ -598,7 +634,40 @@ impl Controller {
             input_ts_wrap_high: AtomicU32::new(0),
             last_multitrack_video_ms: AtomicU64::new(0),
             backpressure_since_ms: AtomicU64::new(0),
+            shutdown_notify: Notify::new(),
+            shutdown_kind: AtomicU8::new(0),
+            started: std::time::Instant::now(),
             logs: crate::sync::Mutex::new(std::collections::VecDeque::with_capacity(512)),
+        }
+    }
+
+    /// Seconds since the process started, for the dashboard uptime readout.
+    pub fn uptime_secs(&self) -> u64 {
+        self.started.elapsed().as_secs()
+    }
+
+    /// Ask the main loop to shut down cleanly and then exit for good.
+    /// Idempotent: a second call before the loop wakes just re-arms the same
+    /// notification. Safe to call from any thread (tray) or task (web).
+    pub fn request_quit(&self) {
+        self.shutdown_kind.store(1, Ordering::SeqCst);
+        self.shutdown_notify.notify_one();
+    }
+
+    /// Ask the main loop to shut down cleanly and then relaunch in place.
+    pub fn request_restart(&self) {
+        self.shutdown_kind.store(2, Ordering::SeqCst);
+        self.shutdown_notify.notify_one();
+    }
+
+    /// Park until a quit/restart is requested, then report which. `notify_one`
+    /// stores a permit if it fires before this is awaited, so the signal can
+    /// never be lost to a race with the main loop entering its select.
+    pub async fn wait_shutdown(&self) -> ShutdownKind {
+        self.shutdown_notify.notified().await;
+        match self.shutdown_kind.load(Ordering::SeqCst) {
+            2 => ShutdownKind::Restart,
+            _ => ShutdownKind::Quit,
         }
     }
 
@@ -1214,7 +1283,36 @@ impl Controller {
 
     // ---- Ingest entry points (called from rtmp::server) ----
 
-    pub async fn begin_publish(&self, _stream_key: &str) -> io::Result<u64> {
+    pub async fn begin_publish(&self, stream_key: &str, peer_ip: &str) -> io::Result<u64> {
+        // Ingest auth: when a key is configured, only a publisher using that
+        // exact key gets in. Empty key (the default) accepts anyone, which is
+        // the right behaviour on a local machine. Checked before the slot lock
+        // so a wrong key never even contends for the publisher slot.
+        {
+            let required = self.ingest_key.lock().clone();
+            if !required.is_empty() {
+                // Throttle first so a locked-out guesser burns no work.
+                if self.ingest_limiter.check(peer_ip).is_err() {
+                    self.log("ingest: rejected publisher (rate limited)");
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "too many attempts",
+                    ));
+                }
+                // Constant-time compare, same as the dashboard password / dock
+                // token: a plain `!=` early-exits on the first differing byte
+                // and leaks the match length to a timing attacker.
+                if !crate::crypto::constant_time_eq(stream_key.as_bytes(), required.as_bytes()) {
+                    self.ingest_limiter.record_failure(peer_ip);
+                    self.log("ingest: rejected publisher (wrong stream key)");
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "invalid stream key",
+                    ));
+                }
+                self.ingest_limiter.record_success(peer_ip);
+            }
+        }
         let _g = self.publish_lock.lock().await;
         // One publisher at a time - a second OBS connecting would
         // interleave its tags into the buffer with its own timestamp
@@ -1455,6 +1553,12 @@ impl Controller {
     /// string disables webhook delivery entirely.
     pub fn update_webhook(&self, url: String) {
         *self.webhook_url.lock() = url;
+    }
+
+    /// Mirror the required ingest stream key from Settings. Empty disables the
+    /// check (any key accepted). Called on startup and on every settings edit.
+    pub fn update_ingest_key(&self, key: String) {
+        *self.ingest_key.lock() = key;
     }
 
     /// Snapshot the current webhook URL. Used by the test endpoint so it
@@ -2609,6 +2713,43 @@ mod tests {
         assert_eq!(h.ctrl.target_delay_ms(), 0);
     }
 
+    // ── Shutdown signal (web Quit/Restart + tray Quit converge here) ──
+
+    #[tokio::test]
+    async fn shutdown_signal_reports_restart() {
+        let h = harness(0);
+        // notify_one stores a permit, so wait_shutdown resolves immediately
+        // even though the request fires before we await - no lost wakeup.
+        h.ctrl.request_restart();
+        assert_eq!(h.ctrl.wait_shutdown().await, ShutdownKind::Restart);
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_reports_quit() {
+        let h = harness(0);
+        h.ctrl.request_quit();
+        assert_eq!(h.ctrl.wait_shutdown().await, ShutdownKind::Quit);
+    }
+
+    // ── Ingest key (optional publisher auth, off by default) ─────────
+
+    #[tokio::test]
+    async fn empty_ingest_key_accepts_any_publisher() {
+        let h = harness(0);
+        assert!(h.ctrl.begin_publish("literally-anything", "127.0.0.1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn set_ingest_key_rejects_wrong_and_accepts_right() {
+        let h = harness(0);
+        h.ctrl.update_ingest_key("secret123".into());
+        // Wrong key is rejected by the auth check, before the slot is taken,
+        // so a following correct publish still succeeds.
+        let err = h.ctrl.begin_publish("wrong", "127.0.0.1").await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(h.ctrl.begin_publish("secret123", "127.0.0.1").await.is_ok());
+    }
+
     // ── "Cut after this airs" (scheduled safe cut) ───────────────────
 
     #[test]
@@ -2704,7 +2845,7 @@ mod tests {
         // Fresh publisher: the mark's timestamp belongs to the OLD
         // session's timeline (the new one restarts near 0), so keeping
         // it would leave an unreachable mark pending forever.
-        h.ctrl.begin_publish("key").await.expect("slot is free");
+        h.ctrl.begin_publish("key", "127.0.0.1").await.expect("slot is free");
         assert!(!h.ctrl.safe_cut_pending());
     }
 
@@ -3413,7 +3554,7 @@ mod tests {
         // 4. Critical transition: A brand new publisher hits the RTMP stack.
         //    `begin_publish` must perform atomic state purging of the ring caches.
         h.ctrl
-            .begin_publish("fresh_incoming_stream_key")
+            .begin_publish("fresh_incoming_stream_key", "127.0.0.1")
             .await
             .expect("begin_publish must accept the new session token assignment");
 
@@ -3487,7 +3628,7 @@ mod tests {
         // ring so the new session's ts_ms (starting near 0) is
         // measured against an empty index.
         h.ctrl
-            .begin_publish("fresh-session-after-stop-start")
+            .begin_publish("fresh-session-after-stop-start", "127.0.0.1")
             .await
             .expect("begin_publish must succeed on fresh session");
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,258 @@
+//! Zero-dependency crypto for the OPTIONAL dashboard auth: PBKDF2-HMAC-SHA256
+//! password hashing, an OS CSPRNG for tokens, and a constant-time compare.
+//!
+//! Built entirely on our own `sha256` and the OS RNG we already link
+//! (BCryptGenRandom via `windows-sys`, `/dev/urandom` on Unix), so enabling
+//! auth pulls in NO new crate. For the default install that never sets a
+//! password this is a few KB of never-executed code and nothing more.
+//!
+//! Correctness is pinned to the published RFC 4231 (HMAC) and RFC 7914 /
+//! PBKDF2-HMAC-SHA256 test vectors in the test module. Do not touch the round
+//! functions without re-running them.
+
+use crate::sha256;
+
+const SHA256_BLOCK: usize = 64;
+
+/// Iteration count for new password hashes. PBKDF2 sets both our login cost
+/// and the attacker's per-guess cost; paired with the login rate limiter
+/// (the primary defence against online guessing) this is a sound balance for
+/// a self-hosted tool where the hash only leaks under a deeper compromise.
+/// The value is stored inside each hash, so raising it later re-hashes on the
+/// next password change without breaking existing logins.
+const PBKDF2_ITERATIONS: u32 = 210_000;
+
+const SALT_LEN: usize = 16;
+
+/// HMAC-SHA256(key, msg) per RFC 2104.
+fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
+    // Keys longer than the block are hashed down first (RFC 2104).
+    let mut k = [0u8; SHA256_BLOCK];
+    if key.len() > SHA256_BLOCK {
+        k[..32].copy_from_slice(&sha256::digest(key));
+    } else {
+        k[..key.len()].copy_from_slice(key);
+    }
+
+    let mut ipad = [0x36u8; SHA256_BLOCK];
+    let mut opad = [0x5cu8; SHA256_BLOCK];
+    for i in 0..SHA256_BLOCK {
+        ipad[i] ^= k[i];
+        opad[i] ^= k[i];
+    }
+
+    // inner = H(ipad || msg)
+    let mut inner = Vec::with_capacity(SHA256_BLOCK + msg.len());
+    inner.extend_from_slice(&ipad);
+    inner.extend_from_slice(msg);
+    let inner_digest = sha256::digest(&inner);
+
+    // H(opad || inner)
+    let mut outer = [0u8; SHA256_BLOCK + 32];
+    outer[..SHA256_BLOCK].copy_from_slice(&opad);
+    outer[SHA256_BLOCK..].copy_from_slice(&inner_digest);
+    sha256::digest(&outer)
+}
+
+/// PBKDF2-HMAC-SHA256 producing a 32-byte key (RFC 8018). One output block, so
+/// the derived length equals one HMAC output and no block loop is needed.
+fn pbkdf2_sha256(password: &[u8], salt: &[u8], iterations: u32) -> [u8; 32] {
+    // U1 = PRF(pw, salt || INT_32_BE(1)); Ui = PRF(pw, Ui-1); T = U1 ^ ... ^ Uc.
+    let mut salt_block = Vec::with_capacity(salt.len() + 4);
+    salt_block.extend_from_slice(salt);
+    salt_block.extend_from_slice(&1u32.to_be_bytes());
+
+    let mut u = hmac_sha256(password, &salt_block);
+    let mut t = u;
+    for _ in 1..iterations {
+        u = hmac_sha256(password, &u);
+        for i in 0..32 {
+            t[i] ^= u[i];
+        }
+    }
+    t
+}
+
+/// Constant-time byte comparison: no early return, so a caller cannot learn
+/// how many leading bytes matched by timing the response.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for i in 0..a.len() {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// Fill `buf` with cryptographically secure random bytes from the OS. Used for
+/// salts and session/dock tokens. A failure here means the OS RNG is
+/// unavailable, which is not a recoverable state for a server that must mint
+/// unguessable tokens, so we fail hard rather than emit weak randomness.
+pub fn os_random(buf: &mut [u8]) {
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Security::Cryptography::{
+            BCryptGenRandom, BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+        };
+        // SAFETY: null algorithm handle is valid with USE_SYSTEM_PREFERRED_RNG;
+        // buffer + length describe a live, writable slice.
+        let status = unsafe {
+            BCryptGenRandom(
+                std::ptr::null_mut(),
+                buf.as_mut_ptr(),
+                buf.len() as u32,
+                BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+            )
+        };
+        assert!(status == 0, "BCryptGenRandom failed: {status:#x}");
+    }
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        let mut f = std::fs::File::open("/dev/urandom").expect("open /dev/urandom");
+        f.read_exact(buf).expect("read /dev/urandom");
+    }
+}
+
+/// A fresh 256-bit token as 64 lowercase hex chars. Used for session and dock
+/// tokens; 256 bits of CSPRNG output is not brute-forceable.
+pub fn random_token() -> String {
+    let mut b = [0u8; 32];
+    os_random(&mut b);
+    sha256::hex_bytes(&b)
+}
+
+/// Hash a password for storage as `pbkdf2-sha256$<iter>$<salt_hex>$<dk_hex>`.
+/// A fresh random salt is generated per call, so identical passwords never
+/// share a hash.
+pub fn hash_password(password: &str) -> String {
+    let mut salt = [0u8; SALT_LEN];
+    os_random(&mut salt);
+    let dk = pbkdf2_sha256(password.as_bytes(), &salt, PBKDF2_ITERATIONS);
+    format!(
+        "pbkdf2-sha256${}${}${}",
+        PBKDF2_ITERATIONS,
+        sha256::hex_bytes(&salt),
+        sha256::hex_bytes(&dk)
+    )
+}
+
+/// Verify `password` against a stored hash. Constant-time on the digest
+/// compare; returns false on any parse failure (an unrecognised or corrupt
+/// stored value can never authenticate).
+pub fn verify_password(password: &str, stored: &str) -> bool {
+    let parts: Vec<&str> = stored.split('$').collect();
+    if parts.len() != 4 || parts[0] != "pbkdf2-sha256" {
+        return false;
+    }
+    let Ok(iterations) = parts[1].parse::<u32>() else {
+        return false;
+    };
+    if iterations == 0 {
+        return false;
+    }
+    let (Some(salt), Some(expected)) = (unhex(parts[2]), unhex(parts[3])) else {
+        return false;
+    };
+    let dk = pbkdf2_sha256(password.as_bytes(), &salt, iterations);
+    constant_time_eq(&dk, &expected)
+}
+
+/// Decode a lowercase/uppercase hex string to bytes. None on odd length or a
+/// non-hex character.
+fn unhex(s: &str) -> Option<Vec<u8>> {
+    let b = s.as_bytes();
+    if !b.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(b.len() / 2);
+    let val = |c: u8| -> Option<u8> {
+        match c {
+            b'0'..=b'9' => Some(c - b'0'),
+            b'a'..=b'f' => Some(c - b'a' + 10),
+            b'A'..=b'F' => Some(c - b'A' + 10),
+            _ => None,
+        }
+    };
+    for pair in b.chunks_exact(2) {
+        out.push((val(pair[0])? << 4) | val(pair[1])?);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 4231 HMAC-SHA256 test case 1: key = 0x0b x20, data = "Hi There".
+    #[test]
+    fn hmac_rfc4231_case1() {
+        let mac = hmac_sha256(&[0x0b; 20], b"Hi There");
+        assert_eq!(
+            sha256::hex_bytes(&mac),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    /// RFC 4231 test case 2: key = "Jefe", data = "what do ya want for nothing?".
+    #[test]
+    fn hmac_rfc4231_case2() {
+        let mac = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            sha256::hex_bytes(&mac),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    /// Published PBKDF2-HMAC-SHA256 vectors (password "password", salt "salt").
+    #[test]
+    fn pbkdf2_known_vectors() {
+        assert_eq!(
+            sha256::hex_bytes(&pbkdf2_sha256(b"password", b"salt", 1)),
+            "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"
+        );
+        assert_eq!(
+            sha256::hex_bytes(&pbkdf2_sha256(b"password", b"salt", 2)),
+            "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43"
+        );
+        assert_eq!(
+            sha256::hex_bytes(&pbkdf2_sha256(b"password", b"salt", 4096)),
+            "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"
+        );
+    }
+
+    #[test]
+    fn password_round_trip() {
+        let h = hash_password("correct horse battery staple");
+        assert!(verify_password("correct horse battery staple", &h));
+        assert!(!verify_password("wrong password", &h));
+        // Same password, fresh salt -> different stored hash.
+        let h2 = hash_password("correct horse battery staple");
+        assert_ne!(h, h2);
+    }
+
+    #[test]
+    fn verify_rejects_garbage() {
+        assert!(!verify_password("x", ""));
+        assert!(!verify_password("x", "not-a-hash"));
+        assert!(!verify_password("x", "pbkdf2-sha256$0$aa$bb"));
+        assert!(!verify_password("x", "pbkdf2-sha256$1$zz$bb")); // non-hex salt
+    }
+
+    #[test]
+    fn constant_time_eq_basics() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+    }
+
+    #[test]
+    fn tokens_are_unique_and_sized() {
+        let a = random_token();
+        let b = random_token();
+        assert_eq!(a.len(), 64);
+        assert_ne!(a, b);
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -176,7 +176,7 @@ fn unhex(s: &str) -> Option<Vec<u8>> {
             _ => None,
         }
     };
-    for pair in b.chunks_exact(2) {
+    for pair in b.as_chunks::<2>().0 {
         out.push((val(pair[0])? << 4) | val(pair[1])?);
     }
     Some(out)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,15 +24,16 @@
 //! full restart (the DiskRing is immutable once mapped). The UI shows a
 //! sticky "restart required" banner when those are pending.
 
+mod auth;
 mod autostart;
 mod buffer;
 mod compat;
 mod config;
 mod controller;
+mod crypto;
 mod h264;
 mod https;
 mod obs_register;
-#[cfg(windows)]
 mod portcheck;
 mod rtmp;
 mod self_update;
@@ -130,12 +131,12 @@ fn main() -> std::io::Result<()> {
         let _ = settings.save(&cfg_path);
     }
 
-    // Port pre-flight (Windows only). Without this, a busy port leaves
-    // us in a silent retry loop with no console to print to - the worst
-    // possible first-run UX. If either port is taken we identify the
-    // owning process, propose the next free port in the +0..+9 window,
-    // and pop a native modal asking the user to switch or quit.
-    #[cfg(windows)]
+    // Port pre-flight. Without this, a busy port leaves us in a silent
+    // retry loop - the worst possible first-run UX (no console on Windows,
+    // no one watching on a headless VPS). If either port is taken we resolve
+    // the conflict: a native "switch or quit" modal on Windows, an automatic
+    // fall-forward to the next free port with a loud stderr line elsewhere
+    // (see `resolve_port_conflict`).
     {
         // When relaunched by a restart / self-update, the outgoing instance
         // may still be releasing its listening sockets (the OS can report the
@@ -152,7 +153,7 @@ fn main() -> std::io::Result<()> {
             &format!("{}:{}", host_ingest, settings.ingest_port),
             relaunched,
         ) {
-            match preflight_resolve("RTMP port", settings.ingest_port, host_ingest) {
+            match resolve_port_conflict("RTMP port", settings.ingest_port, host_ingest) {
                 Some(new_port) => settings.ingest_port = new_port,
                 None => return Ok(()),
             }
@@ -163,7 +164,7 @@ fn main() -> std::io::Result<()> {
             "127.0.0.1"
         };
         if !port_free_with_grace(&format!("{}:{}", host_web, settings.web_port), relaunched) {
-            match preflight_resolve("Web port", settings.web_port, host_web) {
+            match resolve_port_conflict("Web port", settings.web_port, host_web) {
                 Some(new_port) => settings.web_port = new_port,
                 None => return Ok(()),
             }
@@ -189,7 +190,7 @@ fn main() -> std::io::Result<()> {
                 // there's no console to print this to, so pop a native
                 // dialog before exiting - otherwise the binary appears
                 // to do nothing and the user has no path to diagnose.
-                // Mirrors how `preflight_resolve` surfaces port
+                // Mirrors how `resolve_port_conflict` surfaces port
                 // conflicts before the runtime starts.
                 let msg = format!(
                     "InstantClone couldn't open or create the delay buffer file.\n\n\
@@ -207,9 +208,7 @@ fn main() -> std::io::Result<()> {
                     settings.buffer_mb,
                     e,
                 );
-                #[cfg(windows)]
-                portcheck::show_error("InstantClone -buffer error", &msg);
-                eprintln!("{}", msg);
+                notify_fatal("InstantClone buffer error", &msg);
                 return Err(e);
             }
         };
@@ -251,6 +250,7 @@ fn main() -> std::io::Result<()> {
         // a line) so a stale shortcut never crashes the app.
         if launch_eb {
             let web_port = settings.web_port;
+            let dock_token = settings.dock_token.clone();
             let ctrl_eb = ctrl.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(600)).await;
@@ -262,7 +262,7 @@ fn main() -> std::io::Result<()> {
                                 .log("[--launch-eb] OBS config not found - is OBS installed?"),
                             Err(e) => ctrl_eb.log(format!("[--launch-eb] flag write failed: {e}")),
                         }
-                        match obs_register::launch_obs_with_eb_config(web_port) {
+                        match obs_register::launch_obs_with_eb_config(web_port, &dock_token) {
                             Ok(exe) => ctrl_eb
                                 .log(format!("[--launch-eb] launched OBS ({})", exe.display())),
                             Err(e) => ctrl_eb.log(format!("[--launch-eb] OBS launch failed: {e}")),
@@ -272,16 +272,19 @@ fn main() -> std::io::Result<()> {
             });
         }
 
-        // System-tray icon (Windows): hidden message-only window in its
-        // own OS thread, signals shutdown back here via a oneshot. The
-        // tray gives us the exit affordance that the dropped console
-        // window used to provide. The tray also reaches into the
-        // controller for status + Cut delay, and into settings for the
-        // RTMP URL clipboard action. On non-Windows the receiver just
-        // sits pending forever (the matching `tray::spawn` is gated by cfg).
-        let (_tray_tx, tray_rx) = tokio::sync::oneshot::channel::<()>();
+        // System-tray icon (Windows): hidden message-only window in its own
+        // OS thread. Its Quit calls straight into the controller's shutdown
+        // signal - the same path the web Quit route uses - so both converge on
+        // the one graceful-teardown epilogue below. The tray also reaches into
+        // the controller for status + Cut delay, and into settings for the
+        // RTMP URL clipboard action.
         #[cfg(windows)]
-        tray::spawn(rx.clone(), ctrl.clone(), _tray_tx);
+        tray::spawn(rx.clone(), ctrl.clone());
+
+        // Shared dashboard-auth state (sessions + login rate limiter). Created
+        // here, not inside the web supervisor, so a web restart (port change)
+        // does not log everyone out. Inert until a password is set.
+        let auth = Arc::new(auth::AuthState::new());
 
         let ingest_sup = tokio::spawn(supervise_ingest(rx.clone(), ctrl.clone()));
         let egress_sup = tokio::spawn(supervise_egress(rx.clone(), ctrl.clone()));
@@ -290,15 +293,24 @@ fn main() -> std::io::Result<()> {
             ctrl.clone(),
             tx.clone(),
             cfg_path.clone(),
+            auth.clone(),
         ));
 
         let shutdown_reason: &str;
+        // Default to Quit; only an explicit restart request flips this.
+        let mut exit_kind = controller::ShutdownKind::Quit;
         tokio::select! {
             _ = ingest_sup => { shutdown_reason = "ingest supervisor exited"; }
             _ = egress_sup => { shutdown_reason = "egress supervisor exited"; }
             _ = web_sup    => { shutdown_reason = "web supervisor exited"; }
             _ = tokio::signal::ctrl_c() => { shutdown_reason = "ctrl-c"; }
-            _ = tray_rx                 => { shutdown_reason = "tray quit"; }
+            kind = ctrl.wait_shutdown() => {
+                exit_kind = kind;
+                shutdown_reason = match kind {
+                    controller::ShutdownKind::Restart => "restart requested",
+                    controller::ShutdownKind::Quit => "quit requested",
+                };
+            }
         }
         eprintln!("\nShutting down ({shutdown_reason}) - closing active streams cleanly...");
         // Flush the egress trace so the last few thousand events make
@@ -326,6 +338,14 @@ fn main() -> std::io::Result<()> {
             if meta.is_file() && meta.len() == cleanup_cap {
                 let _ = std::fs::remove_file(&cleanup_path);
             }
+        }
+
+        // Restart request: now that egress has been torn down cleanly, relaunch
+        // a fresh process in place. `restart_now` spawns the relauncher (which
+        // waits for our PID to release the ports) and hard-exits, so this never
+        // returns on the restart path. A plain Quit just falls through.
+        if let controller::ShutdownKind::Restart = exit_kind {
+            self_update::restart_now();
         }
         Ok::<_, std::io::Error>(())
     })
@@ -367,9 +387,11 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
         (String, tokio::task::JoinHandle<std::io::Result<()>>),
     > = std::collections::HashMap::new();
 
-    // Mirror webhook URL into the controller on every settings change.
+    // Mirror webhook URL + ingest key into the controller on every settings
+    // change (the ingest task enforces the key but has no settings handle).
     let initial_webhook = { rx.borrow().discord_webhook_url.clone() };
     ctrl.update_webhook(initial_webhook);
+    ctrl.update_ingest_key(rx.borrow().ingest_key.clone());
 
     // Managed "Local test sink" child process. Spawned while any
     // enabled destination has platform "sink"; killed when the last
@@ -727,9 +749,10 @@ async fn supervise_egress(mut rx: watch::Receiver<Settings>, ctrl: Arc<controlle
         tokio::select! {
             ch = rx.changed() => {
                 if ch.is_err() { return; }
-                // Mirror webhook URL on every settings change.
+                // Mirror webhook URL + ingest key on every settings change.
                 let new_webhook = { rx.borrow().discord_webhook_url.clone() };
                 ctrl.update_webhook(new_webhook);
+                ctrl.update_ingest_key(rx.borrow().ingest_key.clone());
             }
             _ = periodic_wake => {
                 // One or more pumps exited unexpectedly. Drop dead ones
@@ -848,10 +871,18 @@ async fn supervise_web(
     ctrl: Arc<controller::Controller>,
     tx: Arc<watch::Sender<Settings>>,
     cfg_path: PathBuf,
+    auth: Arc<auth::AuthState>,
 ) {
     let mut current_addr = rx.borrow().web_addr();
-    let spawn_one =
-        |addr: String| tokio::spawn(web::run(addr, ctrl.clone(), tx.clone(), cfg_path.clone()));
+    let spawn_one = |addr: String| {
+        tokio::spawn(web::run(
+            addr,
+            ctrl.clone(),
+            tx.clone(),
+            cfg_path.clone(),
+            auth.clone(),
+        ))
+    };
     let mut handle = spawn_one(current_addr.clone());
     loop {
         tokio::select! {
@@ -875,11 +906,13 @@ async fn supervise_web(
     }
 }
 
-/// Run the port-conflict dialog and return the user's choice.
-/// Returns `Some(new_port)` if the user accepted a fallback,
-/// or `None` if they chose to quit (or no free port was available).
+/// Resolve a port conflict. Returns `Some(new_port)` to bind a fallback,
+/// or `None` to exit cleanly.
+///
+/// Windows pops a native "switch to the next free port or quit" modal, since
+/// the release build has no console to print to.
 #[cfg(windows)]
-fn preflight_resolve(label: &str, port: u16, host: &str) -> Option<u16> {
+fn resolve_port_conflict(label: &str, port: u16, host: &str) -> Option<u16> {
     let owner = portcheck::find_process_on_port(port);
     let proposed = portcheck::find_free_port(host, port.saturating_add(1), 9);
     match portcheck::ask_user(label, port, owner, proposed) {
@@ -888,12 +921,60 @@ fn preflight_resolve(label: &str, port: u16, host: &str) -> Option<u16> {
     }
 }
 
+/// Headless resolution (VPS / Linux desktop): there is no modal to show, so
+/// fall forward to the next free port in the +1..+9 window and print the move
+/// loudly, mirroring what the Windows modal proposes. The new port is
+/// persisted by the caller so OBS / the dashboard can be repointed once. If
+/// the whole window is busy, print an actionable error and exit.
+#[cfg(not(windows))]
+fn resolve_port_conflict(label: &str, port: u16, host: &str) -> Option<u16> {
+    match portcheck::find_free_port(host, port.saturating_add(1), 9) {
+        Some(new_port) => {
+            eprintln!(
+                "[preflight] {label} :{port} is already in use. Moved to :{new_port} - \
+                 point OBS (and the dashboard URL) at the new port."
+            );
+            Some(new_port)
+        }
+        None => {
+            let msg = format!(
+                "{label} :{port} is already in use and no free port was found in \
+                 :{port}..:{}. Free the port or set a different one in \
+                 instantclone.config.json, then relaunch.",
+                port.saturating_add(9)
+            );
+            notify_fatal("InstantClone port conflict", &msg);
+            None
+        }
+    }
+}
+
+/// Surface a fatal, pre-runtime error on every platform. The Windows release
+/// build has no console, and a Linux desktop launched from a `.desktop` entry
+/// has none either, so a bare stderr line would vanish. Always print, then add
+/// the platform's native surface on top.
+fn notify_fatal(title: &str, body: &str) {
+    eprintln!("{body}");
+    #[cfg(windows)]
+    portcheck::show_error(title, body);
+    #[cfg(target_os = "linux")]
+    {
+        // Desktop toast via libnotify. Best effort: on a headless box notify-send
+        // is absent and the spawn just fails, which is fine because stderr is
+        // already visible in the terminal / journal there.
+        let _ = std::process::Command::new("notify-send")
+            .args(["-u", "critical", title, body])
+            .spawn();
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
+    let _ = title;
+}
+
 /// Is `addr` bindable? When `grace` is set (we were relaunched by a restart /
 /// self-update), wait out the outgoing instance's socket-release window before
-/// deciding it's taken - so a normal handoff never pops the "switch port?"
-/// modal. Returns the moment the port frees, so the common case is instant; a
+/// deciding it's taken - so a normal handoff never trips the conflict path.
+/// Returns the moment the port frees, so the common case is instant; a
 /// genuine conflict still falls through after the window.
-#[cfg(windows)]
 fn port_free_with_grace(addr: &str, grace: bool) -> bool {
     if grace {
         portcheck::wait_until_bindable(addr, Duration::from_secs(20))

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,11 @@ fn main() -> std::io::Result<()> {
         // config flag, if we add one later).
         let initial_armed = settings.armed_delay_ms.max(settings.target_delay_ms);
         let ctrl = Arc::new(controller::Controller::new(ring, initial_armed));
+        // Seed the ingest key from config now, before the ingest listener is
+        // spawned below, so a publisher connecting in the first moments of
+        // startup can never slip in with any key while the mirror is still
+        // pending. supervise_egress keeps it in sync on later edits.
+        ctrl.update_ingest_key(settings.ingest_key.clone());
 
         let (tx, rx) = watch::channel(settings.clone());
         let tx = Arc::new(tx);

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -399,10 +399,12 @@ fn legacy_global_ini_in(obs_dir: &Path) -> Option<PathBuf> {
 /// `[Basic] Profile=` lives in this file too, so the active-profile
 /// detection below shares the same lookup.
 fn obs_user_config_path() -> Option<PathBuf> {
-    let obs_dir = std::env::var("APPDATA")
-        .ok()
-        .map(|p| PathBuf::from(p).join("obs-studio"))?;
-    resolve_user_config_in(&obs_dir)
+    // Walk the same cross-platform candidate dirs as services.json (Windows
+    // APPDATA/LOCALAPPDATA, Linux XDG/Flatpak/Snap). The old %APPDATA%-only
+    // lookup returned None on Linux, silently no-op'ing the VOD-audio flag.
+    obs_config_dirs()
+        .into_iter()
+        .find_map(|obs_dir| resolve_user_config_in(&obs_dir))
 }
 
 /// Legacy global.ini path - only consulted for the post-upgrade
@@ -410,10 +412,9 @@ fn obs_user_config_path() -> Option<PathBuf> {
 /// left behind by v0.1.0..0.1.2. None on pre-32 installs where
 /// `obs_user_config_path` already points at global.ini.
 fn legacy_global_ini_path_for_cleanup() -> Option<PathBuf> {
-    let obs_dir = std::env::var("APPDATA")
-        .ok()
-        .map(|p| PathBuf::from(p).join("obs-studio"))?;
-    legacy_global_ini_in(&obs_dir)
+    obs_config_dirs()
+        .into_iter()
+        .find_map(|obs_dir| legacy_global_ini_in(&obs_dir))
 }
 
 /// Read `[General] EnableCustomServerVodTrack` from OBS's user config.
@@ -605,7 +606,8 @@ fn ini_set(file: &str, section: &str, key: &str, enable: bool) -> String {
 // is the user-chosen scope from the dashboard: minimal footprint, the
 // user is warned that switching OBS profiles disables the injection.
 
-const PROFILES_DIR_REL: &str = "obs-studio/basic/profiles";
+// Relative to an OBS config dir (the `.../obs-studio` paths from obs_config_dirs).
+const PROFILES_DIR_REL: &str = "basic/profiles";
 
 /// Active OBS profile name, read from `[Basic] Profile=<name>` in
 /// OBS's user config (user.ini on 32+, global.ini on older installs).
@@ -620,12 +622,15 @@ pub fn active_profile() -> Option<String> {
 /// installed / no profile is selected.
 pub fn active_profile_service_json_path() -> Option<PathBuf> {
     let profile = active_profile()?;
-    let base = std::env::var("APPDATA").ok().map(PathBuf::from)?;
-    let p = base
-        .join(PROFILES_DIR_REL)
-        .join(&profile)
-        .join("service.json");
-    p.exists().then_some(p)
+    obs_config_dirs()
+        .into_iter()
+        .map(|obs_dir| {
+            obs_dir
+                .join(PROFILES_DIR_REL)
+                .join(&profile)
+                .join("service.json")
+        })
+        .find(|p| p.exists())
 }
 
 /// True when our `multitrack_video_configuration_url` is currently

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -17,31 +17,65 @@
 //! write goes via a `.bak` copy first; if anything goes sideways the
 //! user can restore manually.
 //!
-//! Location resolution priority:
-//!   1. `$APPDATA\obs-studio\plugin_config\rtmp-services\services.json`
-//!      (the OBS-on-Windows standard path)
-//!   2. `$LOCALAPPDATA\obs-studio\plugin_config\rtmp-services\services.json`
-//!      (rare - some portable installs land here)
-//!
-//! macOS / Linux paths are not handled - the rest of the app is
-//! Windows-only by design.
+//! Config-dir resolution (services.json + logs both live under it):
+//!   * Windows: `%APPDATA%\obs-studio`, then `%LOCALAPPDATA%\obs-studio`.
+//!   * Linux: `$XDG_CONFIG_HOME/obs-studio` (native / deb), then the Flatpak
+//!     and Snap locations.
+//!   * macOS: not handled yet (no candidates).
 
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-/// Locate the user's `services.json`. Returns `None` if neither
-/// candidate path exists - typical when OBS isn't installed at all.
+/// Candidate OBS config directories for this platform, in priority order.
+/// Both `services.json` and the log folder are resolved relative to these,
+/// so one list drives every OBS-path lookup.
+fn obs_config_dirs() -> Vec<PathBuf> {
+    #[cfg(windows)]
+    {
+        ["APPDATA", "LOCALAPPDATA"]
+            .iter()
+            .filter_map(|v| std::env::var(v).ok())
+            .map(|base| PathBuf::from(base).join("obs-studio"))
+            .collect()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        obs_config_dirs_from(
+            std::env::var_os("HOME").map(PathBuf::from),
+            std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
+        )
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+/// Pure builder for the Linux OBS config-dir candidates - no env reads, so the
+/// XDG / Flatpak / Snap layout is unit-testable. Empty when no home resolves.
+#[cfg(target_os = "linux")]
+fn obs_config_dirs_from(home: Option<PathBuf>, xdg: Option<PathBuf>) -> Vec<PathBuf> {
+    let Some(home) = home else {
+        return Vec::new();
+    };
+    let xdg = xdg
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home.join(".config"));
+    vec![
+        xdg.join("obs-studio"),                                        // native / deb / ppa
+        home.join(".var/app/com.obsproject.Studio/config/obs-studio"), // flatpak
+        home.join("snap/obs-studio/current/.config/obs-studio"),       // snap
+    ]
+}
+
+/// Locate the user's `services.json`. Returns `None` when no candidate path
+/// exists - typical when OBS isn't installed at all.
 pub fn services_json_path() -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("APPDATA")
-            .ok()
-            .map(|p| PathBuf::from(p).join("obs-studio/plugin_config/rtmp-services/services.json")),
-        std::env::var("LOCALAPPDATA")
-            .ok()
-            .map(|p| PathBuf::from(p).join("obs-studio/plugin_config/rtmp-services/services.json")),
-    ];
-    candidates.into_iter().flatten().find(|c| c.exists())
+    obs_config_dirs()
+        .into_iter()
+        .map(|d| d.join("plugin_config/rtmp-services/services.json"))
+        .find(|p| p.exists())
 }
 
 /// True when the user's services.json already contains an entry whose
@@ -657,6 +691,7 @@ pub fn revert_vod_eb(web_port: u16) -> io::Result<bool> {
 /// Standard Windows install paths for obs64.exe. The first match wins.
 /// Portable / non-standard installs aren't auto-discovered (rare and
 /// the user can always launch OBS themselves with the flag).
+#[cfg(windows)]
 fn obs_executable_candidates() -> [PathBuf; 2] {
     [
         PathBuf::from("C:\\Program Files\\obs-studio\\bin\\64bit\\obs64.exe"),
@@ -664,8 +699,31 @@ fn obs_executable_candidates() -> [PathBuf; 2] {
     ]
 }
 
+#[cfg(windows)]
 pub fn find_obs_executable() -> Option<PathBuf> {
     obs_executable_candidates().into_iter().find(|p| p.exists())
+}
+
+/// Native `obs` binary from the standard prefixes, then a PATH scan. Flatpak
+/// / Snap installs expose no plain binary path (they launch via `flatpak run`
+/// / the snap wrapper), so those users launch OBS themselves.
+#[cfg(target_os = "linux")]
+pub fn find_obs_executable() -> Option<PathBuf> {
+    for p in ["/usr/bin/obs", "/usr/local/bin/obs", "/bin/obs"] {
+        let pb = PathBuf::from(p);
+        if pb.exists() {
+            return Some(pb);
+        }
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join("obs"))
+        .find(|p| p.exists())
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn find_obs_executable() -> Option<PathBuf> {
+    None
 }
 
 // ── OBS version + optional VOD-unlocker script install ──────────────
@@ -703,9 +761,10 @@ fn first_version_triple(s: &str) -> Option<(u32, u32, u32)> {
 /// a note", not a hard block: this only gates the experimental
 /// VOD-unlocker script.
 pub fn obs_version() -> Option<(u32, u32, u32)> {
-    let logs_dir = std::env::var("APPDATA")
-        .ok()
-        .map(|p| PathBuf::from(p).join("obs-studio").join("logs"))?;
+    let logs_dir = obs_config_dirs()
+        .into_iter()
+        .map(|d| d.join("logs"))
+        .find(|p| p.is_dir())?;
     let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
     for entry in fs::read_dir(&logs_dir).ok()?.flatten() {
         let path = entry.path();
@@ -769,58 +828,165 @@ pub fn is_obs_running() -> bool {
     }
 }
 
-#[cfg(not(windows))]
+/// Whether an `obs` process is currently running, by scanning `/proc/*/comm`.
+/// Any read failure reads as "not running" - the setup note just stays hidden,
+/// which is harmless.
+#[cfg(target_os = "linux")]
+pub fn is_obs_running() -> bool {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        // Only numeric PID dirs carry a comm file worth reading.
+        let name = entry.file_name();
+        let Some(pid) = name.to_str() else { continue };
+        if !pid.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        if let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) {
+            if comm.trim() == "obs" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn is_obs_running() -> bool {
     false
 }
 
-/// Spawn OBS Studio with the `--config-url` flag pointing at
-/// InstantClone's multitrack-config endpoint. Detaches from our
-/// process group so closing InstantClone afterwards doesn't take OBS
-/// down with it.
+/// Spawn OBS Studio with the `--config-url` flag pointing at InstantClone's
+/// multitrack-config endpoint, so Enhanced Broadcasting comes up pre-wired.
 ///
-/// Returns Ok when the spawn syscall succeeded (NOT when OBS finishes
-/// loading - that's async). Errors surface "OBS not installed" or
-/// permission failures to the dashboard so the user can act.
-pub fn launch_obs_with_eb_config(web_port: u16) -> io::Result<PathBuf> {
+/// Returns Ok when the spawn syscall succeeded (NOT when OBS finishes loading,
+/// which is async). Errors carry an actionable "OBS not found" message so the
+/// dashboard can tell the user what to do.
+#[cfg(windows)]
+pub fn launch_obs_with_eb_config(web_port: u16, dock_token: &str) -> io::Result<PathBuf> {
     let exe = find_obs_executable().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::NotFound,
-            "obs64.exe not found at C:\\Program Files\\obs-studio\\bin\\64bit\\ \
-             (or the x86 path). Launch OBS manually with the \
-             --config-url <our endpoint> flag from the directory where you installed it.",
+            "obs64.exe not found in the standard install locations. Launch OBS \
+             manually with the --config-url <endpoint> flag.",
         )
     })?;
-    let config_url = format!("http://127.0.0.1:{web_port}/obs/multitrack-config");
-    // CREATE_NEW_PROCESS_GROUP (0x00000200) gives OBS its own console
-    // group so InstantClone closing doesn't propagate a SIGTERM-
-    // equivalent. We also pass the launcher's parent dir as the working
-    // directory because OBS's logging and locale paths are resolved
-    // relative to the bin/64bit folder.
-    use std::os::windows::process::CommandExt;
+    let config_url = eb_config_url(web_port, dock_token);
+    // Working dir = OBS's own folder: its logging and locale paths resolve
+    // relative to bin/64bit.
     let workdir = exe.parent().unwrap_or(&exe);
+    use std::os::windows::process::CommandExt;
     std::process::Command::new(&exe)
         .args(["--config-url", &config_url])
         .current_dir(workdir)
+        // CREATE_NEW_PROCESS_GROUP: OBS gets its own console group so
+        // InstantClone closing doesn't propagate a break to it.
         .creation_flags(0x0000_0200)
         .spawn()?;
     Ok(exe)
+}
+
+/// Linux: try a native `obs` binary, then the Flatpak app, then the Snap.
+/// Ubuntu's default OBS is commonly a Flatpak or Snap with no plain binary on
+/// PATH, so covering those is what makes the launch button actually work
+/// instead of failing for most desktop users.
+#[cfg(target_os = "linux")]
+pub fn launch_obs_with_eb_config(web_port: u16, dock_token: &str) -> io::Result<PathBuf> {
+    let config_url = eb_config_url(web_port, dock_token);
+
+    // 1) Native binary (deb / ppa / most distros).
+    if let Some(exe) = find_obs_executable() {
+        let workdir = exe.parent().unwrap_or(&exe);
+        std::process::Command::new(&exe)
+            .args(["--config-url", &config_url])
+            .current_dir(workdir)
+            .spawn()?;
+        return Ok(exe);
+    }
+
+    // 2) Flatpak: present when its per-app data dir exists; launched via
+    //    `flatpak run`, which forwards our flag to OBS.
+    if flatpak_obs_present() && command_on_path("flatpak") {
+        std::process::Command::new("flatpak")
+            .args(["run", "com.obsproject.Studio", "--config-url", &config_url])
+            .spawn()?;
+        return Ok(PathBuf::from("flatpak run com.obsproject.Studio"));
+    }
+
+    // 3) Snap.
+    if snap_obs_present() && command_on_path("snap") {
+        std::process::Command::new("snap")
+            .args(["run", "obs-studio", "--config-url", &config_url])
+            .spawn()?;
+        return Ok(PathBuf::from("snap run obs-studio"));
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "OBS not found. Looked for a native obs binary, the Flatpak \
+         com.obsproject.Studio, and the obs-studio snap. Launch OBS manually \
+         with the --config-url <endpoint> flag.",
+    ))
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn launch_obs_with_eb_config(_web_port: u16, _dock_token: &str) -> io::Result<PathBuf> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "launching OBS is not supported on this platform",
+    ))
+}
+
+/// The `--config-url` OBS should hit for Enhanced Broadcasting. When the
+/// dashboard password is on, the dock token rides in the query so OBS (which
+/// cannot sign in) still passes the auth gate to the control-plane multitrack
+/// endpoint; empty token = the plain URL for the default (no-auth) install.
+#[cfg(any(windows, target_os = "linux"))]
+fn eb_config_url(web_port: u16, dock_token: &str) -> String {
+    if dock_token.is_empty() {
+        format!("http://127.0.0.1:{web_port}/obs/multitrack-config")
+    } else {
+        format!("http://127.0.0.1:{web_port}/obs/multitrack-config?token={dock_token}")
+    }
+}
+
+/// A `~/.var/app/com.obsproject.Studio` dir means the Flatpak OBS is installed.
+#[cfg(target_os = "linux")]
+fn flatpak_obs_present() -> bool {
+    std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".var/app/com.obsproject.Studio").exists())
+        .unwrap_or(false)
+}
+
+/// A `~/snap/obs-studio` dir means the Snap OBS is installed.
+#[cfg(target_os = "linux")]
+fn snap_obs_present() -> bool {
+    std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join("snap/obs-studio").exists())
+        .unwrap_or(false)
+}
+
+/// True if `name` resolves to a file on PATH.
+#[cfg(target_os = "linux")]
+fn command_on_path(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).any(|d| d.join(name).exists()))
+        .unwrap_or(false)
 }
 
 // ── Desktop shortcut: one-click "Start InstantClone + OBS (VOD + EB)" ──
 //
 // Generates a clickable launcher on the Desktop that cold-starts the app
 // with `--launch-eb`, so a streamer who always wants VOD audio + Enhanced
-// Broadcasting gets the whole setup from a single double-click. We prefer
-// a real Windows .lnk (so it carries the app icon), created via
-// PowerShell's WScript.Shell COM to avoid pulling in a COM crate. If that
-// path is unavailable (PowerShell locked down, non-Windows), we fall back
-// to a .cmd launcher so the user always gets something that works.
+// Broadcasting gets the whole setup from a single double-click. On Windows
+// we prefer a real .lnk (so it carries the app icon), created via
+// PowerShell's WScript.Shell COM to avoid a COM crate, falling back to a
+// .cmd launcher. On Linux we write a freedesktop `.desktop` launcher.
 
-/// Best-effort Desktop folder. `%USERPROFILE%\Desktop` covers the vast
-/// majority of Windows installs; OneDrive-redirected desktops are not
-/// auto-discovered (the .cmd/.lnk still lands somewhere clickable if the
-/// user later points us at it). None when we can't resolve a home dir.
+/// Best-effort Desktop folder. `%USERPROFILE%\Desktop` / `$HOME/Desktop`
+/// covers the vast majority of installs; localized or redirected desktops
+/// are not auto-discovered. None when we can't resolve a home dir.
 fn desktop_dir() -> Option<PathBuf> {
     let home = std::env::var("USERPROFILE")
         .ok()
@@ -829,12 +995,14 @@ fn desktop_dir() -> Option<PathBuf> {
 }
 
 /// PowerShell single-quoted-string escaping: a literal `'` becomes `''`.
+#[cfg(windows)]
 fn ps_single_quote(s: &str) -> String {
     s.replace('\'', "''")
 }
 
 /// Try to create a real Windows `.lnk` shortcut via PowerShell COM.
 /// Returns Ok only when PowerShell reports success AND the file exists.
+#[cfg(windows)]
 fn try_create_lnk(lnk: &Path, exe: &Path) -> io::Result<()> {
     let workdir = exe.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let script = format!(
@@ -856,9 +1024,10 @@ fn try_create_lnk(lnk: &Path, exe: &Path) -> io::Result<()> {
 }
 
 /// Create a Desktop shortcut that launches InstantClone in VOD+EB mode
-/// (`instantclone.exe --launch-eb`). Returns the path of the file actually
+/// (`instantclone --launch-eb`). Returns the path of the file actually
 /// created (a `.lnk` when possible, otherwise a `.cmd` fallback) so the UI
 /// can tell the user exactly what to look for.
+#[cfg(windows)]
 pub fn create_eb_shortcut() -> io::Result<PathBuf> {
     let exe = std::env::current_exe()?;
     let desktop = desktop_dir().ok_or_else(|| {
@@ -888,6 +1057,54 @@ pub fn create_eb_shortcut() -> io::Result<PathBuf> {
     );
     write_or_friendly(&cmd, &body)?;
     Ok(cmd)
+}
+
+/// Linux: write a freedesktop `.desktop` launcher on the Desktop. It must be
+/// marked executable (GNOME also treats that as the "trusted" bit) to run on
+/// double-click.
+#[cfg(target_os = "linux")]
+pub fn create_eb_shortcut() -> io::Result<PathBuf> {
+    let exe = std::env::current_exe()?;
+    let desktop = desktop_dir().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "could not locate your Desktop folder")
+    })?;
+    if !desktop.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Desktop folder not found at {}", desktop.display()),
+        ));
+    }
+    let file = desktop.join("InstantClone (VOD + EB).desktop");
+    let icon = crate::autostart::ensure_icon();
+    let icon_line = icon
+        .as_ref()
+        .and_then(|p| p.to_str())
+        .map(|i| format!("Icon={i}\n"))
+        .unwrap_or_default();
+    let entry = format!(
+        "[Desktop Entry]\n\
+         Type=Application\n\
+         Name=InstantClone (VOD + EB)\n\
+         Comment=Start InstantClone in VOD + EB mode and launch OBS\n\
+         {icon_line}\
+         Exec=\"{}\" --launch-eb\n\
+         Terminal=false\n",
+        exe.display()
+    );
+    write_or_friendly(&file, &entry)?;
+    use std::os::unix::fs::PermissionsExt;
+    let mut perm = std::fs::metadata(&file)?.permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&file, perm)?;
+    Ok(file)
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn create_eb_shortcut() -> io::Result<PathBuf> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "desktop shortcut creation is not supported on this platform",
+    ))
 }
 
 /// Remove the multitrack-video-configuration-url key (matching our
@@ -921,6 +1138,26 @@ fn strip_service_json_key(file: &str, web_port: u16) -> String {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32 as TestUniq, Ordering as TestOrd};
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_obs_config_dirs_cover_native_flatpak_snap() {
+        use std::path::PathBuf;
+        let dirs = obs_config_dirs_from(Some(PathBuf::from("/home/u")), Some(PathBuf::from("/xdg")));
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/xdg/obs-studio"),
+                PathBuf::from("/home/u/.var/app/com.obsproject.Studio/config/obs-studio"),
+                PathBuf::from("/home/u/snap/obs-studio/current/.config/obs-studio"),
+            ]
+        );
+        // No home -> no candidates (every OBS lookup then returns None).
+        assert!(obs_config_dirs_from(None, None).is_empty());
+        // A relative XDG value is ignored; falls back to ~/.config.
+        let fb = obs_config_dirs_from(Some(PathBuf::from("/home/u")), Some(PathBuf::from("rel")));
+        assert_eq!(fb[0], PathBuf::from("/home/u/.config/obs-studio"));
+    }
 
     fn fake_services_json() -> String {
         // Minimal but realistic shape. OBS's actual file has many more

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -63,9 +63,9 @@ fn obs_config_dirs_from(home: Option<PathBuf>, xdg: Option<PathBuf>) -> Vec<Path
         .filter(|p| p.is_absolute())
         .unwrap_or_else(|| home.join(".config"));
     vec![
-        xdg.join("obs-studio"),                                        // native / deb / ppa
+        xdg.join("obs-studio"), // native / deb / ppa
         home.join(".var/app/com.obsproject.Studio/config/obs-studio"), // flatpak
-        home.join("snap/obs-studio/current/.config/obs-studio"),       // snap
+        home.join("snap/obs-studio/current/.config/obs-studio"), // snap
     ]
 }
 
@@ -955,7 +955,11 @@ fn eb_config_url(web_port: u16, dock_token: &str) -> String {
 #[cfg(target_os = "linux")]
 fn flatpak_obs_present() -> bool {
     std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".var/app/com.obsproject.Studio").exists())
+        .map(|h| {
+            PathBuf::from(h)
+                .join(".var/app/com.obsproject.Studio")
+                .exists()
+        })
         .unwrap_or(false)
 }
 
@@ -1066,7 +1070,10 @@ pub fn create_eb_shortcut() -> io::Result<PathBuf> {
 pub fn create_eb_shortcut() -> io::Result<PathBuf> {
     let exe = std::env::current_exe()?;
     let desktop = desktop_dir().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, "could not locate your Desktop folder")
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "could not locate your Desktop folder",
+        )
     })?;
     if !desktop.exists() {
         return Err(io::Error::new(
@@ -1143,7 +1150,8 @@ mod tests {
     #[test]
     fn linux_obs_config_dirs_cover_native_flatpak_snap() {
         use std::path::PathBuf;
-        let dirs = obs_config_dirs_from(Some(PathBuf::from("/home/u")), Some(PathBuf::from("/xdg")));
+        let dirs =
+            obs_config_dirs_from(Some(PathBuf::from("/home/u")), Some(PathBuf::from("/xdg")));
         assert_eq!(
             dirs,
             vec![

--- a/src/portcheck.rs
+++ b/src/portcheck.rs
@@ -1,29 +1,38 @@
-//! Startup port pre-flight: detect if the configured RTMP / web ports
-//! are already in use, identify the owning process, ask the user via a
-//! native MessageBox whether to fall back to the next free port or quit.
+//! Startup port pre-flight: detect if the configured RTMP / web ports are
+//! already in use before we try to bind them.
 //!
-//! All FFI is Windows-only; the non-Windows stubs make this a no-op.
+//! The bind checks (`is_port_free`, `find_free_port`, `wait_until_bindable`)
+//! are pure `std::net` and run on every platform. The extras that identify
+//! the owning process (IpHelper) and prompt the user (MessageBox) are
+//! Windows-only, gated below; the caller in main.rs supplies a headless
+//! stderr path for those on other platforms.
 //!
-//! Why we have it: with `windows_subsystem = "windows"` there is no
-//! console, so a silent bind-loop on a busy port is the worst possible
-//! first-run UX. A modal dialog with the offending process's name is
-//! the cheapest fix that doesn't add a runtime dep.
+//! Why we have it: a silent bind-loop on a busy port is the worst possible
+//! first-run UX - on Windows there's no console (`windows_subsystem =
+//! "windows"`), on a headless VPS there's no one watching a hung process.
 
-#![cfg(windows)]
-
-use std::ffi::OsStr;
 use std::net::TcpListener;
+
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
+#[cfg(windows)]
 use std::ptr;
 
+#[cfg(windows)]
 use windows_sys::Win32::Foundation::{CloseHandle, NO_ERROR};
+#[cfg(windows)]
 use windows_sys::Win32::NetworkManagement::IpHelper::{
     GetExtendedTcpTable, MIB_TCPROW_OWNER_PID, TCP_TABLE_OWNER_PID_LISTENER,
 };
+#[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::{ntohs, AF_INET};
+#[cfg(windows)]
 use windows_sys::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
 };
+#[cfg(windows)]
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     MessageBoxW, IDYES, MB_ICONWARNING, MB_OK, MB_YESNO,
 };
@@ -31,6 +40,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 /// Header struct of the variable-length table returned by
 /// `GetExtendedTcpTable(TCP_TABLE_OWNER_PID_LISTENER)`. We never
 /// instantiate this - we cast a `Vec<u8>` buffer to it.
+#[cfg(windows)]
 #[repr(C)]
 struct MibTcpTableOwnerPid {
     num_entries: u32,
@@ -40,6 +50,7 @@ struct MibTcpTableOwnerPid {
 /// Pid + executable filename of the process owning a given listening
 /// TCP port. Returns `None` if no listener is on that port, or if the
 /// OS-level lookup failed entirely.
+#[cfg(windows)]
 pub fn find_process_on_port(port: u16) -> Option<(u32, Option<String>)> {
     unsafe {
         // First call: get required buffer size.
@@ -89,6 +100,7 @@ pub fn find_process_on_port(port: u16) -> Option<(u32, Option<String>)> {
 /// Best-effort executable basename for a PID. `None` if the OS denies
 /// us access (e.g. PID belongs to an elevated process) - the caller
 /// still has the PID to show.
+#[cfg(windows)]
 fn process_name(pid: u32) -> Option<String> {
     unsafe {
         let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
@@ -147,6 +159,7 @@ pub fn find_free_port(host: &str, start: u16, range: u16) -> Option<u16> {
     None
 }
 
+#[cfg(windows)]
 pub enum ConflictChoice {
     SwitchPort(u16),
     Quit,
@@ -154,6 +167,7 @@ pub enum ConflictChoice {
 
 /// Pop a native modal asking the user what to do about a port conflict.
 /// `label` is shown to the user as "RTMP port" / "web port".
+#[cfg(windows)]
 pub fn ask_user(
     label: &str,
     port: u16,
@@ -202,7 +216,8 @@ pub fn ask_user(
 /// Pop a one-shot native error dialog. Used by main.rs for fatal
 /// cold-start failures that would otherwise leave the user staring at
 /// a closed (or never-opened) console - buffer file unwritable, etc.
-/// Safe to call from any thread; on non-Windows it's a no-op.
+/// Windows-only; other platforms print to stderr at the call site.
+#[cfg(windows)]
 pub fn show_error(title: &str, body: &str) {
     let title_w = wide(title);
     let body_w = wide(body);
@@ -216,6 +231,7 @@ pub fn show_error(title: &str, body: &str) {
     }
 }
 
+#[cfg(windows)]
 fn wide(s: &str) -> Vec<u16> {
     OsStr::new(s)
         .encode_wide()
@@ -294,6 +310,7 @@ mod tests {
         drop(held);
     }
 
+    #[cfg(windows)]
     #[test]
     fn find_process_on_port_finds_self_when_holding_socket() {
         // Bind a port in this very process, then ask the FFI who owns

--- a/src/rtmp/server.rs
+++ b/src/rtmp/server.rs
@@ -33,7 +33,7 @@ pub async fn run(addr: String, ctrl: Arc<Controller>) -> io::Result<()> {
         let _ = crate::rtmp::tcp::set_aggressive_keepalive(&sock);
         let ctrl = ctrl.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle(sock, ctrl).await {
+            if let Err(e) = handle(sock, ctrl, peer).await {
                 eprintln!("[ingest] {} closed: {}", peer, e);
             }
         });
@@ -55,8 +55,16 @@ impl Drop for PublishGuard {
     }
 }
 
-async fn handle(mut sock: tokio::net::TcpStream, ctrl: Arc<Controller>) -> io::Result<()> {
+async fn handle(
+    mut sock: tokio::net::TcpStream,
+    ctrl: Arc<Controller>,
+    peer: std::net::SocketAddr,
+) -> io::Result<()> {
     handshake::perform_server(&mut sock).await?;
+
+    // Keys the ingest-key rate limiter; the port pre-flight already resolved a
+    // stable bind, so the connecting peer's IP is the right client identity.
+    let peer_ip = peer.ip().to_string();
 
     let (rd, wr) = split(sock);
     let mut reader = ChunkReader::new(rd);
@@ -87,7 +95,7 @@ async fn handle(mut sock: tokio::net::TcpStream, ctrl: Arc<Controller>) -> io::R
         }
         match msg.type_id {
             20 /* AMF0 command */ => {
-                handle_command(&mut writer, &ctrl, &msg, &mut guard).await?;
+                handle_command(&mut writer, &ctrl, &msg, &mut guard, &peer_ip).await?;
             }
             18 /* AMF0 data - onMetaData et al */ => {
                 ctrl.on_metadata(msg.payload.to_vec());
@@ -163,6 +171,7 @@ async fn handle_command<W: tokio::io::AsyncWrite + Unpin>(
     ctrl: &Arc<Controller>,
     msg: &Message,
     guard: &mut PublishGuard,
+    peer_ip: &str,
 ) -> io::Result<()> {
     let values = amf0::decode_all(&msg.payload)?;
     let name = values
@@ -214,7 +223,7 @@ async fn handle_command<W: tokio::io::AsyncWrite + Unpin>(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            match ctrl.begin_publish(&stream_key).await {
+            match ctrl.begin_publish(&stream_key, peer_ip).await {
                 Ok(_token) => {
                     guard.active = true;
                     // onStatus NetStream.Publish.Start

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -40,6 +40,24 @@ pub struct Staged {
     pub version: String,
 }
 
+/// Release asset filename for the running platform. MUST match the names
+/// produced by `.github/workflows/release.yml`. `tag` includes the leading
+/// `v` (e.g. `v0.1.13`).
+fn release_asset_name(tag: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("instantclone-{tag}-windows-x64.exe")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        format!("instantclone-{tag}-linux-x64")
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
+    {
+        format!("instantclone-{tag}-unknown")
+    }
+}
+
 /// Sibling path `exe` + `.` + `ext`, e.g. `instantclone.exe.new`.
 fn sidecar(exe: &Path, ext: &str) -> PathBuf {
     let mut s = exe.as_os_str().to_owned();
@@ -81,6 +99,20 @@ pub fn prepare() -> Result<Staged, String> {
     std::fs::write(&staged, &bytes)
         .map_err(|e| format!("can't write the update next to the exe: {e}"))?;
 
+    // A downloaded Linux binary lands non-executable; the swap-then-relaunch
+    // would fail with EACCES without this. Windows keys off the extension,
+    // so this is unix-only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = std::fs::metadata(&staged)
+            .map_err(|e| format!("can't stat the staged update: {e}"))?
+            .permissions();
+        perm.set_mode(0o755);
+        std::fs::set_permissions(&staged, perm)
+            .map_err(|e| format!("can't make the staged update executable: {e}"))?;
+    }
+
     Ok(Staged {
         exe,
         staged,
@@ -94,7 +126,7 @@ pub fn prepare() -> Result<Staged, String> {
 /// download-and-verify path with no GitHub round-trip (see tests).
 fn fetch_verified(agent: &ureq::Agent, base: &str, version: &str) -> Result<Vec<u8>, String> {
     let tag = format!("v{version}");
-    let exe_name = format!("instantclone-{tag}-windows-x64.exe");
+    let exe_name = release_asset_name(&tag);
     let exe_url = format!("{base}/{tag}/{exe_name}");
     let sums_url = format!("{base}/{tag}/SHA256SUMS.txt");
 
@@ -271,6 +303,18 @@ mod tests {
 
     const NAME: &str = "instantclone-v0.1.6-windows-x64.exe";
 
+    /// The self-update asset name MUST match what release.yml publishes, or
+    /// the checksum lookup can never find its line. This locks that contract
+    /// per platform.
+    #[test]
+    fn release_asset_name_matches_release_workflow() {
+        let n = super::release_asset_name("v1.2.3");
+        #[cfg(windows)]
+        assert_eq!(n, "instantclone-v1.2.3-windows-x64.exe");
+        #[cfg(target_os = "linux")]
+        assert_eq!(n, "instantclone-v1.2.3-linux-x64");
+    }
+
     #[test]
     fn parses_standard_sha256sums_line() {
         let body = format!("{}  {NAME}\n", "a".repeat(64));
@@ -355,7 +399,10 @@ mod e2e {
     fn fetch_verified_accepts_matching_checksum() {
         let exe = b"FAKE-INSTANTCLONE-EXE-BODY-v9.9.9".to_vec();
         let hash = crate::sha256::hex(&exe);
-        let sums = format!("{hash}  instantclone-v9.9.9-windows-x64.exe\n");
+        // Name the asset per the running platform, exactly as fetch_verified
+        // resolves it - a Windows-only literal fails the checksum lookup on
+        // the Linux build.
+        let sums = format!("{hash}  {}\n", super::release_asset_name("v9.9.9"));
         let port = serve_release(exe.clone(), sums);
         let base = format!("http://127.0.0.1:{port}");
         let agent = crate::https::https_agent();
@@ -369,7 +416,7 @@ mod e2e {
         // (tampered) body - verification must reject it.
         let genuine = b"GENUINE-BODY".to_vec();
         let hash = crate::sha256::hex(&genuine);
-        let sums = format!("{hash}  instantclone-v9.9.9-windows-x64.exe\n");
+        let sums = format!("{hash}  {}\n", super::release_asset_name("v9.9.9"));
         let tampered = b"TAMPERED-PAYLOAD-PRETENDING-TO-BE-THE-RELEASE".to_vec();
         let port = serve_release(tampered, sums);
         let base = format!("http://127.0.0.1:{port}");

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -52,7 +52,7 @@ pub fn digest(data: &[u8]) -> [u8; 32] {
     }
     msg.extend_from_slice(&bit_len.to_be_bytes());
 
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
         for (i, word) in w.iter_mut().take(16).enumerate() {
             *word = u32::from_be_bytes([

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -22,9 +22,14 @@ const K: [u32; 64] = [
 
 /// Lowercase hex of the SHA-256 digest of `data`.
 pub fn hex(data: &[u8]) -> String {
-    let d = digest(data);
-    let mut s = String::with_capacity(64);
-    for b in d {
+    hex_bytes(&digest(data))
+}
+
+/// Lowercase hex encoding of arbitrary bytes (no hashing). Used by
+/// `crate::crypto` for salts, tokens, and derived keys.
+pub fn hex_bytes(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
         s.push_str(&format!("{b:02x}"));
     }
     s

--- a/src/sysstat.rs
+++ b/src/sysstat.rs
@@ -1,7 +1,8 @@
 //! Self-process CPU% and resident-set-size sampling for the dashboard
-//! metric grid. Windows-only hand-rolled FFI (no `sysinfo` / `procfs`
-//! dependency); other platforms compile to inert no-op stubs that report
-//! zero. Adding /proc and Mach impls later is a few dozen lines.
+//! metric grid. Hand-rolled per platform, no `sysinfo` / `procfs`
+//! dependency: Windows uses kernel32/psapi FFI, Linux reads `/proc/self`.
+//! Any other Unix (macOS) compiles to an inert stub that reports zero
+//! until a Mach impl is added.
 
 use crate::sync::Mutex;
 use std::time::Instant;
@@ -149,10 +150,114 @@ mod platform {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::SysStat;
+    use std::time::Instant;
+
+    /// (cpu_percent, rss_bytes) from `/proc/self`. Mirrors the Windows
+    /// sampler's contract: CPU% is the process's user+system time consumed
+    /// since the previous call over the wall-clock delta, clamped so a
+    /// multi-core spike can't render as "700%". Any read/parse failure
+    /// degrades to zero rather than 500-ing the /state endpoint.
+    pub fn sample(s: &SysStat) -> (f32, u64) {
+        let now = Instant::now();
+        let cpu_pct = match read_proc_ticks() {
+            Some(ticks) => {
+                let mut prev = s.prev.lock();
+                let pct = match *prev {
+                    Some((prev_ticks, prev_t)) => {
+                        let dt = now.duration_since(prev_t).as_secs_f64();
+                        let work = ticks.saturating_sub(prev_ticks) as f64 / clk_tck();
+                        if dt <= 0.0 {
+                            0.0
+                        } else {
+                            (work / dt) as f32 * 100.0
+                        }
+                    }
+                    None => 0.0,
+                };
+                *prev = Some((ticks, now));
+                pct
+            }
+            None => 0.0,
+        };
+        let rss = read_proc_rss().unwrap_or(0);
+        (cpu_pct.clamp(0.0, 100.0 * num_cpus_hint() as f32), rss)
+    }
+
+    /// Sum of utime + stime (clock ticks) from `/proc/self/stat`. The comm
+    /// field (field 2) can contain spaces and parentheses, so we split after
+    /// the final ')': the first token past it is `state` (field 3), which
+    /// puts utime at index 11 and stime at index 12.
+    fn read_proc_ticks() -> Option<u64> {
+        let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+        let rest = &stat[stat.rfind(')')? + 1..];
+        let fields: Vec<&str> = rest.split_whitespace().collect();
+        let utime: u64 = fields.get(11)?.parse().ok()?;
+        let stime: u64 = fields.get(12)?.parse().ok()?;
+        Some(utime.saturating_add(stime))
+    }
+
+    /// Resident set size in bytes: field 2 of `/proc/self/statm` (pages)
+    /// times the page size.
+    fn read_proc_rss() -> Option<u64> {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+        Some(resident_pages.saturating_mul(page_size()))
+    }
+
+    /// Ticks per second. Effectively always 100 on Linux, but read it so an
+    /// exotic kernel config can't skew the percentage. Falls back to 100.
+    fn clk_tck() -> f64 {
+        let v = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if v > 0 {
+            v as f64
+        } else {
+            100.0
+        }
+    }
+
+    fn page_size() -> u64 {
+        let v = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if v > 0 {
+            v as u64
+        } else {
+            4096
+        }
+    }
+
+    fn num_cpus_hint() -> u32 {
+        std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1)
+    }
+}
+
+// Any Unix that is not Linux (macOS) has no /proc; report zero until a
+// native sampler is added. Windows and Linux are handled above.
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 mod platform {
     use super::SysStat;
     pub fn sample(_s: &SysStat) -> (f32, u64) {
         (0.0, 0)
+    }
+}
+
+// Linux-only: the /proc sampler is the only platform impl worth a self-test
+// here (Windows FFI needs a live process to mean anything). Gating the whole
+// module to Linux keeps the `SysStat` import from reading as unused elsewhere.
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::SysStat;
+
+    /// The sampler must read a real resident-set size from /proc/self/statm - a
+    /// non-zero RSS is the whole point of the port (the old stub returned 0).
+    /// CPU% is 0 on the first sample by design (no prior reading to diff), so
+    /// we only assert RSS here.
+    #[test]
+    fn linux_sampler_reports_nonzero_rss() {
+        let (_cpu, rss) = SysStat::new().sample();
+        assert!(rss > 0, "expected a real RSS from /proc/self/statm, got 0");
     }
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -17,7 +17,6 @@
 
 #![cfg(windows)]
 
-use crate::sync::Mutex;
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr;
@@ -70,28 +69,18 @@ struct TrayState {
     dock_url: String,
     ctrl: Arc<Controller>,
     settings: watch::Receiver<Settings>,
-    /// `Mutex<Option<…>>` so the WNDPROC can `take()` the sender on the
-    /// Quit click and `send(())` once. (`oneshot::Sender::send` consumes
-    /// `self`, hence the `take` shape.) Previous design used Notify which
-    /// was a no-op if no receiver was awaiting at that moment; oneshot
-    /// has no such race.
-    quit: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 }
 
 /// Spawn the tray on its own OS thread. Returns immediately; the thread
 /// runs the message loop until the user picks Quit (or the process dies).
-pub fn spawn(
-    settings: watch::Receiver<Settings>,
-    ctrl: Arc<Controller>,
-    quit: tokio::sync::oneshot::Sender<()>,
-) {
+pub fn spawn(settings: watch::Receiver<Settings>, ctrl: Arc<Controller>) {
     let s = settings.borrow().clone();
     let web_url = format!("http://127.0.0.1:{}/", s.web_port);
     let dock_url = format!("http://127.0.0.1:{}/dock", s.web_port);
     std::thread::Builder::new()
         .name("instantclone-tray".into())
         .spawn(move || {
-            if let Err(e) = run(web_url, dock_url, ctrl, settings, quit) {
+            if let Err(e) = run(web_url, dock_url, ctrl, settings) {
                 eprintln!("[tray] init failed: {e}");
             }
         })
@@ -103,7 +92,6 @@ fn run(
     dock_url: String,
     ctrl: Arc<Controller>,
     settings: watch::Receiver<Settings>,
-    quit: tokio::sync::oneshot::Sender<()>,
 ) -> Result<(), String> {
     unsafe {
         let h_instance = GetModuleHandleW(ptr::null());
@@ -152,7 +140,6 @@ fn run(
             dock_url,
             ctrl,
             settings,
-            quit: Mutex::new(Some(quit)),
         });
         SetWindowLongPtrW(hwnd, GWLP_USERDATA, Box::into_raw(state) as isize);
 
@@ -264,9 +251,12 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
                     // VOD-track flag, then launch OBS with --config-url.
                     // Both are synchronous and degrade quietly (missing
                     // OBS just logs) so a click never wedges the tray.
-                    let web_port = state.settings.borrow().web_port;
+                    let (web_port, dock_token) = {
+                        let s = state.settings.borrow();
+                        (s.web_port, s.dock_token.clone())
+                    };
                     let _ = crate::obs_register::set_vod_audio_flag(true);
-                    match crate::obs_register::launch_obs_with_eb_config(web_port) {
+                    match crate::obs_register::launch_obs_with_eb_config(web_port, &dock_token) {
                         Ok(exe) => state.ctrl.log(format!(
                             "[tray] launched OBS for VOD + EB ({})",
                             exe.display()
@@ -282,12 +272,10 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
                     if state.ctrl.ingest_alive() && !confirm_quit_while_live(hwnd) {
                         return 0;
                     }
-                    // Take the sender so a second click can't double-send.
-                    // Ignore the Err: it just means the main task already shut
-                    // down (race with ctrl-c) and dropped the receiver.
-                    if let Some(tx) = state.quit.lock().take() {
-                        let _ = tx.send(());
-                    }
+                    // Signal the main loop to tear down egress cleanly and exit
+                    // - the same path the web Quit route uses. Idempotent, so a
+                    // second click is harmless.
+                    state.ctrl.request_quit();
                     PostQuitMessage(0);
                 }
                 _ => {}

--- a/src/web.rs
+++ b/src/web.rs
@@ -3598,6 +3598,16 @@ fn classify_access(method: &str, path: &str) -> Access {
     if path == "/overlay" || path.starts_with("/overlay/") {
         return Access::Public;
     }
+    // OBS fetches the multitrack (Enhanced Broadcasting) config when it starts
+    // streaming, with no session cookie and often no token - the config URL is
+    // saved in OBS before any password is set. It returns only the encoder
+    // ladder plus a local ingest template ("rtmp://127.0.0.1:<port>/live/
+    // {stream_key}"), never a secret, and cannot control anything, so it stays
+    // public like the overlay display. Gating it would break Start Streaming the
+    // moment a dashboard password is enabled.
+    if path == "/obs/multitrack-config" {
+        return Access::Public;
+    }
     match (method, path) {
         ("GET", "/state")
         | ("GET", "/events")
@@ -3606,11 +3616,6 @@ fn classify_access(method: &str, path: &str) -> Access {
         | ("GET", "/docks")
         | ("GET", "/profiles")
         | ("GET", "/platforms")
-        // OBS itself hits this (no session cookie); it authenticates with the
-        // dock token embedded in the --config-url we hand it. Control-only:
-        // it returns the EB ladder config, never a secret.
-        | ("GET", "/obs/multitrack-config")
-        | ("POST", "/obs/multitrack-config")
         | ("POST", "/arm")
         | ("POST", "/activate")
         | ("POST", "/stop")

--- a/src/web.rs
+++ b/src/web.rs
@@ -1375,6 +1375,25 @@ async fn obs_multitrack_config_proxy(
     ctrl: &Arc<Controller>,
     settings: &Arc<watch::Sender<Settings>>,
 ) -> String {
+    // Enforce the InstantClone ingest key at the Enhanced Broadcasting entry
+    // point. Under proxy EB, OBS publishes with the Twitch session token (which
+    // we broker), so begin_publish never sees the user's key - the ONLY place it
+    // is presented is the `authentication` field of THIS request (OBS puts its
+    // Stream Key field there). If we don't check it here, a wrong key still gets
+    // a brokered session and streams. Empty ingest key = open, same as
+    // begin_publish. Strip any query the user appended, matching begin_publish.
+    if !eb_request_authorized(body, &settings.borrow().ingest_key) {
+        ctrl.log(
+            "[OBS multitrack] rejected config request - wrong InstantClone key in the \
+             OBS Stream Key field. Returning static config; the publish will be refused.",
+        );
+        crate::trace::log(
+            "OBS_MULTITRACK",
+            "wrong ingest key in request - refusing to broker an EB session",
+        );
+        return obs_multitrack_config_static(query, settings);
+    }
+
     // The streamer's real Twitch key lives in our destinations list.
     // Pick the first enabled Twitch destination with a non-empty key.
     // Also report what we found in the dashboard event log - the
@@ -1535,17 +1554,14 @@ async fn obs_multitrack_config_proxy(
     // with `url_template` values like
     // `rtmps://<region>.contribute.live-video.net/app/{stream_key}`.
     // Replace every rtmp:// or rtmps:// URL in url_template fields with our
-    // localhost ingest so OBS sends the multi-track stream to us instead. The
-    // path segment carries our ingest key when one is set (so EB publishes with
-    // the key begin_publish enforces); otherwise it stays the `{stream_key}`
-    // token OBS fills from its Stream Key field (any key accepted).
+    // localhost ingest so OBS sends the multi-track stream to us instead. We
+    // keep `{stream_key}` as the literal token - OBS substitutes it with the
+    // session `authentication` token from this config. When an ingest key is
+    // set that token would not match it, so we remember the token below and
+    // begin_publish accepts it (see Controller::remember_eb_key).
     let rewritten = rewrite_url_templates(
         &twitch_json,
-        &format!(
-            "rtmp://127.0.0.1:{}/live/{}",
-            ingest_port,
-            multitrack_ingest_segment(settings)
-        ),
+        &format!("rtmp://127.0.0.1:{}/live/{{stream_key}}", ingest_port),
     );
     // Extract the *original* IVS ingest URL from Twitch's response
     // BEFORE rewriting it to localhost, substitute the streamer's real
@@ -1588,6 +1604,24 @@ async fn obs_multitrack_config_proxy(
         .map(|e| (Some(e.url_template), e.authentication))
         .unwrap_or((None, None));
     let substitution = ivs_auth.as_deref().unwrap_or(&twitch_key);
+    // OBS will publish the EB stream to our ingest using an endpoint's session
+    // token as the stream key (it fills the {stream_key} token in the url_template
+    // we returned). Remember EVERY endpoint's token, not just the first: OBS's
+    // create_service picks the first endpoint matching its RTMP/RTMPS preference
+    // and publishes with THAT one's token. Twitch currently returns the same
+    // token for its RTMP and RTMPS endpoints, but we don't rely on that. Each is
+    // remembered so begin_publish accepts the EB publish once an ingest key is set
+    // - the token and the ingest key are different by design.
+    let endpoint_auths = all_ingest_endpoint_auths(&twitch_json);
+    for auth in &endpoint_auths {
+        ctrl.remember_eb_key(auth.clone());
+    }
+    // Non-IVS multitrack (no token on any endpoint): OBS falls back to its Stream
+    // Key field, which our proxy swapped for the real Twitch key - remember that
+    // so the publish is still accepted.
+    if endpoint_auths.is_empty() {
+        ctrl.remember_eb_key(twitch_key.clone());
+    }
     let ivs_url = ivs_template.map(|t| t.replace("{stream_key}", substitution));
     if let Some(ivs) = ivs_url.as_ref() {
         // Apply the override to EXACTLY one Twitch destination: the
@@ -1678,6 +1712,22 @@ struct IngestEndpoint {
     authentication: Option<String>,
 }
 
+/// Whether an OBS multitrack-config request may broker an Enhanced Broadcasting
+/// session. Under proxy EB, OBS publishes with the Twitch session token (not the
+/// user's key), so `begin_publish` can't enforce the ingest key - the user's key
+/// is presented only here, as the request's `authentication` field (OBS's Stream
+/// Key field). An empty ingest key means auth is off, so everything is allowed.
+/// The query is stripped to match `Controller::begin_publish`; constant-time
+/// compare matches the ingest-key / password / dock-token paths.
+fn eb_request_authorized(body: &str, ingest_key: &str) -> bool {
+    if ingest_key.is_empty() {
+        return true;
+    }
+    let presented = read_string_field(body, "authentication").unwrap_or_default();
+    let presented = presented.split('?').next().unwrap_or("");
+    crate::crypto::constant_time_eq(presented.as_bytes(), ingest_key.as_bytes())
+}
+
 /// Pull the first `ingest_endpoints[…]` entry's `url_template` and
 /// optional `authentication` out of Twitch's response. The parser is
 /// scoped to the substring starting at the first `"ingest_endpoints"`
@@ -1694,6 +1744,36 @@ fn first_ingest_endpoint(json: &str) -> Option<IngestEndpoint> {
         url_template,
         authentication,
     })
+}
+
+/// Every `authentication` token inside the `ingest_endpoints` array. OBS may
+/// publish with any endpoint's token (it picks the first matching its RTMP/RTMPS
+/// preference), so the broker remembers all of them. Scoped to the array - the
+/// endpoint objects hold only string fields, so the first `]` after the array
+/// key closes it, which keeps us from scooping an `authentication` from
+/// elsewhere in the response.
+fn all_ingest_endpoint_auths(json: &str) -> Vec<String> {
+    let Some(start) = json.find("\"ingest_endpoints\"") else {
+        return Vec::new();
+    };
+    let region = &json[start..];
+    let region = match region.find(']') {
+        Some(end) => &region[..end],
+        None => region,
+    };
+    let needle = "\"authentication\"";
+    let mut auths = Vec::new();
+    let mut cursor = 0;
+    while let Some(pos) = region[cursor..].find(needle) {
+        let abs = cursor + pos;
+        if let Some(val) = read_string_field(&region[abs..], "authentication") {
+            if !val.is_empty() {
+                auths.push(val);
+            }
+        }
+        cursor = abs + needle.len();
+    }
+    auths
 }
 
 /// Find `"<key>": "<value>"` in a JSON-ish substring and return the
@@ -1841,26 +1921,6 @@ fn rewrite_url_templates(json: &str, new_value: &str) -> String {
     out
 }
 
-/// The path segment OBS publishes to in the multitrack (Enhanced Broadcasting)
-/// config we hand it. With an ingest key set we embed it so OBS publishes with
-/// the exact key `Controller::begin_publish` enforces - otherwise EB would send
-/// its own session key and get rejected. Without a key (or with a key that
-/// isn't URL/JSON-safe, which a stray character could use to corrupt the config
-/// OBS parses) we leave the `{stream_key}` token for OBS to fill; generated
-/// keys are hex, so the safe path is the normal path.
-fn multitrack_ingest_segment(settings: &Arc<watch::Sender<Settings>>) -> String {
-    let key = settings.borrow().ingest_key.clone();
-    let safe = !key.is_empty()
-        && key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
-    if safe {
-        key
-    } else {
-        "{stream_key}".to_string()
-    }
-}
-
 fn obs_multitrack_config_static(query: &str, settings: &Arc<watch::Sender<Settings>>) -> String {
     let params = config::parse_form(query);
     let encoder = params.get("encoder").map(|s| s.as_str()).unwrap_or("x264");
@@ -1955,10 +2015,9 @@ fn obs_multitrack_config_static(query: &str, settings: &Arc<watch::Sender<Settin
     }
 
     format!(
-        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://127.0.0.1:{port}/live/{seg}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
+        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://127.0.0.1:{port}/live/{{stream_key}}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
         cid = config_id,
         port = ingest_port,
-        seg = multitrack_ingest_segment(settings),
         encs = enc_configs,
     )
 }
@@ -2159,6 +2218,12 @@ async fn post_config(
     // Mirror webhook into the controller so events fire correctly even
     // before the next supervisor settings-change tick.
     ctrl.update_webhook(new_settings.discord_webhook_url.clone());
+    // Same for the ingest key: mirror it inline so locking down the ingest port
+    // takes effect this instant. Waiting for the supervisor tick would leave a
+    // brief window where begin_publish still enforces the previous (usually
+    // empty) key and accepts any publisher - exactly the exposure the user just
+    // moved to close.
+    ctrl.update_ingest_key(new_settings.ingest_key.clone());
     // Flip the trace switch right away so a toggle in the System tab
     // takes effect this instant - no need to wait for a restart.
     crate::trace::set_enabled(new_settings.tracing_enabled);
@@ -4713,28 +4778,63 @@ mod tests {
     }
 
     #[test]
-    fn multitrack_config_embeds_ingest_key_when_set() {
-        // No key: OBS keeps the {stream_key} token, so any key is accepted.
+    fn multitrack_config_keeps_stream_key_token() {
+        // The ingest url_template we hand OBS always keeps the {stream_key}
+        // token; OBS fills it (with its Stream Key field, or the EB session
+        // token). EB publishes are accepted via Controller::remember_eb_key, not
+        // by embedding a key in this URL.
         let mut s = crate::config::Settings::defaults();
         s.ingest_port = 1935;
-        let (tx, _rx) = watch::channel(s.clone());
-        let open = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx));
-        assert!(open.contains("/live/{stream_key}"));
-
-        // Safe key: embedded directly so Enhanced Broadcasting publishes with
-        // exactly the key begin_publish enforces (no more "wrong stream key").
         s.ingest_key = "abc123def".into();
-        let (tx2, _rx2) = watch::channel(s.clone());
-        let locked = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx2));
-        assert!(locked.contains("/live/abc123def"));
-        assert!(!locked.contains("{stream_key}"));
+        let (tx, _rx) = watch::channel(s);
+        let cfg = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx));
+        assert!(cfg.contains("/live/{stream_key}"));
+    }
 
-        // Unsafe key (a stray quote could corrupt the config JSON): fall back
-        // to the token rather than emit a malformed config.
-        s.ingest_key = "bad key\"".into();
-        let (tx3, _rx3) = watch::channel(s);
-        let fb = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx3));
-        assert!(fb.contains("/live/{stream_key}"));
+    #[test]
+    fn all_ingest_endpoint_auths_collects_every_endpoint() {
+        // Real Twitch shape: an RTMP and an RTMPS endpoint. OBS picks one by its
+        // RTMPS preference, so the broker must remember both tokens. (Twitch here
+        // returns the same token for both, but distinct tokens must also work.)
+        let json = r#"{"meta":{"config_id":"x"},"ingest_endpoints":[
+            {"protocol":"RTMP","url_template":"rtmp://a/app/{stream_key}","authentication":"tok_rtmp"},
+            {"protocol":"RTMPS","url_template":"rtmps://a/app/{stream_key}","authentication":"tok_rtmps"}
+        ],"encoder_configurations":[{"authentication":"NOT_AN_ENDPOINT_TOKEN"}]}"#;
+        let auths = all_ingest_endpoint_auths(json);
+        assert_eq!(auths, vec!["tok_rtmp".to_string(), "tok_rtmps".to_string()]);
+        // The `authentication` in encoder_configurations is outside the array and
+        // must not be scooped up.
+        assert!(!auths.iter().any(|a| a.contains("NOT_AN_ENDPOINT")));
+
+        // No endpoints / no tokens -> empty, and the proxy's twitch-key fallback
+        // covers it.
+        assert!(all_ingest_endpoint_auths(r#"{"meta":{}}"#).is_empty());
+        assert!(all_ingest_endpoint_auths(
+            r#"{"ingest_endpoints":[{"protocol":"RTMP","url_template":"rtmp://a/{stream_key}"}]}"#
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn eb_request_authorized_enforces_ingest_key() {
+        // OBS presents the user's Stream Key field as the request's
+        // `authentication`. This is the ONLY place the ingest key is checkable
+        // under proxy EB (the publish itself carries the Twitch token).
+        let body = r#"{"schema_version":"2024-06-04","authentication":"secretkey","client":{}}"#;
+
+        // No ingest key configured: auth off, anything allowed.
+        assert!(eb_request_authorized(body, ""));
+
+        // Correct key allowed; wrong key (the reported bug) refused.
+        assert!(eb_request_authorized(body, "secretkey"));
+        assert!(!eb_request_authorized(body, "wrongkey"));
+
+        // A user-appended query on the key field is stripped before matching.
+        let body_q = r#"{"authentication":"secretkey?bandwidthtest=true","client":{}}"#;
+        assert!(eb_request_authorized(body_q, "secretkey"));
+
+        // Missing authentication field with a key set: refused, not allowed.
+        assert!(!eb_request_authorized(r#"{"client":{}}"#, "secretkey"));
     }
 
     #[test]

--- a/src/web.rs
+++ b/src/web.rs
@@ -580,6 +580,14 @@ async fn auth_gate(
         return Ok(AuthDecision::Handled);
     }
     if method == "POST" && bare_path == "/auth/disable" {
+        // Already disabled when no password is set: a no-op without a config
+        // write (and there is no session this request could have proven). When
+        // auth is on, the gate above already required an admin session to reach
+        // this point.
+        if settings.borrow().dashboard_password_hash.is_empty() {
+            write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, "").await?;
+            return Ok(AuthDecision::Handled);
+        }
         {
             let _wl = settings_write_guard();
             let mut ns = settings.borrow().clone();
@@ -594,6 +602,21 @@ async fn auth_gate(
         return Ok(AuthDecision::Handled);
     }
     if method == "POST" && bare_path == "/auth/regen-dock" {
+        // The dock token only gates anything once a password is set, so refuse
+        // to rotate it (and churn config) from an unauthenticated request while
+        // auth is off. When auth is on, the gate above already required an admin
+        // session to reach this point.
+        if settings.borrow().dashboard_password_hash.is_empty() {
+            write_simple(
+                sock,
+                "400 Bad Request",
+                "application/json",
+                r#"{"ok":false,"error":"enable a dashboard password before rotating the dock token"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
         let new_token;
         {
             let _wl = settings_write_guard();

--- a/src/web.rs
+++ b/src/web.rs
@@ -430,7 +430,9 @@ async fn auth_gate(
             // Rate-limit BEFORE hashing so a locked-out or spamming client
             // burns no CPU. Vital on the single-threaded runtime, where a
             // 230ms hash on every attempt would otherwise stall the stream.
-            if let Err(wait) = auth.check_login_allowed(peer_ip) {
+            // begin_login_attempt counts this try as it checks, so N concurrent
+            // requests can't all clear the gate before the hash below resolves.
+            if let Err(wait) = auth.begin_login_attempt(peer_ip) {
                 let msg = format!(
                     r#"{{"ok":false,"error":"too many attempts, wait {}s"}}"#,
                     wait.as_secs() + 1
@@ -460,7 +462,7 @@ async fn auth_gate(
                 write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, &set).await?;
                 return Ok(AuthDecision::Handled);
             }
-            auth.record_failure(peer_ip);
+            // The attempt was already counted by begin_login_attempt above.
             write_simple(
                 sock,
                 "401 Unauthorized",

--- a/src/web.rs
+++ b/src/web.rs
@@ -216,13 +216,13 @@ async fn serve(
     // fail-closed once a password is set. The whole security-critical surface
     // lives in one auditable function; a `Handled` result means it already
     // wrote a response (login page, 401, redirect, an /auth/* mutation).
-    let dock_set_cookie = match auth_gate(
+    let (dock_set_cookie, is_admin) = match auth_gate(
         &mut sock, method, path, bare_path, head_str, body, &settings, &cfg_path, &auth, &peer_ip,
     )
     .await?
     {
         AuthDecision::Handled => return Ok(()),
-        AuthDecision::Allow(cookie) => cookie,
+        AuthDecision::Allow { cookie, is_admin } => (cookie, is_admin),
     };
 
     // Fast-path: static, pre-gzipped dashboard + dock. These two pages
@@ -345,7 +345,7 @@ async fn serve(
     }
 
     let (status, ctype, payload) =
-        route(method, path, body, &ctrl, &settings, &cfg_path, &sysstat).await;
+        route(method, path, body, &ctrl, &settings, &cfg_path, &sysstat, is_admin).await;
 
     // ACAO is intentionally restrictive now - only set on GET responses
     // so overlays / docks loaded as foreign origins can still read state.
@@ -370,7 +370,11 @@ async fn serve(
 /// request is allowed through with an optional `/dock` Set-Cookie header.
 enum AuthDecision {
     Handled,
-    Allow(String),
+    /// The request may proceed. `cookie` is an optional Set-Cookie line (the
+    /// dock-token handoff); `is_admin` is true for a full dashboard session or
+    /// when auth is off, false for a dock-token-only caller. Routes use it to
+    /// redact secrets and refuse settings writes for the dock.
+    Allow { cookie: String, is_admin: bool },
 }
 
 /// The optional dashboard-auth gate, kept in one auditable place so `serve()`
@@ -392,6 +396,10 @@ async fn auth_gate(
     peer_ip: &str,
 ) -> io::Result<AuthDecision> {
     let mut dock_set_cookie = String::new();
+    // True for a full dashboard session and (below) when auth is off entirely.
+    // Flipped to the session state once a password is set, so a dock-token
+    // caller is marked non-admin and routes can redact secrets from it.
+    let mut is_admin = true;
 
     // OFF BY DEFAULT: with no password set this is a single is_empty() on the
     // borrow (no allocation, no clone) and we fall straight through. Once a
@@ -404,6 +412,9 @@ async fn auth_gate(
         let cookies = parse_cookies(head_str);
         let session_cookie = cookies.get("ic_session").cloned().unwrap_or_default();
         let has_session = auth.validate_session(&session_cookie);
+        // Only a real session is admin; a dock token authorizes Control routes
+        // but never confers admin, so it never sees a redacted-away secret.
+        is_admin = has_session;
 
         // --- login page + login/logout (reachable without a session) ---
         if method == "GET" && bare_path == "/login" {
@@ -631,9 +642,16 @@ async fn auth_gate(
         return Ok(AuthDecision::Handled);
     }
 
-    Ok(AuthDecision::Allow(dock_set_cookie))
+    Ok(AuthDecision::Allow {
+        cookie: dock_set_cookie,
+        is_admin,
+    })
 }
 
+// The central request dispatcher genuinely needs all of these: the request
+// parts, the shared runtime handles, and the caller's admin flag. Bundling them
+// into a struct would only move the argument list, not remove it.
+#[allow(clippy::too_many_arguments)]
 async fn route(
     method: &str,
     path: &str,
@@ -642,6 +660,7 @@ async fn route(
     settings: &Arc<watch::Sender<Settings>>,
     cfg_path: &Path,
     sysstat: &Arc<SysStat>,
+    is_admin: bool,
 ) -> (&'static str, &'static str, String) {
     // Strip ?query - we only read it for /overlay.
     let (bare_path, query) = match path.split_once('?') {
@@ -698,7 +717,11 @@ async fn route(
         ("GET", "/config") => (
             "200 OK",
             "application/json",
-            settings.borrow().to_json(crate::autostart::is_enabled()),
+            // A dock-token caller (is_admin == false) gets the config with the
+            // raw ingest key and dock token blanked; a full session gets them.
+            settings
+                .borrow()
+                .to_json(crate::autostart::is_enabled(), is_admin),
         ),
         ("GET", "/docks") => dock_list_json(settings),
         ("GET", "/platforms") => ("200 OK", "application/json", platforms_json()),
@@ -3412,6 +3435,7 @@ fn apply_field_str(s: &mut Settings, key: &str, value: &str) {
             }
         }
         "ingest_bind_all" => s.ingest_bind_all = value == "on" || value == "true" || value == "1",
+        "ingest_key" => s.ingest_key = value.into(),
         "web_port" => {
             if let Ok(v) = value.parse() {
                 s.web_port = v;
@@ -3616,6 +3640,16 @@ fn classify_access(method: &str, path: &str) -> Access {
         | ("GET", "/docks")
         | ("GET", "/profiles")
         | ("GET", "/platforms")
+        // Read + operational routes the OBS dock needs so it can render and run
+        // the stream. GET /config is redacted for a dock caller (no raw ingest
+        // key or dock token - see route + to_json); GET /destinations is already
+        // redacted (a "key set" boolean, never the raw key); toggling a
+        // destination on/off is operational, not a settings change. Editing
+        // settings, upserting destinations, and every secret write stay Admin.
+        | ("GET", "/config")
+        | ("GET", "/destinations")
+        | ("GET", "/overlays")
+        | ("POST", "/destinations/toggle")
         | ("POST", "/arm")
         | ("POST", "/activate")
         | ("POST", "/stop")
@@ -3625,6 +3659,8 @@ fn classify_access(method: &str, path: &str) -> Access {
         | ("POST", "/cut-after")
         | ("POST", "/cut-after/cancel") => Access::Control,
         ("POST", p) if p.starts_with("/docks/") => Access::Control,
+        // GET a saved dock layout (the dock loads its own persisted layout).
+        ("GET", p) if p.starts_with("/docks/") => Access::Control,
         _ => Access::Admin,
     }
 }
@@ -4254,6 +4290,19 @@ mod tests {
             normalize_stream_format("youtube", Some("garbage")),
             "horizontal"
         );
+    }
+
+    #[test]
+    fn apply_field_str_persists_ingest_key() {
+        // Regression: ingest_key is in post_config's form whitelist, so
+        // apply_field_str must have a matching arm or the "Save key" button
+        // silently no-ops and the ingest is never actually locked.
+        let mut s = crate::config::Settings::defaults();
+        assert!(s.ingest_key.is_empty());
+        apply_field_str(&mut s, "ingest_key", "hunter2ingest");
+        assert_eq!(s.ingest_key, "hunter2ingest");
+        apply_field_str(&mut s, "ingest_key", "");
+        assert!(s.ingest_key.is_empty());
     }
 
     #[test]

--- a/src/web.rs
+++ b/src/web.rs
@@ -344,8 +344,10 @@ async fn serve(
         return Ok(());
     }
 
-    let (status, ctype, payload) =
-        route(method, path, body, &ctrl, &settings, &cfg_path, &sysstat, is_admin).await;
+    let (status, ctype, payload) = route(
+        method, path, body, &ctrl, &settings, &cfg_path, &sysstat, is_admin,
+    )
+    .await;
 
     // ACAO is intentionally restrictive now - only set on GET responses
     // so overlays / docks loaded as foreign origins can still read state.
@@ -374,7 +376,10 @@ enum AuthDecision {
     /// dock-token handoff); `is_admin` is true for a full dashboard session or
     /// when auth is off, false for a dock-token-only caller. Routes use it to
     /// redact secrets and refuse settings writes for the dock.
-    Allow { cookie: String, is_admin: bool },
+    Allow {
+        cookie: String,
+        is_admin: bool,
+    },
 }
 
 /// The optional dashboard-auth gate, kept in one auditable place so `serve()`

--- a/src/web.rs
+++ b/src/web.rs
@@ -33,21 +33,19 @@ use tokio::sync::watch;
 /// later `send()` clobbers the other's change. That lost update used to
 /// silently reset the `configured` flag and bounce users into the first-run
 /// wizard. This is the one lock that deliberately keeps `std`'s poison
-/// handling (rather than `crate::sync`): a panic mid-save should not wedge
-/// every later config write, so `settings_write_guard` recovers the guard
-/// instead of propagating. A plain `std::sync::Mutex` is also correct here
-/// because the critical section never `.await`s (its `!Send` guard makes that
-/// a compile error), so it can be taken from the sync persist/overlay handlers.
-static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// serializes the read-modify-write-send cycle so concurrent POSTs can't
+/// clobber each other. Uses `crate::sync::Mutex` like the rest of the codebase:
+/// under `panic = "abort"` a poisoned lock is unreachable in release, and the
+/// fail-fast path in debug is the right signal (see `crate::sync`). The
+/// critical section never `.await`s (the `!Send` guard makes that a compile
+/// error), so it is safe to take from the sync persist/overlay handlers.
+static SETTINGS_WRITE_LOCK: crate::sync::Mutex<()> = crate::sync::Mutex::new(());
 
 /// Take the settings write lock for a full read-modify-write-send cycle. Hold
 /// the guard from just before `settings.borrow().clone()` until after
-/// `settings.send(..)`. Recovers from a poisoned mutex - a panic mid-save must
-/// not wedge every later config write.
+/// `settings.send(..)`.
 fn settings_write_guard() -> std::sync::MutexGuard<'static, ()> {
-    SETTINGS_WRITE_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
+    SETTINGS_WRITE_LOCK.lock()
 }
 
 /// True when at least one destination is enabled and fully addressable (a
@@ -68,6 +66,7 @@ pub async fn run(
     ctrl: Arc<Controller>,
     settings: Arc<watch::Sender<Settings>>,
     cfg_path: PathBuf,
+    auth: Arc<crate::auth::AuthState>,
 ) -> io::Result<()> {
     let listener = TcpListener::bind(&addr).await?;
     // Don't let a restart/self-update child inherit this listener, or the port
@@ -78,13 +77,18 @@ pub async fn run(
     // delta, so we cannot construct one per request.
     let sysstat = Arc::new(SysStat::new());
     loop {
-        let (sock, _) = listener.accept().await?;
+        let (sock, peer) = listener.accept().await?;
         let ctrl = ctrl.clone();
         let settings = settings.clone();
         let cfg_path = cfg_path.clone();
         let sysstat = sysstat.clone();
+        let auth = auth.clone();
+        // Peer IP keys the login rate limiter. Behind a reverse proxy every
+        // request shares the proxy's IP, which just makes the limit global -
+        // safe, since a spoofed X-Forwarded-For must never relax it.
+        let peer_ip = peer.ip().to_string();
         tokio::spawn(async move {
-            let _ = serve(sock, ctrl, settings, cfg_path, sysstat).await;
+            let _ = serve(sock, ctrl, settings, cfg_path, sysstat, auth, peer_ip).await;
         });
     }
 }
@@ -95,14 +99,23 @@ async fn serve(
     settings: Arc<watch::Sender<Settings>>,
     cfg_path: PathBuf,
     sysstat: Arc<SysStat>,
+    auth: Arc<crate::auth::AuthState>,
+    peer_ip: String,
 ) -> io::Result<()> {
     // Read until the headers terminator. For our POST bodies (config form,
     // <2 KB) this single read is enough - but be defensive about partials.
     let mut buf = vec![0u8; 16 * 1024];
     let mut used = 0usize;
     let head_end;
+    // Total deadline for the whole request-head read, so a slowloris client
+    // dripping one byte at a time can't pin a connection (and its buffers / FD)
+    // open forever. A deadline bounds the aggregate, unlike a per-read timeout.
+    let head_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
     loop {
-        let n = sock.read(&mut buf[used..]).await?;
+        let n = match tokio::time::timeout_at(head_deadline, sock.read(&mut buf[used..])).await {
+            Ok(r) => r?,
+            Err(_) => return Ok(()), // headers took too long; drop
+        };
         if n == 0 {
             return Ok(());
         }
@@ -156,6 +169,62 @@ async fn serve(
     // `path` here still carries the `?...` suffix.
     let bare_path = path.split_once('?').map(|(p, _)| p).unwrap_or(path);
 
+    // Request body: only POST routes (the config form, login, the auth
+    // mutations) consume one, so we read a body for POST alone. A GET or HEAD
+    // that advertises a large Content-Length therefore never makes us allocate
+    // or block reading a body it has no business sending - it is served (or
+    // gated) straight from the head we already have.
+    const MAX_BODY: usize = 32 * 1024 * 1024;
+    let body_buf = if method == "POST" {
+        if content_length > MAX_BODY {
+            let body = br#"{"ok":false,"error":"body too large (max 32 MB)"}"# as &[u8];
+            let r = format!(
+                "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            sock.write_all(r.as_bytes()).await?;
+            sock.write_all(body).await?;
+            return Ok(());
+        }
+        let mut b = buf[head_end..used].to_vec();
+        // Same idea as the header deadline: bound the whole body read so a
+        // client advertising a large Content-Length can't feed it one slow
+        // byte at a time.
+        let body_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        while b.len() < content_length {
+            let mut tmp = [0u8; 4096];
+            let n = match tokio::time::timeout_at(body_deadline, sock.read(&mut tmp)).await {
+                Ok(r) => r?,
+                Err(_) => break, // body took too long; use what we have
+            };
+            if n == 0 {
+                break;
+            }
+            b.extend_from_slice(&tmp[..n]);
+        }
+        // Drop any pipelined bytes past this request (we always Connection:
+        // close, so there is no next request on this socket anyway).
+        b.truncate(content_length);
+        b
+    } else {
+        Vec::new()
+    };
+    let body = std::str::from_utf8(&body_buf).unwrap_or("");
+
+    // Optional dashboard auth. Off by default (a single is_empty() inside),
+    // fail-closed once a password is set. The whole security-critical surface
+    // lives in one auditable function; a `Handled` result means it already
+    // wrote a response (login page, 401, redirect, an /auth/* mutation).
+    let dock_set_cookie = match auth_gate(
+        &mut sock, method, path, bare_path, head_str, body, &settings, &cfg_path, &auth, &peer_ip,
+    )
+    .await?
+    {
+        AuthDecision::Handled => return Ok(()),
+        AuthDecision::Allow(cookie) => cookie,
+    };
+
     // Fast-path: static, pre-gzipped dashboard + dock. These two pages
     // dominate the binary (~125 KB raw); shipping only the gz blob saves
     // ~100 KB. Every real browser sends `Accept-Encoding: gzip`; for the
@@ -183,8 +252,9 @@ async fn serve(
             "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
              Content-Encoding: gzip\r\nVary: Accept-Encoding\r\n\
              Content-Length: {}\r\n\
-             Access-Control-Allow-Origin: *\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
-            blob.len()
+             Access-Control-Allow-Origin: *\r\n{}Cache-Control: no-store\r\nConnection: close\r\n\r\n",
+            blob.len(),
+            dock_set_cookie
         );
         sock.write_all(r.as_bytes()).await?;
         sock.write_all(blob).await?;
@@ -252,38 +322,27 @@ async fn serve(
         return handle_sse(sock, ctrl, settings, sysstat).await;
     }
 
-    // Cap POST body size. The only callers are the local dashboard and OBS
-    // (127.0.0.1-only), so this is just defense-in-depth against a caller
-    // advertising a giant Content-Length and forcing a huge allocation. It
-    // is set generously because a Studio overlay can embed an uploaded image
-    // as a base64 data URL (which rides inside the saved overlay HTML).
-    const MAX_BODY: usize = 32 * 1024 * 1024;
-    if content_length > MAX_BODY {
-        let body = br#"{"ok":false,"error":"body too large (max 32 MB)"}"# as &[u8];
-        let r = format!(
-            "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\n\
-             Content-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        );
-        sock.write_all(r.as_bytes()).await?;
-        sock.write_all(body).await?;
+    // Lifecycle controls (admin-gated by auth_gate above): acknowledge and
+    // flush the 200 to the client BEFORE tripping the shutdown signal. The main
+    // loop can exit the process the instant its egress teardown finishes, so
+    // signalling first would race our own exit and drop the response. Write,
+    // half-close so the FIN follows the bytes, then signal.
+    if method == "POST" && (bare_path == "/app/restart" || bare_path == "/app/quit") {
+        let restart = bare_path == "/app/restart";
+        let payload = if restart {
+            r#"{"ok":true,"restarting":true}"#
+        } else {
+            r#"{"ok":true,"quitting":true}"#
+        };
+        write_simple(&mut sock, "200 OK", "application/json", payload, "").await?;
+        let _ = sock.shutdown().await;
+        if restart {
+            ctrl.request_restart();
+        } else {
+            ctrl.request_quit();
+        }
         return Ok(());
     }
-
-    // For POST: ensure we have the full body.
-    let mut body_buf = buf[head_end..used].to_vec();
-    while body_buf.len() < content_length {
-        let mut tmp = [0u8; 4096];
-        let n = sock.read(&mut tmp).await?;
-        if n == 0 {
-            break;
-        }
-        body_buf.extend_from_slice(&tmp[..n]);
-    }
-    if body_buf.len() > content_length {
-        body_buf.truncate(content_length);
-    }
-    let body = std::str::from_utf8(&body_buf).unwrap_or("");
 
     let (status, ctype, payload) =
         route(method, path, body, &ctrl, &settings, &cfg_path, &sysstat).await;
@@ -304,6 +363,252 @@ async fn serve(
     sock.write_all(resp.as_bytes()).await?;
     sock.write_all(payload.as_bytes()).await?;
     Ok(())
+}
+
+/// Result of the auth gate: either it already wrote a response (login page,
+/// 401, redirect, or an /auth/* mutation) and the caller returns, or the
+/// request is allowed through with an optional `/dock` Set-Cookie header.
+enum AuthDecision {
+    Handled,
+    Allow(String),
+}
+
+/// The optional dashboard-auth gate, kept in one auditable place so `serve()`
+/// stays readable and the entire security surface (login, logout, the
+/// fail-closed public/control/admin gate, and the /auth/* management endpoints)
+/// is reviewable together. Off by default: with no password set it returns
+/// `Allow` after a single `is_empty()`.
+#[allow(clippy::too_many_arguments)]
+async fn auth_gate(
+    sock: &mut TcpStream,
+    method: &str,
+    path: &str,
+    bare_path: &str,
+    head_str: &str,
+    body: &str,
+    settings: &Arc<watch::Sender<Settings>>,
+    cfg_path: &Path,
+    auth: &Arc<crate::auth::AuthState>,
+    peer_ip: &str,
+) -> io::Result<AuthDecision> {
+    let mut dock_set_cookie = String::new();
+
+    // OFF BY DEFAULT: with no password set this is a single is_empty() on the
+    // borrow (no allocation, no clone) and we fall straight through. Once a
+    // password is set it fails closed - see `classify_access` (default = admin).
+    if !settings.borrow().dashboard_password_hash.is_empty() {
+        let (pw_hash, dock_token) = {
+            let s = settings.borrow();
+            (s.dashboard_password_hash.clone(), s.dock_token.clone())
+        };
+        let cookies = parse_cookies(head_str);
+        let session_cookie = cookies.get("ic_session").cloned().unwrap_or_default();
+        let has_session = auth.validate_session(&session_cookie);
+
+        // --- login page + login/logout (reachable without a session) ---
+        if method == "GET" && bare_path == "/login" {
+            write_simple(sock, "200 OK", "text/html; charset=utf-8", LOGIN_HTML, "").await?;
+            return Ok(AuthDecision::Handled);
+        }
+        if method == "POST" && bare_path == "/login" {
+            // Rate-limit BEFORE hashing so a locked-out or spamming client
+            // burns no CPU. Vital on the single-threaded runtime, where a
+            // 230ms hash on every attempt would otherwise stall the stream.
+            if let Err(wait) = auth.check_login_allowed(peer_ip) {
+                let msg = format!(
+                    r#"{{"ok":false,"error":"too many attempts, wait {}s"}}"#,
+                    wait.as_secs() + 1
+                );
+                write_simple(sock, "429 Too Many Requests", "application/json", &msg, "").await?;
+                return Ok(AuthDecision::Handled);
+            }
+            let password = crate::config::parse_form(body)
+                .get("password")
+                .cloned()
+                .unwrap_or_default();
+            // PBKDF2 off the runtime thread so the stream never hitches.
+            let hash_for = pw_hash.clone();
+            let ok = tokio::task::spawn_blocking(move || {
+                crate::crypto::verify_password(&password, &hash_for)
+            })
+            .await
+            .unwrap_or(false);
+            if ok {
+                auth.record_success(peer_ip);
+                let token = auth.create_session();
+                let set = format!(
+                    "Set-Cookie: ic_session={}; HttpOnly; SameSite=Strict; Path=/{}\r\n",
+                    token,
+                    secure_flag(head_str)
+                );
+                write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, &set).await?;
+                return Ok(AuthDecision::Handled);
+            }
+            auth.record_failure(peer_ip);
+            write_simple(
+                sock,
+                "401 Unauthorized",
+                "application/json",
+                r#"{"ok":false,"error":"wrong password"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
+        if method == "POST" && bare_path == "/logout" {
+            if !session_cookie.is_empty() {
+                auth.revoke_session(&session_cookie);
+            }
+            let clear = "Set-Cookie: ic_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0\r\n";
+            write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, clear).await?;
+            return Ok(AuthDecision::Handled);
+        }
+
+        // --- the gate for every other route ---
+        let access = classify_access(method, bare_path);
+        let dock_supplied = query_param(path, "token")
+            .or_else(|| cookies.get("ic_dock").cloned())
+            .unwrap_or_default();
+        let has_dock = !dock_token.is_empty()
+            && crate::crypto::constant_time_eq(dock_supplied.as_bytes(), dock_token.as_bytes());
+        let allowed = match access {
+            Access::Public => true,
+            Access::Control => has_session || has_dock,
+            Access::Admin => has_session,
+        };
+        if !allowed {
+            // Browser navigation to a protected page bounces to /login; an
+            // API/XHR call gets a clean 401 the dashboard can react to.
+            if method == "GET" && wants_html(head_str) {
+                let r = "HTTP/1.1 302 Found\r\nLocation: /login\r\n\
+                         Content-Length: 0\r\nConnection: close\r\n\r\n";
+                sock.write_all(r.as_bytes()).await?;
+                return Ok(AuthDecision::Handled);
+            }
+            write_simple(
+                sock,
+                "401 Unauthorized",
+                "application/json",
+                r#"{"ok":false,"error":"authentication required"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
+        // Dock authenticated via ?token: hand it a cookie so its later
+        // same-origin control calls (which won't carry the query) are allowed.
+        if bare_path == "/dock" && has_dock && query_param(path, "token").is_some() {
+            dock_set_cookie = format!(
+                "Set-Cookie: ic_dock={}; HttpOnly; SameSite=Strict; Path=/{}\r\n",
+                dock_token,
+                secure_flag(head_str)
+            );
+        }
+    }
+
+    // Auth management (cookie-bearing responses). Reached only after the gate
+    // above (these classify as admin, so session-gated when auth is on); open
+    // when auth is off so the very first password can be set locally.
+    if method == "POST" && bare_path == "/auth/set-password" {
+        // Bootstrapping the FIRST password is the one admin action reachable
+        // without a session (there is no session to require yet), so restrict
+        // that single case to loopback. On a bind-all box this stops a LAN peer
+        // from seizing the dashboard before the owner sets a password; changing
+        // an existing password already required an admin session at the gate.
+        let first_time = settings.borrow().dashboard_password_hash.is_empty();
+        if first_time && !is_loopback(peer_ip) {
+            write_simple(
+                sock,
+                "403 Forbidden",
+                "application/json",
+                r#"{"ok":false,"error":"the first password must be set from the local machine"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
+        let pw = crate::config::parse_form(body)
+            .get("password")
+            .cloned()
+            .unwrap_or_default();
+        // Enforce a minimum server-side, not just in the UI, so a short
+        // password can't be set via a direct API call.
+        if pw.chars().count() < 8 {
+            write_simple(
+                sock,
+                "400 Bad Request",
+                "application/json",
+                r#"{"ok":false,"error":"password must be at least 8 characters"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
+        let hash = tokio::task::spawn_blocking(move || crate::crypto::hash_password(&pw))
+            .await
+            .unwrap_or_default();
+        if hash.is_empty() {
+            write_simple(
+                sock,
+                "500 Internal Server Error",
+                "application/json",
+                r#"{"ok":false,"error":"hashing failed"}"#,
+                "",
+            )
+            .await?;
+            return Ok(AuthDecision::Handled);
+        }
+        {
+            let _wl = settings_write_guard();
+            let mut ns = settings.borrow().clone();
+            ns.dashboard_password_hash = hash;
+            if ns.dock_token.is_empty() {
+                ns.dock_token = crate::crypto::random_token();
+            }
+            let _ = ns.save(cfg_path);
+            let _ = settings.send(ns);
+        }
+        // Every prior session dies; issue a fresh one for whoever set it.
+        auth.revoke_all();
+        let token = auth.create_session();
+        let set = format!(
+            "Set-Cookie: ic_session={}; HttpOnly; SameSite=Strict; Path=/{}\r\n",
+            token,
+            secure_flag(head_str)
+        );
+        write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, &set).await?;
+        return Ok(AuthDecision::Handled);
+    }
+    if method == "POST" && bare_path == "/auth/disable" {
+        {
+            let _wl = settings_write_guard();
+            let mut ns = settings.borrow().clone();
+            ns.dashboard_password_hash.clear();
+            ns.dock_token.clear();
+            let _ = ns.save(cfg_path);
+            let _ = settings.send(ns);
+        }
+        auth.revoke_all();
+        let clear = "Set-Cookie: ic_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0\r\n";
+        write_simple(sock, "200 OK", "application/json", r#"{"ok":true}"#, clear).await?;
+        return Ok(AuthDecision::Handled);
+    }
+    if method == "POST" && bare_path == "/auth/regen-dock" {
+        let new_token;
+        {
+            let _wl = settings_write_guard();
+            let mut ns = settings.borrow().clone();
+            ns.dock_token = crate::crypto::random_token();
+            new_token = ns.dock_token.clone();
+            let _ = ns.save(cfg_path);
+            let _ = settings.send(ns);
+        }
+        let msg = format!(r#"{{"ok":true,"dock_token":"{}"}}"#, new_token);
+        write_simple(sock, "200 OK", "application/json", &msg, "").await?;
+        return Ok(AuthDecision::Handled);
+    }
+
+    Ok(AuthDecision::Allow(dock_set_cookie))
 }
 
 async fn route(
@@ -454,7 +759,7 @@ async fn route(
         },
         ("POST", "/obs/launch-with-eb") => {
             let s = settings.borrow();
-            match crate::obs_register::launch_obs_with_eb_config(s.web_port) {
+            match crate::obs_register::launch_obs_with_eb_config(s.web_port, &s.dock_token) {
                 Ok(exe) => {
                     ctrl.log(format!(
                         "obs-eb-launch: spawned {} with --config-url",
@@ -489,7 +794,10 @@ async fn route(
             // step (e.g. OBS still open, so the flag write is blocked) is
             // surfaced with its own message instead of failing the whole
             // operation silently.
-            let web_port = settings.borrow().web_port;
+            let (web_port, dock_token) = {
+                let s = settings.borrow();
+                (s.web_port, s.dock_token.clone())
+            };
             let (flag_ok, flag_msg) = match crate::obs_register::set_vod_audio_flag(true) {
                 Ok(true) => (true, "VOD-track flag written to OBS config".to_string()),
                 Ok(false) => (
@@ -502,7 +810,7 @@ async fn route(
                 ),
             };
             let (launch_ok, launch_msg) =
-                match crate::obs_register::launch_obs_with_eb_config(web_port) {
+                match crate::obs_register::launch_obs_with_eb_config(web_port, &dock_token) {
                     Ok(exe) => {
                         ctrl.log("[vod-eb setup] launched OBS with --config-url");
                         (true, format!("OBS launched ({})", exe.display()))
@@ -613,19 +921,10 @@ async fn route(
                 ),
             }
         }
-        ("POST", "/app/restart") => {
-            // Relaunch from a detached thread so this 200 flushes first; the
-            // dashboard then polls /config and reloads when we're back.
-            std::thread::spawn(|| {
-                std::thread::sleep(std::time::Duration::from_millis(600));
-                crate::self_update::restart_now();
-            });
-            (
-                "200 OK",
-                "application/json",
-                r#"{"ok":true,"restarting":true}"#.to_string(),
-            )
-        }
+        // POST /app/restart and /app/quit are handled in `serve` (they must
+        // flush their 200 before the shutdown signal exits the process), so
+        // they never reach the router.
+
         // Reveal one of our known files in the OS file browser. The keyword
         // is fixed (not a client-supplied path), so this can only ever open
         // our own buffer / overlays / trace - never an arbitrary location.
@@ -907,7 +1206,7 @@ fn state_json(
         crate::h264::detect_vertical_primary_track(&ctrl.ring.video_seq_headers.lock()).is_some();
 
     format!(
-        r#"{{"phase":"{ph}","armed_delay_ms":{ad},"target_delay_ms":{td},"current_delay_ms":{cd},"buffer_fill_ms":{bf},"buffer_target_ms":{btm},"buffer_capacity_ms_est":{bc},"ingest_alive":{ia},"egress_alive":{ea},"destinations_alive":{dla},"destinations_total":{dlt},"buffer_building":{bb},"configured":{cfg},"obs_url":"{ou}","webhook_set":{ws},"video_codec":"{vc}","audio_codec":"{ac}","multitrack_video":{mtv},"multitrack_audio":{mta},"vertical_present":{vp},"cpu_pct":{cp:.2},"rss_bytes":{rb},"publisher_token":{pt},"consumer_lag":{cl},"backpressure":{bp},"safe_cut_pending":{scp},"safe_cut_remaining_ms":{scr},"compat_warning":{cw},"stats":{{"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"ingest_disconnects":{id},"egress_reconnects":{er},"bitrate_kbps":{br}}},"destinations":[{dl}]}}"#,
+        r#"{{"phase":"{ph}","armed_delay_ms":{ad},"target_delay_ms":{td},"current_delay_ms":{cd},"buffer_fill_ms":{bf},"buffer_target_ms":{btm},"buffer_capacity_ms_est":{bc},"ingest_alive":{ia},"egress_alive":{ea},"destinations_alive":{dla},"destinations_total":{dlt},"buffer_building":{bb},"configured":{cfg},"obs_url":"{ou}","webhook_set":{ws},"video_codec":"{vc}","audio_codec":"{ac}","multitrack_video":{mtv},"multitrack_audio":{mta},"vertical_present":{vp},"cpu_pct":{cp:.2},"rss_bytes":{rb},"uptime_secs":{up},"publisher_token":{pt},"consumer_lag":{cl},"backpressure":{bp},"safe_cut_pending":{scp},"safe_cut_remaining_ms":{scr},"compat_warning":{cw},"stats":{{"tags_sent":{ts},"bytes_sent":{bs},"cuts":{cu},"ingest_disconnects":{id},"egress_reconnects":{er},"bitrate_kbps":{br}}},"destinations":[{dl}]}}"#,
         ph = ctrl.phase(),
         scp = ctrl.safe_cut_pending(),
         scr = ctrl.safe_cut_remaining_ms(),
@@ -939,6 +1238,7 @@ fn state_json(
         vp = vertical_present,
         cp = cpu_pct,
         rb = rss_bytes,
+        up = ctrl.uptime_secs(),
         pt = ctrl.publisher_token(),
         cl = consumer_lag,
         bp = backpressure,
@@ -1665,6 +1965,7 @@ async fn post_config(
             k.as_str(),
             "ingest_port"
                 | "ingest_bind_all"
+                | "ingest_key"
                 | "web_port"
                 | "web_bind_all"
                 | "buffer_mb"
@@ -2766,9 +3067,13 @@ fn reveal_path(path: &Path) {
     {
         let _ = std::process::Command::new("explorer").arg(&dir).spawn();
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
     {
-        let _ = &dir;
+        let _ = std::process::Command::new("open").arg(&dir).spawn();
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(&dir).spawn();
     }
 }
 
@@ -3244,6 +3549,185 @@ fn strip_prefix_icase<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
 fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
     hay.windows(needle.len()).position(|w| w == needle)
 }
+
+// ---- Optional dashboard auth: request classification + helpers -----------
+
+/// Access level a route requires WHEN auth is enabled. The default is `Admin`,
+/// so any route not explicitly listed below is protected (fail closed): a new
+/// endpoint is locked down unless someone deliberately opens it here.
+enum Access {
+    /// No auth: the login page and overlay DISPLAY (OBS browser sources).
+    Public,
+    /// Session cookie OR the least-privilege dock token: status, delay
+    /// control, and the dock itself. Never anything that reveals a secret.
+    Control,
+    /// Session cookie only: everything that changes config, destinations,
+    /// files, or the app lifecycle, or that could disclose a stream key.
+    Admin,
+}
+
+fn classify_access(method: &str, path: &str) -> Access {
+    if path == "/login" {
+        return Access::Public;
+    }
+    // Overlay DISPLAY only (browser sources can't log in); saving overlays is
+    // a POST to /overlays/ which stays Admin.
+    if path == "/overlay" || path.starts_with("/overlay/") {
+        return Access::Public;
+    }
+    match (method, path) {
+        ("GET", "/state")
+        | ("GET", "/events")
+        | ("GET", "/dock")
+        | ("GET", "/dock.js")
+        | ("GET", "/docks")
+        | ("GET", "/profiles")
+        | ("GET", "/platforms")
+        // OBS itself hits this (no session cookie); it authenticates with the
+        // dock token embedded in the --config-url we hand it. Control-only:
+        // it returns the EB ladder config, never a secret.
+        | ("GET", "/obs/multitrack-config")
+        | ("POST", "/obs/multitrack-config")
+        | ("POST", "/arm")
+        | ("POST", "/activate")
+        | ("POST", "/stop")
+        | ("POST", "/disarm")
+        | ("POST", "/delay")
+        | ("POST", "/go-live")
+        | ("POST", "/cut-after")
+        | ("POST", "/cut-after/cancel") => Access::Control,
+        ("POST", p) if p.starts_with("/docks/") => Access::Control,
+        _ => Access::Admin,
+    }
+}
+
+/// Parse the Cookie header into name -> value (`a=b; c=d`).
+fn parse_cookies(head: &str) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    for line in head.split("\r\n") {
+        if let Some(v) = strip_prefix_icase(line, "cookie:") {
+            for pair in v.split(';') {
+                if let Some((k, val)) = pair.split_once('=') {
+                    out.insert(k.trim().to_string(), val.trim().to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// First value of query parameter `name` in a `path?a=b&c=d` string. Tokens
+/// are hex, so no URL-decoding is needed.
+fn query_param(path: &str, name: &str) -> Option<String> {
+    let q = path.split_once('?')?.1;
+    for pair in q.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == name {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// "; Secure" when the request reached us over HTTPS (a reverse proxy sets
+/// `X-Forwarded-Proto: https`), so the auth cookie is never sent in the clear
+/// once TLS is in front. Empty over plain HTTP so local use still works.
+///
+/// This trusts the header, which is correct because it is fail-safe in the only
+/// two ways that matter: a spoofed `https` from a direct plain-HTTP client only
+/// makes the cookie MORE restrictive (a `Secure` cookie the browser then won't
+/// resend over that same plain connection), and a proxy that omits the header
+/// over real TLS merely drops `Secure` (the cookie still works, just without
+/// that one hardening bit). Neither weakens auth; the documented deployment is
+/// a proxy that sets the header.
+fn secure_flag(head: &str) -> &'static str {
+    for line in head.split("\r\n") {
+        if let Some(v) = strip_prefix_icase(line, "x-forwarded-proto:") {
+            if v.trim().eq_ignore_ascii_case("https") {
+                return "; Secure";
+            }
+        }
+    }
+    ""
+}
+
+/// True when the client prefers HTML (a browser navigation), so an
+/// unauthorized response should redirect to the login page rather than 401.
+fn wants_html(head: &str) -> bool {
+    for line in head.split("\r\n") {
+        if let Some(v) = strip_prefix_icase(line, "accept:") {
+            return v.contains("text/html");
+        }
+    }
+    false
+}
+
+/// Write a small response with an optional extra header block (Set-Cookie).
+/// True if `ip` (a peer address string like "127.0.0.1" or "::1") is an
+/// IPv4/IPv6 loopback address. Used to keep first-time password bootstrap on
+/// the local machine. An unparseable value is treated as non-loopback so the
+/// restriction fails closed.
+fn is_loopback(ip: &str) -> bool {
+    ip.parse::<std::net::IpAddr>()
+        .map(|a| a.is_loopback())
+        .unwrap_or(false)
+}
+
+async fn write_simple(
+    sock: &mut TcpStream,
+    status: &str,
+    ctype: &str,
+    body: &str,
+    extra_headers: &str,
+) -> io::Result<()> {
+    let resp = format!(
+        "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\n{}Cache-Control: no-store\r\nConnection: close\r\n\r\n{}",
+        status, ctype, body.len(), extra_headers, body
+    );
+    sock.write_all(resp.as_bytes()).await
+}
+
+/// Self-contained login page (no external assets, so it renders before any
+/// authenticated request). Served at GET /login only when auth is enabled.
+const LOGIN_HTML: &str = r##"<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>InstantClone - Sign in</title>
+<style>
+:root{color-scheme:dark}
+body{margin:0;height:100vh;display:flex;align-items:center;justify-content:center;background:#07080a;color:#e8edf3;font:15px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+.card{width:320px;max-width:88vw;background:#11141a;border:1px solid #1f242d;border-radius:14px;padding:26px}
+h1{margin:0 0 4px;font-size:18px}
+p{margin:0 0 18px;color:#8b95a3;font-size:13px}
+input{width:100%;box-sizing:border-box;padding:11px 12px;border-radius:9px;border:1px solid #2a313c;background:#0c0e12;color:#e8edf3;font-size:14px}
+input:focus{outline:none;border-color:#5ac8fa}
+button{width:100%;margin-top:12px;padding:11px;border:0;border-radius:9px;background:#5ac8fa;color:#04121a;font-weight:700;font-size:14px;cursor:pointer}
+button:disabled{opacity:.6;cursor:default}
+.err{margin-top:12px;color:#ff6b6b;font-size:13px;min-height:1.2em}
+.dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:#5ac8fa;margin-right:8px}
+</style></head><body>
+<form class="card" onsubmit="return signIn(event)">
+<h1><span class="dot"></span>InstantClone</h1>
+<p>Enter the dashboard password to continue.</p>
+<input id="pw" type="password" placeholder="Password" autocomplete="current-password" autofocus>
+<button id="btn" type="submit">Sign in</button>
+<div class="err" id="err"></div>
+</form>
+<script>
+async function signIn(e){
+  e.preventDefault();
+  var btn=document.getElementById('btn'),err=document.getElementById('err');
+  btn.disabled=true;btn.textContent='Signing in...';err.textContent='';
+  try{
+    var r=await fetch('/login',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'password='+encodeURIComponent(document.getElementById('pw').value)});
+    if(r.ok){location.href='/';return false;}
+    var j=await r.json().catch(function(){return {};});
+    err.textContent=(j&&j.error)?j.error:'Sign in failed';
+  }catch(_){err.textContent='Network error';}
+  btn.disabled=false;btn.textContent='Sign in';
+  return false;
+}
+</script></body></html>"##;
 
 fn json_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());

--- a/src/web.rs
+++ b/src/web.rs
@@ -1532,14 +1532,18 @@ async fn obs_multitrack_config_proxy(
     // Twitch's response has one or more `ingest_endpoints` entries
     // with `url_template` values like
     // `rtmps://<region>.contribute.live-video.net/app/{stream_key}`.
-    // Replace every rtmp:// or rtmps:// URL in url_template fields
-    // with our localhost ingest so OBS sends the multi-track stream
-    // to us instead. We keep `{stream_key}` as the literal token -
-    // OBS substitutes it with whatever's in its Stream Key field
-    // (which the streamer can type as anything; we ignore it).
+    // Replace every rtmp:// or rtmps:// URL in url_template fields with our
+    // localhost ingest so OBS sends the multi-track stream to us instead. The
+    // path segment carries our ingest key when one is set (so EB publishes with
+    // the key begin_publish enforces); otherwise it stays the `{stream_key}`
+    // token OBS fills from its Stream Key field (any key accepted).
     let rewritten = rewrite_url_templates(
         &twitch_json,
-        &format!("rtmp://127.0.0.1:{}/live/{{stream_key}}", ingest_port),
+        &format!(
+            "rtmp://127.0.0.1:{}/live/{}",
+            ingest_port,
+            multitrack_ingest_segment(settings)
+        ),
     );
     // Extract the *original* IVS ingest URL from Twitch's response
     // BEFORE rewriting it to localhost, substitute the streamer's real
@@ -1835,6 +1839,26 @@ fn rewrite_url_templates(json: &str, new_value: &str) -> String {
     out
 }
 
+/// The path segment OBS publishes to in the multitrack (Enhanced Broadcasting)
+/// config we hand it. With an ingest key set we embed it so OBS publishes with
+/// the exact key `Controller::begin_publish` enforces - otherwise EB would send
+/// its own session key and get rejected. Without a key (or with a key that
+/// isn't URL/JSON-safe, which a stray character could use to corrupt the config
+/// OBS parses) we leave the `{stream_key}` token for OBS to fill; generated
+/// keys are hex, so the safe path is the normal path.
+fn multitrack_ingest_segment(settings: &Arc<watch::Sender<Settings>>) -> String {
+    let key = settings.borrow().ingest_key.clone();
+    let safe = !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if safe {
+        key
+    } else {
+        "{stream_key}".to_string()
+    }
+}
+
 fn obs_multitrack_config_static(query: &str, settings: &Arc<watch::Sender<Settings>>) -> String {
     let params = config::parse_form(query);
     let encoder = params.get("encoder").map(|s| s.as_str()).unwrap_or("x264");
@@ -1929,9 +1953,10 @@ fn obs_multitrack_config_static(query: &str, settings: &Arc<watch::Sender<Settin
     }
 
     format!(
-        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://127.0.0.1:{port}/live/{{stream_key}}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
+        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://127.0.0.1:{port}/live/{seg}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
         cid = config_id,
         port = ingest_port,
+        seg = multitrack_ingest_segment(settings),
         encs = enc_configs,
     )
 }
@@ -4683,6 +4708,31 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("ic-overlay-test-{tag}-{nanos}"));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn multitrack_config_embeds_ingest_key_when_set() {
+        // No key: OBS keeps the {stream_key} token, so any key is accepted.
+        let mut s = crate::config::Settings::defaults();
+        s.ingest_port = 1935;
+        let (tx, _rx) = watch::channel(s.clone());
+        let open = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx));
+        assert!(open.contains("/live/{stream_key}"));
+
+        // Safe key: embedded directly so Enhanced Broadcasting publishes with
+        // exactly the key begin_publish enforces (no more "wrong stream key").
+        s.ingest_key = "abc123def".into();
+        let (tx2, _rx2) = watch::channel(s.clone());
+        let locked = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx2));
+        assert!(locked.contains("/live/abc123def"));
+        assert!(!locked.contains("{stream_key}"));
+
+        // Unsafe key (a stray quote could corrupt the config JSON): fall back
+        // to the token rather than emit a malformed config.
+        s.ingest_key = "bad key\"".into();
+        let (tx3, _rx3) = watch::channel(s);
+        let fb = obs_multitrack_config_static("encoder=x264&tracks=1", &Arc::new(tx3));
+        assert!(fb.contains("/live/{stream_key}"));
     }
 
     #[test]

--- a/web/index.html
+++ b/web/index.html
@@ -810,6 +810,10 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
 @media (max-width:680px){.sys-about-grid{grid-template-columns:1fr}}
 .sys-about-card{background:var(--surface-2);border:1px solid var(--line);border-radius:10px;padding:14px}
 .sys-about-card .ic-label{margin-bottom:4px}
+/* One input that grows + its action buttons, on a single line (wrapping only
+   when the row gets genuinely narrow). Used by the Security controls. */
+.sec-row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.sec-row .ic-input{flex:1 1 180px;min-width:0}
 .sys-version-row{display:flex;align-items:center;gap:10px;margin-top:8px;flex-wrap:wrap}
 .sys-version-num{font-family:var(--mono);font-size:13px;color:var(--fg);font-weight:600}
 .sys-version-pill{display:inline-flex;align-items:center;gap:6px;padding:2px 8px;border-radius:99px;
@@ -2663,10 +2667,10 @@ details.sys-collapse>summary .ic-label{margin:0}
         <span class="muted" id="ingest-status-note" style="font-size:12.5px">Any stream key is accepted</span>
       </div>
       <div class="tab-sub" style="margin-top:8px">Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
-      <div class="row" style="gap:8px;align-items:center;margin-top:12px">
-        <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:160px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
-        <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="genIngestKey()">Generate</button>
-        <button class="ic-btn ic-btn-primary" style="flex:0 0 auto" onclick="saveIngestKey(this)">Save key</button>
+      <div class="sec-row" style="margin-top:12px">
+        <input id="s-ingest-key" class="ic-input mono" placeholder="blank = accept any key" aria-label="Ingest key" autocomplete="off" spellcheck="false">
+        <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
+        <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
       </div>
       <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:8px"></div>
     </section>
@@ -2680,18 +2684,18 @@ details.sys-collapse>summary .ic-label{margin:0}
 
       <div id="sec-off" style="margin-top:14px">
         <div class="ic-label">New password</div>
-        <div class="row" style="gap:8px;align-items:center;margin-top:6px">
-          <input id="sec-pw" type="password" class="ic-input" style="flex:1;min-width:160px" placeholder="at least 8 characters" autocomplete="new-password" spellcheck="false">
-          <button class="ic-btn ic-btn-primary" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw')">Enable</button>
+        <div class="sec-row" style="margin-top:6px">
+          <input id="sec-pw" type="password" class="ic-input" placeholder="at least 8 characters" aria-label="New dashboard password" autocomplete="new-password" spellcheck="false">
+          <button class="ic-btn ic-btn-primary" onclick="enableAuth(this,'sec-pw')">Enable</button>
         </div>
         <div class="muted" id="sec-off-msg" style="font-size:11.5px;margin-top:8px"></div>
       </div>
 
       <div id="sec-on" hidden style="margin-top:14px">
         <div class="ic-label">Change password</div>
-        <div class="row" style="gap:8px;align-items:center;margin-top:6px">
-          <input id="sec-pw2" type="password" class="ic-input" style="flex:1;min-width:160px" placeholder="new password" autocomplete="new-password" spellcheck="false">
-          <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw2')">Update</button>
+        <div class="sec-row" style="margin-top:6px">
+          <input id="sec-pw2" type="password" class="ic-input" placeholder="new password" aria-label="Change dashboard password" autocomplete="new-password" spellcheck="false">
+          <button class="ic-btn ic-btn-ghost" onclick="enableAuth(this,'sec-pw2')">Update</button>
         </div>
 
         <div class="sys-about-card" style="margin-top:14px">
@@ -2702,12 +2706,12 @@ details.sys-collapse>summary .ic-label{margin:0}
             <button class="ic-btn ic-btn-ghost" id="sec-dock-toggle" onclick="toggleSecret('sec-dock-url',this)">Show</button>
             <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'sec-dock-url','Dock URL')">Copy</button>
           </div>
-          <div class="row" style="margin-top:10px">
+          <div class="sec-row" style="margin-top:10px">
             <button class="ic-btn ic-btn-ghost" onclick="regenDock(this)">Regenerate</button>
           </div>
         </div>
 
-        <div class="row" style="gap:8px;align-items:center;margin-top:14px">
+        <div class="sec-row" style="margin-top:14px">
           <button class="ic-btn ic-btn-ghost" onclick="logoutNow()">Log out</button>
           <button class="ic-btn ic-btn-warn" onclick="disableAuth(this)">Turn off password</button>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -829,6 +829,11 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
    or screen-share; the Show button reveals on demand. Copy still works blurred. */
 .blur-secret{filter:blur(6px);transition:filter .1s ease;user-select:none}
 .blur-secret.revealed{filter:none;user-select:text}
+/* A blurred secret INPUT stays editable: unblur while focused (so typing is
+   never blurred) and while empty (so the placeholder is readable). It only
+   blurs a saved value sitting idle on screen. */
+.ic-input.blur-secret:focus,
+.ic-input.blur-secret:placeholder-shown{filter:none;user-select:text}
 /* Live system-info tiles in the About tab. Hairline-separated grid. */
 .sysinfo{display:grid;grid-template-columns:repeat(auto-fit,minmax(148px,1fr));gap:1px;margin-top:16px;
   background:var(--line);border:1px solid var(--line);border-radius:10px;overflow:hidden}
@@ -2668,7 +2673,8 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
       <div class="tab-sub" style="margin-top:8px">Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
       <div class="sec-row" style="margin-top:12px">
-        <input id="s-ingest-key" class="ic-input mono" placeholder="blank = accept any key" aria-label="Ingest key" autocomplete="off" spellcheck="false">
+        <input id="s-ingest-key" class="ic-input mono blur-secret" placeholder="blank = accept any key" aria-label="Ingest key" autocomplete="off" spellcheck="false">
+        <button class="ic-btn ic-btn-ghost" id="ingest-key-toggle" onclick="toggleSecret('s-ingest-key',this)">Show</button>
         <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
         <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
       </div>
@@ -5289,7 +5295,13 @@ function genIngestKey(){
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
   const inp = $('s-ingest-key');
-  if (inp) inp.value = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+  if (inp){
+    inp.value = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+    // Reveal the freshly generated key so it can be read and copied; it
+    // re-blurs on its own once focus leaves the field.
+    inp.classList.add('revealed');
+    const t = $('ingest-key-toggle'); if (t) t.textContent = 'Hide';
+  }
 }
 
 async function saveIngestKey(btn){

--- a/web/index.html
+++ b/web/index.html
@@ -2296,18 +2296,7 @@ details.sys-collapse>summary .ic-label{margin:0}
             <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'obs-key','Stream key')">Copy</button>
           </div>
           <div class="tab-sub" id="obs-key-note" style="margin-top:6px">Any string works. The real platform key lives in <b>Destinations</b>.</div>
-          <details class="ic-disclose" style="margin-top:8px">
-            <summary>Require a key (lock the ingest)</summary>
-            <div class="ic-disclose-body">
-              <p style="margin:0 0 8px">Set a secret here and only OBS using it can publish. Worth doing when the ingest is reachable over a network. Leave blank to accept any key.</p>
-              <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-                <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:180px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
-                <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
-                <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
-              </div>
-              <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:6px"></div>
-            </div>
-          </details>
+          <div class="tab-sub" style="margin-top:8px">Want only OBS with a secret to publish? Set an <b>ingest key</b> in <a href="#" onclick="goNetworkSettings();return false">System &rarr; Network</a>; it becomes the Stream key here.</div>
         </div>
       </div>
     </section>
@@ -2665,6 +2654,16 @@ details.sys-collapse>summary .ic-label{margin:0}
         <span class="lw-ic" aria-hidden="true">⚠</span>
         <span id="lan-warn-text"></span>
       </div>
+    </section>
+    <section class="sys-section">
+      <div class="ic-label">Ingest key</div>
+      <div class="tab-sub">Off by default. Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
+      <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:12px">
+        <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:180px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
+        <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
+        <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
+      </div>
+      <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:6px"></div>
     </section>
     <section class="sys-section">
       <div class="ic-label">Dashboard password</div>
@@ -7054,6 +7053,10 @@ $$('.tab').forEach(t => t.addEventListener('click', () => showTab(t.dataset.tab)
 window.addEventListener('resize', moveTabInd);
 
 // - Sub-tabs (currently only the System pane uses these) -------
+// Jump straight to System -> Network (used by the "set an ingest key" pointer
+// on the OBS tab, now that the key control lives under Network settings).
+function goNetworkSettings(){ showTab('system'); showSubTab('system', 'network'); }
+
 function showSubTab(paneName, subName){
   const pane = document.querySelector(`.tab-pane[data-pane="${paneName}"]`);
   if (!pane) return;

--- a/web/index.html
+++ b/web/index.html
@@ -818,6 +818,7 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
 .sys-version-pill.new{background:color-mix(in oklch,var(--warn,#d6a23a) 18%,transparent);color:var(--warn,#d6a23a)}
 .sys-version-pill.ahead{background:color-mix(in oklch,#a18bff 18%,transparent);color:#a18bff}
 .sys-version-pill.err{background:color-mix(in oklch,var(--err) 14%,transparent);color:var(--err)}
+.sys-version-pill.off{background:color-mix(in oklch,var(--fg-3) 16%,transparent);color:var(--fg-3)}
 .sys-os-chip{display:inline-flex;align-items:center;padding:2px 9px;border-radius:99px;font-size:11px;
   font-weight:600;letter-spacing:.3px;background:var(--surface-3);color:var(--fg-2);border:1px solid var(--line)}
 /* Secrets (dock token URL) blurred by default so they can't leak on a stream
@@ -1095,7 +1096,6 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
 .ic-badge{display:inline-block;font-size:10px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;
   padding:2px 7px;border-radius:99px;margin-right:8px;vertical-align:1px}
 .ic-badge-ok{background:rgba(90,200,250,.18);color:#5ac8fa;border:1px solid rgba(90,200,250,.4)}
-.ic-badge-muted{background:rgba(139,149,163,.14);color:#8b95a3;border:1px solid var(--line)}
 .copy-block{display:flex;align-items:center;gap:10px;padding:9px 12px;background:var(--surface);
   border:1px solid var(--line);border-radius:8px;margin-top:10px}
 .copy-block code{flex:1;font-size:12.5px;color:var(--fg);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
@@ -2657,59 +2657,57 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
     </section>
     <section class="sys-section">
-      <div class="row" style="align-items:center;gap:8px;justify-content:space-between">
-        <div class="ic-label" style="margin:0">Ingest key</div>
-        <span id="ingest-status" class="ic-badge ic-badge-muted" style="margin:0">open</span>
+      <div class="ic-label">Ingest key</div>
+      <div class="sys-version-row">
+        <span class="sys-version-pill off" id="ingest-status">Open</span>
+        <span class="muted" id="ingest-status-note" style="font-size:12.5px">Any stream key is accepted</span>
       </div>
-      <div class="tab-sub" style="margin-top:6px">Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
-      <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:12px">
-        <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:180px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
-        <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
-        <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
+      <div class="tab-sub" style="margin-top:8px">Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
+      <div class="row" style="gap:8px;align-items:center;margin-top:12px">
+        <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:160px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
+        <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="genIngestKey()">Generate</button>
+        <button class="ic-btn ic-btn-primary" style="flex:0 0 auto" onclick="saveIngestKey(this)">Save key</button>
       </div>
-      <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:6px"></div>
+      <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:8px"></div>
     </section>
     <section class="sys-section">
-      <div class="row" style="align-items:center;gap:8px;justify-content:space-between">
-        <div class="ic-label" style="margin:0">Dashboard password</div>
-        <span id="pw-status" class="ic-badge ic-badge-muted" style="margin:0">off</span>
+      <div class="ic-label">Dashboard password</div>
+      <div class="sys-version-row">
+        <span class="sys-version-pill off" id="pw-status">Off</span>
+        <span class="muted" id="pw-status-note" style="font-size:12.5px">Local-only use needs none</span>
       </div>
-      <div class="tab-sub" style="margin-top:6px">When the web UI is open to a network, a password stops anyone who finds it from touching your stream. Local-only use needs none.</div>
+      <div class="tab-sub" style="margin-top:8px">When the web UI is open to a network, a password stops anyone who finds it from touching your stream.</div>
 
-      <div id="sec-off" style="margin-top:12px">
-        <div class="form-row tight" style="align-items:end">
-          <div style="flex:1;min-width:0">
-            <span class="ic-label">New password</span>
-            <input id="sec-pw" type="password" class="ic-input" placeholder="at least 8 characters" autocomplete="new-password" spellcheck="false">
-          </div>
+      <div id="sec-off" style="margin-top:14px">
+        <div class="ic-label">New password</div>
+        <div class="row" style="gap:8px;align-items:center;margin-top:6px">
+          <input id="sec-pw" type="password" class="ic-input" style="flex:1;min-width:160px" placeholder="at least 8 characters" autocomplete="new-password" spellcheck="false">
           <button class="ic-btn ic-btn-primary" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw')">Enable</button>
         </div>
-        <div class="muted" id="sec-off-msg" style="font-size:11.5px;margin-top:6px"></div>
+        <div class="muted" id="sec-off-msg" style="font-size:11.5px;margin-top:8px"></div>
       </div>
 
-      <div id="sec-on" hidden style="margin-top:12px">
-        <div class="muted" style="font-size:12px">The dashboard requires sign-in. Manage the password and dock access below.</div>
-
-        <div class="form-row tight" style="align-items:end;margin-top:12px">
-          <div style="flex:1;min-width:0">
-            <span class="ic-label">Change password</span>
-            <input id="sec-pw2" type="password" class="ic-input" placeholder="new password" autocomplete="new-password" spellcheck="false">
-          </div>
+      <div id="sec-on" hidden style="margin-top:14px">
+        <div class="ic-label">Change password</div>
+        <div class="row" style="gap:8px;align-items:center;margin-top:6px">
+          <input id="sec-pw2" type="password" class="ic-input" style="flex:1;min-width:160px" placeholder="new password" autocomplete="new-password" spellcheck="false">
           <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw2')">Update</button>
         </div>
 
-        <div class="ic-card" style="margin-top:14px;padding:14px">
-          <span class="ic-label">OBS dock URL</span>
-          <div class="tab-sub" style="margin-top:2px">The OBS dock can't sign in, so paste this token URL as its Custom Browser Dock. It runs the stream (delay, cut, destination on/off) but never reveals your keys or changes settings.</div>
-          <div class="copy-block" style="margin-top:6px">
+        <div class="sys-about-card" style="margin-top:14px">
+          <div class="ic-label">OBS dock URL</div>
+          <div class="tab-sub" style="margin-top:4px">The OBS dock can't sign in, so paste this token URL as its Custom Browser Dock. It runs the stream (delay, cut, destination on/off) but never reveals your keys or changes settings.</div>
+          <div class="copy-block" style="margin-top:8px">
             <code class="mono blur-secret" id="sec-dock-url" style="overflow-x:auto;white-space:nowrap;min-width:0" title="Hidden to prevent leaks on stream. Use Show to reveal."></code>
             <button class="ic-btn ic-btn-ghost" id="sec-dock-toggle" onclick="toggleSecret('sec-dock-url',this)">Show</button>
             <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'sec-dock-url','Dock URL')">Copy</button>
           </div>
-          <button class="ic-btn ic-btn-ghost" style="margin-top:10px" onclick="regenDock(this)">Regenerate</button>
+          <div class="row" style="margin-top:10px">
+            <button class="ic-btn ic-btn-ghost" onclick="regenDock(this)">Regenerate</button>
+          </div>
         </div>
 
-        <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:16px">
+        <div class="row" style="gap:8px;align-items:center;margin-top:14px">
           <button class="ic-btn ic-btn-ghost" onclick="logoutNow()">Log out</button>
           <button class="ic-btn ic-btn-warn" onclick="disableAuth(this)">Turn off password</button>
         </div>
@@ -5180,9 +5178,11 @@ function applyAuthState(enabled, dockToken){
   if ($('sec-on')) $('sec-on').hidden = !_authEnabled;
   const st = $('pw-status');
   if (st){
-    st.textContent = _authEnabled ? 'on' : 'off';
-    st.className = 'ic-badge ' + (_authEnabled ? 'ic-badge-ok' : 'ic-badge-muted');
+    st.textContent = _authEnabled ? 'On' : 'Off';
+    st.className = 'sys-version-pill ' + (_authEnabled ? 'ok' : 'off');
   }
+  const stn = $('pw-status-note');
+  if (stn) stn.textContent = _authEnabled ? 'Sign-in required' : 'Local-only use needs none';
   const url = $('sec-dock-url');
   if (url){
     url.textContent = dockToken ? (location.origin + '/dock?token=' + dockToken) : '';
@@ -5273,9 +5273,11 @@ function applyIngestKey(key){
     : 'Any string works. The real platform key lives in <b>Destinations</b>.';
   const st = $('ingest-status');
   if (st){
-    st.textContent = key ? 'locked' : 'open';
-    st.className = 'ic-badge ' + (key ? 'ic-badge-ok' : 'ic-badge-muted');
+    st.textContent = key ? 'Locked' : 'Open';
+    st.className = 'sys-version-pill ' + (key ? 'ok' : 'off');
   }
+  const stn = $('ingest-status-note');
+  if (stn) stn.textContent = key ? 'Only OBS with your key can publish' : 'Any stream key is accepted';
   renderLanWarning();
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1095,6 +1095,7 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
 .ic-badge{display:inline-block;font-size:10px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;
   padding:2px 7px;border-radius:99px;margin-right:8px;vertical-align:1px}
 .ic-badge-ok{background:rgba(90,200,250,.18);color:#5ac8fa;border:1px solid rgba(90,200,250,.4)}
+.ic-badge-muted{background:rgba(139,149,163,.14);color:#8b95a3;border:1px solid var(--line)}
 .copy-block{display:flex;align-items:center;gap:10px;padding:9px 12px;background:var(--surface);
   border:1px solid var(--line);border-radius:8px;margin-top:10px}
 .copy-block code{flex:1;font-size:12.5px;color:var(--fg);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
@@ -2656,8 +2657,11 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
     </section>
     <section class="sys-section">
-      <div class="ic-label">Ingest key</div>
-      <div class="tab-sub">Off by default. Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
+      <div class="row" style="align-items:center;gap:8px;justify-content:space-between">
+        <div class="ic-label" style="margin:0">Ingest key</div>
+        <span id="ingest-status" class="ic-badge ic-badge-muted" style="margin:0">open</span>
+      </div>
+      <div class="tab-sub" style="margin-top:6px">Set a secret and only OBS publishing with it can connect - worth doing whenever the ingest port is reachable over a network. It becomes the Stream key you paste into OBS. Leave blank to accept any key.</div>
       <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:12px">
         <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:180px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
         <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
@@ -2666,8 +2670,11 @@ details.sys-collapse>summary .ic-label{margin:0}
       <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:6px"></div>
     </section>
     <section class="sys-section">
-      <div class="ic-label">Dashboard password</div>
-      <div class="tab-sub">Off by default. When the web UI is open to a network, a password stops anyone who finds it from touching your stream. Local-only use needs none.</div>
+      <div class="row" style="align-items:center;gap:8px;justify-content:space-between">
+        <div class="ic-label" style="margin:0">Dashboard password</div>
+        <span id="pw-status" class="ic-badge ic-badge-muted" style="margin:0">off</span>
+      </div>
+      <div class="tab-sub" style="margin-top:6px">When the web UI is open to a network, a password stops anyone who finds it from touching your stream. Local-only use needs none.</div>
 
       <div id="sec-off" style="margin-top:12px">
         <div class="form-row tight" style="align-items:end">
@@ -2681,10 +2688,7 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
 
       <div id="sec-on" hidden style="margin-top:12px">
-        <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-          <span class="ic-badge ic-badge-ok">password on</span>
-          <span class="muted" style="font-size:12px">The dashboard requires sign-in.</span>
-        </div>
+        <div class="muted" style="font-size:12px">The dashboard requires sign-in. Manage the password and dock access below.</div>
 
         <div class="form-row tight" style="align-items:end;margin-top:12px">
           <div style="flex:1;min-width:0">
@@ -2694,15 +2698,15 @@ details.sys-collapse>summary .ic-label{margin:0}
           <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw2')">Update</button>
         </div>
 
-        <div style="margin-top:14px">
+        <div class="ic-card" style="margin-top:14px;padding:14px">
           <span class="ic-label">OBS dock URL</span>
-          <div class="tab-sub" style="margin-top:2px">The OBS dock can't sign in, so paste this token URL as its Custom Browser Dock. It controls the delay only, never settings or keys.</div>
+          <div class="tab-sub" style="margin-top:2px">The OBS dock can't sign in, so paste this token URL as its Custom Browser Dock. It runs the stream (delay, cut, destination on/off) but never reveals your keys or changes settings.</div>
           <div class="copy-block" style="margin-top:6px">
             <code class="mono blur-secret" id="sec-dock-url" style="overflow-x:auto;white-space:nowrap;min-width:0" title="Hidden to prevent leaks on stream. Use Show to reveal."></code>
             <button class="ic-btn ic-btn-ghost" id="sec-dock-toggle" onclick="toggleSecret('sec-dock-url',this)">Show</button>
             <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'sec-dock-url','Dock URL')">Copy</button>
           </div>
-          <button class="ic-btn ic-btn-ghost" style="margin-top:8px" onclick="regenDock(this)">Regenerate</button>
+          <button class="ic-btn ic-btn-ghost" style="margin-top:10px" onclick="regenDock(this)">Regenerate</button>
         </div>
 
         <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:16px">
@@ -5174,6 +5178,11 @@ function applyAuthState(enabled, dockToken){
   _authEnabled = !!enabled;
   if ($('sec-off')) $('sec-off').hidden = _authEnabled;
   if ($('sec-on')) $('sec-on').hidden = !_authEnabled;
+  const st = $('pw-status');
+  if (st){
+    st.textContent = _authEnabled ? 'on' : 'off';
+    st.className = 'ic-badge ' + (_authEnabled ? 'ic-badge-ok' : 'ic-badge-muted');
+  }
   const url = $('sec-dock-url');
   if (url){
     url.textContent = dockToken ? (location.origin + '/dock?token=' + dockToken) : '';
@@ -5262,6 +5271,11 @@ function applyIngestKey(key){
   if (note) note.innerHTML = key
     ? 'The ingest is locked. OBS must use <b>this exact key</b> to publish.'
     : 'Any string works. The real platform key lives in <b>Destinations</b>.';
+  const st = $('ingest-status');
+  if (st){
+    st.textContent = key ? 'locked' : 'open';
+    st.className = 'ic-badge ' + (key ? 'ic-badge-ok' : 'ic-badge-muted');
+  }
   renderLanWarning();
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -818,6 +818,19 @@ h1,h2,h3,.tab-title,.st-head-title,.wiz-step-t{text-wrap:balance}
 .sys-version-pill.new{background:color-mix(in oklch,var(--warn,#d6a23a) 18%,transparent);color:var(--warn,#d6a23a)}
 .sys-version-pill.ahead{background:color-mix(in oklch,#a18bff 18%,transparent);color:#a18bff}
 .sys-version-pill.err{background:color-mix(in oklch,var(--err) 14%,transparent);color:var(--err)}
+.sys-os-chip{display:inline-flex;align-items:center;padding:2px 9px;border-radius:99px;font-size:11px;
+  font-weight:600;letter-spacing:.3px;background:var(--surface-3);color:var(--fg-2);border:1px solid var(--line)}
+/* Secrets (dock token URL) blurred by default so they can't leak on a stream
+   or screen-share; the Show button reveals on demand. Copy still works blurred. */
+.blur-secret{filter:blur(6px);transition:filter .1s ease;user-select:none}
+.blur-secret.revealed{filter:none;user-select:text}
+/* Live system-info tiles in the About tab. Hairline-separated grid. */
+.sysinfo{display:grid;grid-template-columns:repeat(auto-fit,minmax(148px,1fr));gap:1px;margin-top:16px;
+  background:var(--line);border:1px solid var(--line);border-radius:10px;overflow:hidden}
+.sysinfo .si{background:var(--surface-2);padding:10px 12px;min-width:0}
+.sysinfo .si .k{display:block;font-size:10.5px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.5px}
+.sysinfo .si .v{display:block;font-size:14px;color:var(--fg);font-weight:600;margin-top:4px;
+  font-family:var(--mono);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 /* Version-aware requirement callout (VOD unlocker section). `.req` = a hard
    requirement (OBS 32.2+ must use the script), `.info` = softer guidance. */
 .sys-callout{margin-top:12px;padding:10px 13px;border-radius:9px;font-size:12.5px;
@@ -2279,10 +2292,22 @@ details.sys-collapse>summary .ic-label{margin:0}
         <div class="obs-manual-field">
           <div class="ic-label">Stream key</div>
           <div class="copy-block">
-            <code class="mono">main</code>
-            <button class="ic-btn ic-btn-ghost" onclick="copyText(this,'main','Stream key')">Copy</button>
+            <code class="mono" id="obs-key">main</code>
+            <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'obs-key','Stream key')">Copy</button>
           </div>
-          <div class="tab-sub" style="margin-top:6px">Any string works - the real platform key lives in <b>Destinations</b>.</div>
+          <div class="tab-sub" id="obs-key-note" style="margin-top:6px">Any string works. The real platform key lives in <b>Destinations</b>.</div>
+          <details class="ic-disclose" style="margin-top:8px">
+            <summary>Require a key (lock the ingest)</summary>
+            <div class="ic-disclose-body">
+              <p style="margin:0 0 8px">Set a secret here and only OBS using it can publish. Worth doing when the ingest is reachable over a network. Leave blank to accept any key.</p>
+              <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+                <input id="s-ingest-key" class="ic-input mono" style="flex:1;min-width:180px" placeholder="blank = accept any key" autocomplete="off" spellcheck="false">
+                <button class="ic-btn ic-btn-ghost" onclick="genIngestKey()">Generate</button>
+                <button class="ic-btn ic-btn-primary" onclick="saveIngestKey(this)">Save key</button>
+              </div>
+              <div class="muted" id="ingest-key-msg" style="font-size:11.5px;margin-top:6px"></div>
+            </div>
+          </details>
         </div>
       </div>
     </section>
@@ -2523,8 +2548,8 @@ details.sys-collapse>summary .ic-label{margin:0}
           <label style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;flex:1">
             <input type="checkbox" id="s-startup" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
-              <div style="font-weight:600">Start with Windows</div>
-              <div class="tab-sub" style="margin-top:2px">Launches at login and waits in the tray, so OBS always has somewhere to publish.</div>
+              <div style="font-weight:600" id="s-startup-title">Start with Windows</div>
+              <div class="tab-sub" style="margin-top:2px" id="s-startup-sub">Launches at login and waits in the tray, so OBS always has somewhere to publish.</div>
             </div>
           </label>
         </div>
@@ -2533,7 +2558,7 @@ details.sys-collapse>summary .ic-label{margin:0}
             <input type="checkbox" id="s-open-dash" style="width:16px;height:16px;cursor:pointer;margin-top:2px">
             <div>
               <div style="font-weight:600">Open dashboard on launch</div>
-              <div class="tab-sub" style="margin-top:2px">Opens this page in your browser each time the app starts. Turn off to stay in the tray.</div>
+              <div class="tab-sub" style="margin-top:2px" id="s-open-dash-sub">Opens this page in your browser each time the app starts. Turn off to stay in the tray.</div>
             </div>
           </label>
         </div>
@@ -2641,6 +2666,53 @@ details.sys-collapse>summary .ic-label{margin:0}
         <span id="lan-warn-text"></span>
       </div>
     </section>
+    <section class="sys-section">
+      <div class="ic-label">Dashboard password</div>
+      <div class="tab-sub">Off by default. When the web UI is open to a network, a password stops anyone who finds it from touching your stream. Local-only use needs none.</div>
+
+      <div id="sec-off" style="margin-top:12px">
+        <div class="form-row tight" style="align-items:end">
+          <div style="flex:1;min-width:0">
+            <span class="ic-label">New password</span>
+            <input id="sec-pw" type="password" class="ic-input" placeholder="at least 8 characters" autocomplete="new-password" spellcheck="false">
+          </div>
+          <button class="ic-btn ic-btn-primary" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw')">Enable</button>
+        </div>
+        <div class="muted" id="sec-off-msg" style="font-size:11.5px;margin-top:6px"></div>
+      </div>
+
+      <div id="sec-on" hidden style="margin-top:12px">
+        <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+          <span class="ic-badge ic-badge-ok">password on</span>
+          <span class="muted" style="font-size:12px">The dashboard requires sign-in.</span>
+        </div>
+
+        <div class="form-row tight" style="align-items:end;margin-top:12px">
+          <div style="flex:1;min-width:0">
+            <span class="ic-label">Change password</span>
+            <input id="sec-pw2" type="password" class="ic-input" placeholder="new password" autocomplete="new-password" spellcheck="false">
+          </div>
+          <button class="ic-btn ic-btn-ghost" style="flex:0 0 auto" onclick="enableAuth(this,'sec-pw2')">Update</button>
+        </div>
+
+        <div style="margin-top:14px">
+          <span class="ic-label">OBS dock URL</span>
+          <div class="tab-sub" style="margin-top:2px">The OBS dock can't sign in, so paste this token URL as its Custom Browser Dock. It controls the delay only, never settings or keys.</div>
+          <div class="copy-block" style="margin-top:6px">
+            <code class="mono blur-secret" id="sec-dock-url" style="overflow-x:auto;white-space:nowrap;min-width:0" title="Hidden to prevent leaks on stream. Use Show to reveal."></code>
+            <button class="ic-btn ic-btn-ghost" id="sec-dock-toggle" onclick="toggleSecret('sec-dock-url',this)">Show</button>
+            <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'sec-dock-url','Dock URL')">Copy</button>
+          </div>
+          <button class="ic-btn ic-btn-ghost" style="margin-top:8px" onclick="regenDock(this)">Regenerate</button>
+        </div>
+
+        <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap;margin-top:16px">
+          <button class="ic-btn ic-btn-ghost" onclick="logoutNow()">Log out</button>
+          <button class="ic-btn ic-btn-warn" onclick="disableAuth(this)">Turn off password</button>
+        </div>
+        <div class="muted" id="sec-on-msg" style="font-size:11.5px;margin-top:8px"></div>
+      </div>
+    </section>
   </div>
 
   <!-- Buffer sub-pane -->
@@ -2654,7 +2726,7 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
       <div class="muted" id="s-bmb-hint" style="margin-top:8px;font-size:11.5px;line-height:1.4"></div>
       <div class="row" style="margin-top:10px">
-        <button class="ic-btn ic-btn-ghost" onclick="reveal('buffer',this)">Show buffer file in Explorer</button>
+        <button class="ic-btn ic-btn-ghost reveal-btn" onclick="reveal('buffer',this)">Show buffer file in Explorer</button>
       </div>
     </section>
   </div>
@@ -2684,7 +2756,7 @@ details.sys-collapse>summary .ic-label{margin:0}
         <span>Capture trace log when streaming</span>
       </label>
       <div class="row" style="margin-top:10px">
-        <button class="ic-btn ic-btn-ghost" onclick="reveal('trace',this)">Show log file in Explorer</button>
+        <button class="ic-btn ic-btn-ghost reveal-btn" onclick="reveal('trace',this)">Show log file in Explorer</button>
       </div>
     </section>
   </div>
@@ -2695,18 +2767,32 @@ details.sys-collapse>summary .ic-label{margin:0}
       <div class="ic-label">InstantClone</div>
       <div class="sys-version-row">
         <span class="sys-version-num" id="sys-about-version">v?.?.?</span>
+        <span class="sys-os-chip" id="sys-os-chip" hidden></span>
         <span class="sys-version-pill ok" id="sys-about-pill" hidden>up to date</span>
         <button class="ic-btn ic-btn-ghost" id="sys-about-check-btn" onclick="aboutCheckUpdate()">Check for updates</button>
         <button class="ic-btn ic-btn-primary" id="sys-about-update-btn" onclick="applyUpdate()" hidden>Update now</button>
       </div>
-      <div class="muted" id="sys-about-msg" style="font-size:12px;margin-top:8px;min-height:1.2em"></div>
-      <label style="display:flex;align-items:center;gap:10px;margin-top:12px;cursor:pointer">
+      <div class="sysinfo">
+        <div class="si"><span class="k">Uptime</span><span class="v" id="si-uptime">-</span></div>
+        <div class="si"><span class="k">Memory</span><span class="v" id="si-mem">-</span></div>
+        <div class="si"><span class="k">CPU</span><span class="v" id="si-cpu">-</span></div>
+        <div class="si"><span class="k">Ingest</span><span class="v" id="si-ingest">-</span></div>
+        <div class="si"><span class="k">Dashboard</span><span class="v" id="si-web">-</span></div>
+        <div class="si"><span class="k">Delay buffer</span><span class="v" id="si-buffer">-</span></div>
+        <div class="si"><span class="k">Destinations</span><span class="v" id="si-dests">-</span></div>
+      </div>
+      <div class="muted" id="sys-about-msg" style="font-size:12px;margin-top:12px;min-height:1.2em"></div>
+      <label style="display:flex;align-items:center;gap:10px;margin-top:8px;cursor:pointer">
         <input id="s-update-check" type="checkbox" style="width:16px;height:16px;cursor:pointer">
         <span>Automatically check for updates<span class="muted" style="margin-left:6px;font-size:12px">on launch, from GitHub</span></span>
       </label>
-      <div class="row" style="gap:10px;margin-top:12px;align-items:center">
+    </section>
+    <section class="sys-section">
+      <div class="ic-label">Application</div>
+      <div class="tab-sub">Restart to apply a buffer or port change. Quit stops every destination cleanly and takes the dashboard offline until you launch the app again.</div>
+      <div class="row" style="gap:10px;margin-top:12px;align-items:center;flex-wrap:wrap">
         <button class="ic-btn ic-btn-ghost" onclick="restartApp(this)">Restart InstantClone</button>
-        <span class="muted" style="font-size:12px">Relaunch the app - the dashboard reconnects automatically.</span>
+        <button class="ic-btn ic-btn-warn" onclick="quitApp(this)">Quit InstantClone</button>
       </div>
     </section>
     <div class="sys-about-grid">
@@ -4345,6 +4431,7 @@ async function loadConfig(){
     // Reflects the actual Run-key entry, not a stored preference - so if
     // the user removed it via Task Manager's Startup tab, this shows off.
     $('s-startup').checked = !!c.start_with_windows;
+    applyPlatformCopy(c.os);
     // Both default true server-side; treat a missing field as on.
     $('s-open-dash').checked = c.open_dashboard_on_launch !== false;
     $('s-update-check').checked = c.update_check_enabled !== false;
@@ -4355,6 +4442,24 @@ async function loadConfig(){
     // OBS panel
     $('obs-srv').textContent = c.obs_url;
     if ($('wiz-obs-srv')) $('wiz-obs-srv').textContent = c.obs_url;
+    applyIngestKey(c.ingest_key || '');
+    applyAuthState(!!c.auth_enabled, c.dock_token || '');
+    if ($('sys-os-chip')){
+      const osLabel = {windows:'Windows', linux:'Linux', macos:'macOS'}[c.os] || (c.os || '');
+      if (osLabel){ $('sys-os-chip').textContent = osLabel; $('sys-os-chip').hidden = false; }
+    }
+    // The version row shows v0.1.13 from /update-check; seed it from /config so
+    // it's correct immediately even before the (async) update check returns.
+    if ($('sys-about-version') && c.version && $('sys-about-version').textContent === 'v?.?.?'){
+      $('sys-about-version').textContent = 'v' + c.version;
+    }
+    // System-info tiles: static bits from /config (live bits filled per tick).
+    // Show the port + exposure scope, never an IP - no address should be
+    // readable off a screen-share or stream.
+    const scope = b => b ? 'network' : 'local';
+    if ($('si-ingest')) $('si-ingest').textContent = c.ingest_port + ' · ' + scope(c.ingest_bind_all);
+    if ($('si-web')) $('si-web').textContent = c.web_port + ' · ' + scope(c.web_bind_all);
+    if ($('si-buffer')) $('si-buffer').textContent = (c.buffer_mb || 0) + ' MB';
     $('dock-url').textContent = location.origin + '/dock';
     // footer
     $('foot-rtmp').textContent = ':' + c.ingest_port;
@@ -5064,15 +5169,137 @@ function flashFieldErrors(message){
 // the web UI is an unauthenticated control surface, while the ingest port
 // lets anyone on the network publish into the buffer. Both default off,
 // and this stays hidden until one is actually ticked.
+// --- Optional dashboard auth (Security section) --------------------------
+let _authEnabled = false;
+function applyAuthState(enabled, dockToken){
+  _authEnabled = !!enabled;
+  if ($('sec-off')) $('sec-off').hidden = _authEnabled;
+  if ($('sec-on')) $('sec-on').hidden = !_authEnabled;
+  const url = $('sec-dock-url');
+  if (url){
+    url.textContent = dockToken ? (location.origin + '/dock?token=' + dockToken) : '';
+    url.classList.remove('revealed'); // always start hidden
+  }
+  if ($('sec-dock-toggle')) $('sec-dock-toggle').textContent = 'Show';
+  renderLanWarning();
+}
+
+// Reveal/hide a blurred secret without ever changing what Copy grabs.
+function toggleSecret(id, btn){
+  const el = $(id);
+  if (!el) return;
+  const showing = el.classList.toggle('revealed');
+  if (btn) btn.textContent = showing ? 'Hide' : 'Show';
+}
+
+async function enableAuth(btn, inputId){
+  const inp = $(inputId);
+  const pw = inp ? inp.value : '';
+  if (!pw || pw.length < 8){ toast('Use at least 8 characters', 'err'); return; }
+  const label = btn && btn.textContent;
+  if (btn){ btn.disabled = true; btn.textContent = 'Saving…'; }
+  try {
+    const r = await fetch('/auth/set-password', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:'password=' + encodeURIComponent(pw)});
+    if (r.ok){ if (inp) inp.value=''; toast('Password set', 'ok'); await loadConfig(); }
+    else { const j = await r.json().catch(()=>({})); toast((j&&j.error)?j.error:'Could not set password', 'err'); }
+  } catch(_){ toast('Network error', 'err'); }
+  finally { if (btn){ btn.disabled = false; btn.textContent = label || 'Enable password'; } }
+}
+
+async function disableAuth(btn){
+  if (!confirm('Turn off the password? The dashboard becomes open to anyone who can reach it.')) return;
+  if (btn){ btn.disabled = true; }
+  try {
+    const r = await fetch('/auth/disable', {method:'POST'});
+    if (r.ok){ toast('Password disabled', 'ok'); await loadConfig(); } else toast('Could not disable', 'err');
+  } catch(_){ toast('Network error', 'err'); }
+  finally { if (btn){ btn.disabled = false; } }
+}
+
+async function regenDock(btn){
+  if (!confirm('Regenerate the dock URL? The current one stops working and you must repaste the new URL into OBS.')) return;
+  if (btn){ btn.disabled = true; }
+  try {
+    const r = await fetch('/auth/regen-dock', {method:'POST'});
+    if (r.ok){
+      const j = await r.json().catch(()=>({}));
+      if ($('sec-dock-url') && j && j.dock_token){
+        $('sec-dock-url').textContent = location.origin + '/dock?token=' + j.dock_token;
+        $('sec-dock-url').classList.remove('revealed');
+        if ($('sec-dock-toggle')) $('sec-dock-toggle').textContent = 'Show';
+      }
+      toast('New dock URL generated', 'ok');
+    } else toast('Could not regenerate', 'err');
+  } catch(_){ toast('Network error', 'err'); }
+  finally { if (btn){ btn.disabled = false; } }
+}
+
+async function logoutNow(){
+  try { await fetch('/logout', {method:'POST'}); } catch(_){}
+  location.href = '/login';
+}
+
 function renderLanWarning(){
   const web = $('s-wbind').checked;
   const ingest = $('s-ibind').checked;
+  const hasKey = !!($('s-ingest-key') && $('s-ingest-key').value.trim());
   const parts = [];
-  if (web) parts.push('The web UI has no password - anyone on your network can change the delay, cut, and edit destinations.');
-  if (ingest) parts.push('The ingest port accepts any stream key, so anyone on your network can publish into your buffer.');
+  if (web && !_authEnabled) parts.push('The web UI has no password, so anyone on your network can change the delay, cut, and edit destinations. Set one in Security below.');
+  if (ingest && !hasKey) parts.push('The ingest port accepts any stream key, so anyone on your network can publish into your buffer. Set a required key in the OBS tab to lock it.');
   const on = parts.length > 0;
   $('lan-warn').hidden = !on;
   if (on) $('lan-warn-text').textContent = parts.join(' ') + ' Only enable on a network you trust.';
+}
+
+// Reflect the current ingest key across the OBS tab: the copyable Stream key,
+// the helper note, the input, and the LAN warning (a set key removes the
+// "anyone can publish" line).
+function applyIngestKey(key){
+  const codeEl = $('obs-key');
+  if (codeEl) codeEl.textContent = key || 'main';
+  const inp = $('s-ingest-key');
+  if (inp && document.activeElement !== inp) inp.value = key || '';
+  const note = $('obs-key-note');
+  if (note) note.innerHTML = key
+    ? 'The ingest is locked. OBS must use <b>this exact key</b> to publish.'
+    : 'Any string works. The real platform key lives in <b>Destinations</b>.';
+  renderLanWarning();
+}
+
+function genIngestKey(){
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const inp = $('s-ingest-key');
+  if (inp) inp.value = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function saveIngestKey(btn){
+  const inp = $('s-ingest-key');
+  const key = inp ? inp.value.trim() : '';
+  const msg = $('ingest-key-msg');
+  if (btn){ btn.disabled = true; btn.textContent = 'Saving…'; }
+  try {
+    const resp = await fetch('/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'ingest_key=' + encodeURIComponent(key),
+    });
+    if (resp.ok){
+      applyIngestKey(key);
+      if (msg) msg.textContent = key
+        ? 'Ingest locked. Set this as your OBS stream key.'
+        : 'Ingest key cleared. Any key is accepted again.';
+      toast(key ? 'Ingest key saved' : 'Ingest key cleared', 'ok');
+    } else {
+      if (msg) msg.textContent = 'Could not save (server returned ' + resp.status + ').';
+      toast('Could not save ingest key', 'err');
+    }
+  } catch(_){
+    if (msg) msg.textContent = 'Could not save (network error).';
+    toast('Could not save ingest key', 'err');
+  } finally {
+    if (btn){ btn.disabled = false; btn.textContent = 'Save key'; }
+  }
 }
 
 let _savingSettings = false;
@@ -7054,12 +7281,17 @@ function waitForRestart(){
   }, 1500);
 }
 
-// Restart the app (e.g. to apply a buffer/port change). Same relaunch
-// mechanism as the updater, minus the swap; we reconnect and reload once
-// the fresh process answers.
-let _restarting = false;
+// Restart the app (e.g. to apply a buffer/port change). The server tears
+// down every egress cleanly (deleteStream upstream) and THEN relaunches, so
+// this is safe to run mid-stream - but it still drops the live edge for a few
+// seconds, so we confirm first when OBS is actually publishing.
+let _restarting = false, _quitting = false;
 async function restartApp(btn){
-  if (_restarting) return;
+  if (_restarting || _quitting) return;
+  if (lastState && lastState.ingest_alive &&
+      !confirm('OBS is streaming through InstantClone right now. Restarting relaunches the app and drops every destination for a few seconds.\n\nRestart anyway?')){
+    return;
+  }
   _restarting = true;
   if (btn){ btn.disabled = true; btn.textContent = 'Restarting…'; }
   toast('Restarting InstantClone…','info');
@@ -7067,19 +7299,89 @@ async function restartApp(btn){
   waitForRestart();
 }
 
-// Open one of our files in Explorer. `what` is a fixed keyword the server
-// maps to a known path - buffer / trace / overlays.
+// Quit the app for good - no relaunch. Same clean egress teardown as the
+// Windows tray Quit. Unlike restart we do NOT poll for reconnect: the process
+// is gone, so we replace the view with a terminal farewell instead of leaving
+// a frozen dashboard that looks broken.
+async function quitApp(btn){
+  if (_quitting || _restarting) return;
+  if (lastState && lastState.ingest_alive &&
+      !confirm('OBS is streaming through InstantClone right now. Quitting stops the delay and drops every destination.\n\nQuit anyway?')){
+    return;
+  }
+  if (!confirm('Quit InstantClone? The dashboard will go offline until you launch the app again.')) return;
+  _quitting = true;
+  if (btn){ btn.disabled = true; btn.textContent = 'Quitting…'; }
+  toast('Stopping InstantClone…','info');
+  try { await fetch('/app/quit', {method:'POST'}); } catch(_){ /* server going down */ }
+  showQuitFarewell();
+}
+
+// Full-screen "stopped" overlay shown after Quit. Covers the dashboard so the
+// dead poll loop (whose fetches now just fail silently) isn't visible behind a
+// frozen UI. Uses theme tokens so it reads correctly in the current palette.
+function showQuitFarewell(){
+  const el = document.createElement('div');
+  el.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;'+
+    'justify-content:center;text-align:center;padding:24px;background:var(--bg);color:var(--fg)';
+  el.innerHTML =
+    '<div style="max-width:440px">'+
+      '<div style="font-size:34px;line-height:1;margin-bottom:14px;color:var(--fg-3)">■</div>'+
+      '<h2 style="margin:0 0 10px;font-size:20px">InstantClone has stopped</h2>'+
+      '<p style="margin:0;font-size:14px;line-height:1.55;color:var(--fg-2)">'+
+        'Every destination was disconnected cleanly and the delay buffer released. '+
+        'You can close this tab - launch InstantClone again to bring the dashboard back.'+
+      '</p>'+
+    '</div>';
+  document.body.appendChild(el);
+}
+
+// Swap the handful of OS-specific strings so the dashboard reads native on
+// whatever platform the server runs. `os` comes from /config ("windows",
+// "linux", "macos"). Called on every config load. The file-manager name is
+// cached for the reveal() error toast.
+let _fileManager = 'Explorer';
+function applyPlatformCopy(os){
+  os = os || 'windows';
+  _fileManager = os === 'linux' ? 'file manager' : os === 'macos' ? 'Finder' : 'Explorer';
+  const onWindows = os === 'windows';
+  const title = $('s-startup-title');
+  if (title) title.textContent = onWindows ? 'Start with Windows' : 'Start at login';
+  const sub = $('s-startup-sub');
+  if (sub) sub.textContent = onWindows
+    ? 'Launches at login and waits in the tray, so OBS always has somewhere to publish.'
+    : 'Launches at login and keeps running in the background, so OBS always has somewhere to publish.';
+  const odSub = $('s-open-dash-sub');
+  if (odSub) odSub.textContent = onWindows
+    ? 'Opens this page in your browser each time the app starts. Turn off to stay in the tray.'
+    : 'Opens this page in your browser each time the app starts. Turn off to keep it running in the background.';
+  document.querySelectorAll('.reveal-btn').forEach(b => {
+    const which = /reveal\('trace'/.test(b.getAttribute('onclick') || '') ? 'log file' : 'buffer file';
+    b.textContent = `Show ${which} in ${_fileManager}`;
+  });
+}
+
+// Open one of our files in the OS file browser. `what` is a fixed keyword the
+// server maps to a known path (buffer / trace / overlays).
 async function reveal(what, btn){
   try {
     const j = await (await fetch('/reveal/' + what, {method:'POST'})).json();
-    if (!j || !j.ok) toast('Could not open Explorer','err');
-  } catch(_){ toast('Could not open Explorer','err'); }
+    if (!j || !j.ok) toast('Could not open ' + _fileManager,'err');
+  } catch(_){ toast('Could not open ' + _fileManager,'err'); }
 }
 
 // - Tick / poll loop -------------------------
 // applyState() is the pure render side - used by both the poll path
 // and the SSE push path so we don't have two copies of the dashboard
 // reconciliation logic.
+function fmtUptime(sec){
+  sec = Math.max(0, Math.floor(sec));
+  const d = Math.floor(sec/86400), h = Math.floor(sec%86400/3600), m = Math.floor(sec%3600/60), r = sec%60;
+  if (d) return d+'d '+h+'h';
+  if (h) return h+'h '+m+'m';
+  if (m) return m+'m '+r+'s';
+  return r+'s';
+}
 function applyState(s){
   const prev = lastState;
   if (prev){
@@ -7089,6 +7391,14 @@ function applyState(s){
       toast('OBS reconnected - re-aligned timeline','info');
   }
   lastState = s;
+  // System-info tiles (About tab): live bits, every tick, tab-independent.
+  if ($('si-uptime')) $('si-uptime').textContent = fmtUptime(s.uptime_secs || 0);
+  if ($('si-mem')) $('si-mem').textContent = Math.round((s.rss_bytes || 0) / 1048576) + ' MB';
+  if ($('si-cpu')) $('si-cpu').textContent = Math.round(s.cpu_pct || 0) + '%';
+  if ($('si-dests')){
+    const t = s.destinations_total || 0, a = s.destinations_alive || 0;
+    $('si-dests').textContent = t ? (a + ' of ' + t + ' live') : 'none';
+  }
   // Update the capacity planning bitrate BEFORE any render that reads it
   // (the profile chips + CTA capacity gate), so a transient dip can't
   // flash a too-big delay unlocked mid-tick.


### PR DESCRIPTION
Adds first-class Linux support (headless VPS and Ubuntu desktop) alongside the existing Windows build, plus an optional, off-by-default dashboard-auth layer for network-exposed deployments.

The default install (no password, no ingest key) behaves byte-for-byte as before on every platform. The core relay engine (disk-ring buffer, egress, RTMP chunk/handshake/AMF0, h264, delay+cut) is unchanged: only `rtmp/server.rs` in that area changed, and only to thread a peer IP through.

## Linux support
- Port pre-flight split so the `std::net` bind checks run on every OS; the IpHelper lookup and MessageBox stay Windows-only.
- Linux `.desktop` autostart and app icon; `/proc` CPU and RSS sampler.
- Linux OBS discovery and EB launch (native, Flatpak, Snap). `--launch-eb` is retained for older OBS.
- Unified graceful shutdown: web Quit/Restart and the Windows tray Quit converge on one clean teardown, so Linux gets a Quit/Restart affordance without a native tray.
- CI now builds and tests on Linux; `scripts/e2e.sh` mirrors `e2e.ps1` so the full wire path is proven on Linux too.

## Optional dashboard auth (off by default)
- PBKDF2-HMAC-SHA256 password hashing and HMAC built on the existing sha256, no new crates; OS CSPRNG for tokens and salts.
- Fail-closed access gate (public / control / admin), 256-bit session cookies, least-privilege dock token, constant-time secret compares, shared per-client rate limiter for logins and ingest keys.
- Optional RTMP ingest key enforced in `begin_publish`, throttled and constant-time, skipped entirely when unset.
- Password hashing runs off the reactor so a login never stalls the relay.

## Enhanced Broadcasting ingest key
Making the optional ingest key work with Twitch Enhanced Broadcasting (multitrack), which was the trickiest part of the auth layer.

- Under proxy EB, OBS publishes with the Twitch session token from the config we hand it, not the user's key, and its `create_service` appends `?clientConfigId=...` to whatever key it does send. `begin_publish` now strips the RTMP playpath query before matching, so a correct key is no longer rejected.
- The multitrack `url_template` keeps the `{stream_key}` token; the proxy remembers every ingest endpoint's session token so whichever endpoint OBS selects is accepted, with a constant-time compare.
- The key is enforced at the config request itself: under proxy EB the publish carries the Twitch token, so the only place the user's key is presented is the request's `authentication` field. A wrong key there returns the static config and never brokers a session. This also stops an unauthenticated peer from triggering a Twitch API call with the user's real key.
- The ingest key is mirrored into the controller inline on save, so locking the port takes effect immediately instead of on the next supervisor tick.

Supersedes the earlier url_template key-embedding approach, which could not work: OBS splits server and key, then overrides the key with the endpoint authentication token.

## Hardening
- Fix a remote panic: `url_decode` no longer slices a `str` across a percent-escape before a multibyte char.
- Bounded rate-limiter map, header/body read deadlines, and a request body read only for POST.
- Dock token validated as hex; first-password bootstrap restricted to loopback.
- Config writer strips control characters from every string field, so a newline in a setting cannot inject a second `key=value` line (and flip an unrelated flag) on the next load.
- Login rate limiter counts the attempt as it checks, under one lock, so a burst of concurrent wrong-password requests cannot slip past the lockout across the async password hash.
- `custom_egress_url` is gated behind a full session in `/config`, so a key embedded in a custom URL path is never returned to a dock-token caller.
- Ingest key restricted to `[A-Za-z0-9_-]` in validation (it travels as an RTMP stream key), and `buffer_mb` gained a ceiling so a hand-edited value cannot overflow `buffer_bytes()`.

## Verification
| Check | Linux | Windows |
| --- | --- | --- |
| clippy -D warnings | clean | clean |
| unit/integration tests | 316/316 | 312/312 |
| auth break-test (22 adversarial probes) | 22/22 | 22/22 |
| e2e wire test (ffmpeg to proxy to sink) | 6/6 | mirrors e2e.ps1 |

The follow-up EB and hardening fixes were validated by the unit/integration suites on both platforms (316 on Linux via Docker, 312 on Windows) plus clippy and rustfmt. Two independent audits found no critical or high issues. Windows and Linux were each exercised as the server.
