### PR TITLE
Global hotkeys and MIDI bindings for delay actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_Media_Audio",
     "Win32_System_Console",
     "Win32_System_Registry",
     "Win32_System_LibraryLoader",

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,12 +126,302 @@ pub struct Settings {
     /// it - the dock owns its schema). Persisted here so a customized dock
     /// survives OBS wiping its browser cache or the machine restarting.
     pub docks: BTreeMap<String, String>,
+    /// Global hotkey bindings for the delay actions. Windows-only in
+    /// effect (bound via RegisterHotKey from the tray); other platforms
+    /// keep the values on disk but never register them. See `Hotkeys`.
+    pub hotkeys: Hotkeys,
+    /// MIDI controller bindings for the delay actions. Windows-only in
+    /// effect (winmm listener); other platforms keep the values on disk.
+    /// See `MidiBindings`.
+    pub midi: MidiBindings,
 }
 
 #[derive(Debug, Clone)]
 pub struct DelayProfile {
     pub name: String,
     pub delay_ms: u32,
+}
+
+// Win32 `RegisterHotKey` modifier bit values, mirrored here so the
+// cross-platform config layer can parse a combo string without pulling in
+// windows-sys. The tray passes these straight through to RegisterHotKey.
+pub const HK_MOD_ALT: u32 = 0x0001;
+pub const HK_MOD_CONTROL: u32 = 0x0002;
+pub const HK_MOD_SHIFT: u32 = 0x0004;
+pub const HK_MOD_WIN: u32 = 0x0008;
+
+/// Global hotkey bindings, one canonical combo string per delay action
+/// (e.g. "Ctrl+Alt+D"; empty means unbound). Windows binds them via
+/// RegisterHotKey from the tray's message loop; other platforms round-trip
+/// the values through save/load unchanged but never register them (a
+/// headless Linux box has no global-key surface). Every binding must carry
+/// at least one modifier, so a bare keypress mid-game can never fire a
+/// delay action by accident - that requirement is the misclick guard.
+#[derive(Debug, Clone, Default)]
+pub struct Hotkeys {
+    /// Delay on/off: activate the armed delay, or cut back to live.
+    pub toggle: String,
+    /// Arm the buffer at the default delay.
+    pub arm: String,
+    /// Activate the armed delay (go delayed).
+    pub activate: String,
+    /// Cut back to live, keeping the buffer armed.
+    pub cut: String,
+    /// Schedule a cut for the moment the current live edge airs.
+    pub cut_after: String,
+}
+
+impl Hotkeys {
+    /// Stable (action-name, binding) pairs. One source of truth for the
+    /// save writer, the JSON serializer, and the tray registrar, so a new
+    /// action is added in exactly one place.
+    pub fn entries(&self) -> [(&'static str, &str); 5] {
+        [
+            ("toggle", &self.toggle),
+            ("arm", &self.arm),
+            ("activate", &self.activate),
+            ("cut", &self.cut),
+            ("cut_after", &self.cut_after),
+        ]
+    }
+
+    fn slot_mut(&mut self, action: &str) -> Option<&mut String> {
+        Some(match action {
+            "toggle" => &mut self.toggle,
+            "arm" => &mut self.arm,
+            "activate" => &mut self.activate,
+            "cut" => &mut self.cut,
+            "cut_after" => &mut self.cut_after,
+            _ => return None,
+        })
+    }
+
+    /// Assign one action's binding from a raw combo string. An empty or
+    /// malformed value clears the binding; a valid one is stored in
+    /// canonical form. This is the single choke point that keeps only
+    /// well-formed combos on disk and in memory.
+    pub fn set(&mut self, action: &str, raw: &str) {
+        if let Some(slot) = self.slot_mut(action) {
+            *slot = canonicalize_hotkey(raw).unwrap_or_default();
+        }
+    }
+}
+
+/// MIDI controller bindings, one signature string per delay action (empty
+/// means unbound). A signature is `note:<channel>:<note>` for a note-on pad
+/// or `cc:<channel>:<controller>` for a control-change knob/button, channel
+/// 1-16 and data 0-127. Same five actions as `Hotkeys`; the MIDI listener
+/// thread matches an incoming message against these and fires the shared
+/// controller action. Windows-only in effect (winmm), round-tripped
+/// everywhere.
+#[derive(Debug, Clone, Default)]
+pub struct MidiBindings {
+    pub toggle: String,
+    pub arm: String,
+    pub activate: String,
+    pub cut: String,
+    pub cut_after: String,
+}
+
+impl MidiBindings {
+    /// Stable (action-name, signature) pairs, mirroring `Hotkeys::entries`.
+    pub fn entries(&self) -> [(&'static str, &str); 5] {
+        [
+            ("toggle", &self.toggle),
+            ("arm", &self.arm),
+            ("activate", &self.activate),
+            ("cut", &self.cut),
+            ("cut_after", &self.cut_after),
+        ]
+    }
+
+    fn slot_mut(&mut self, action: &str) -> Option<&mut String> {
+        Some(match action {
+            "toggle" => &mut self.toggle,
+            "arm" => &mut self.arm,
+            "activate" => &mut self.activate,
+            "cut" => &mut self.cut,
+            "cut_after" => &mut self.cut_after,
+            _ => return None,
+        })
+    }
+
+    /// Assign one action's MIDI signature. An empty or malformed value
+    /// clears it; a valid one is stored canonicalized. Single choke point,
+    /// same contract as `Hotkeys::set`.
+    pub fn set(&mut self, action: &str, raw: &str) {
+        if let Some(slot) = self.slot_mut(action) {
+            *slot = canonicalize_midi(raw).unwrap_or_default();
+        }
+    }
+
+    /// Action bound to `signature`, if any. Used by the MIDI listener to
+    /// route an incoming message. First match wins. Windows-only in use
+    /// (plus tests); other platforms have no listener to call it.
+    #[cfg(any(windows, test))]
+    pub fn action_for(&self, signature: &str) -> Option<&'static str> {
+        self.entries()
+            .into_iter()
+            .find(|(_, sig)| !sig.is_empty() && *sig == signature)
+            .map(|(action, _)| action)
+    }
+}
+
+/// Validate and normalise a MIDI signature to `note:ch:n` / `cc:ch:n`, or
+/// None if it is malformed or out of range. Channel 1-16, data 0-127.
+pub fn canonicalize_midi(sig: &str) -> Option<String> {
+    let mut parts = sig.trim().split(':');
+    let kind = parts.next()?.trim().to_ascii_lowercase();
+    let ch: u32 = parts.next()?.trim().parse().ok()?;
+    let data: u32 = parts.next()?.trim().parse().ok()?;
+    if parts.next().is_some() {
+        return None; // trailing junk
+    }
+    if !(1..=16).contains(&ch) || data > 127 {
+        return None;
+    }
+    match kind.as_str() {
+        "note" => Some(format!("note:{ch}:{data}")),
+        "cc" => Some(format!("cc:{ch}:{data}")),
+        _ => None,
+    }
+}
+
+/// Parse a combo string into `(modifier bitmask, virtual-key code)`.
+/// Tokens are '+'-separated, case-insensitive and order-independent:
+/// modifiers Ctrl/Control, Alt, Shift, Win/Super/Meta/Cmd, plus exactly
+/// one main key (A-Z, 0-9, or F1-F24). Returns None unless there is at
+/// least one modifier and exactly one valid main key - the modifier
+/// requirement is what stops a stray keypress from firing.
+pub fn parse_hotkey(combo: &str) -> Option<(u32, u32)> {
+    let mut mods = 0u32;
+    let mut vk: Option<u32> = None;
+    for tok in combo.split('+') {
+        let t = tok.trim();
+        if t.is_empty() {
+            continue;
+        }
+        match t.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => mods |= HK_MOD_CONTROL,
+            "alt" => mods |= HK_MOD_ALT,
+            "shift" => mods |= HK_MOD_SHIFT,
+            "win" | "super" | "meta" | "cmd" => mods |= HK_MOD_WIN,
+            _ => {
+                let code = key_to_vk(t)?;
+                if vk.is_some() {
+                    return None; // more than one main key: not RegisterHotKey-able
+                }
+                vk = Some(code);
+            }
+        }
+    }
+    let vk = vk?;
+    if mods == 0 {
+        return None; // bare key: rejected as a misclick risk
+    }
+    Some((mods, vk))
+}
+
+/// Normalise a combo to canonical display form ("Ctrl+Alt+D"), or None if
+/// it is not a valid modifier+key combo. Modifiers are emitted in a fixed
+/// order so the same combo always renders identically.
+pub fn canonicalize_hotkey(combo: &str) -> Option<String> {
+    let (mods, vk) = parse_hotkey(combo)?;
+    let mut out = String::with_capacity(16);
+    if mods & HK_MOD_CONTROL != 0 {
+        out.push_str("Ctrl+");
+    }
+    if mods & HK_MOD_ALT != 0 {
+        out.push_str("Alt+");
+    }
+    if mods & HK_MOD_SHIFT != 0 {
+        out.push_str("Shift+");
+    }
+    if mods & HK_MOD_WIN != 0 {
+        out.push_str("Win+");
+    }
+    out.push_str(&vk_to_key(vk)?);
+    Some(out)
+}
+
+/// Named main keys beyond the letter/digit/F ranges, as (canonical token,
+/// Win32 VK code). Token spellings deliberately avoid '+' (the combo
+/// separator) so they round-trip through the line-based parser. This table
+/// is the single source of truth for both directions; the dashboard's
+/// capture UI maps browser key codes onto these same tokens.
+const NAMED_KEYS: &[(&str, u32)] = &[
+    ("Space", 0x20),
+    ("Tab", 0x09),
+    ("Esc", 0x1B),
+    ("Enter", 0x0D),
+    ("Backspace", 0x08),
+    ("Left", 0x25),
+    ("Up", 0x26),
+    ("Right", 0x27),
+    ("Down", 0x28),
+    ("PageUp", 0x21),
+    ("PageDown", 0x22),
+    ("End", 0x23),
+    ("Home", 0x24),
+    ("Insert", 0x2D),
+    ("Delete", 0x2E),
+    ("Numpad0", 0x60),
+    ("Numpad1", 0x61),
+    ("Numpad2", 0x62),
+    ("Numpad3", 0x63),
+    ("Numpad4", 0x64),
+    ("Numpad5", 0x65),
+    ("Numpad6", 0x66),
+    ("Numpad7", 0x67),
+    ("Numpad8", 0x68),
+    ("Numpad9", 0x69),
+    ("NumMultiply", 0x6A),
+    ("NumAdd", 0x6B),
+    ("NumSubtract", 0x6D),
+    ("NumDecimal", 0x6E),
+    ("NumDivide", 0x6F),
+];
+
+/// Map a main-key token to its Win32 virtual-key code. Letters A-Z and
+/// digits 0-9 map to VK codes that equal their ASCII value; F1-F24 map to a
+/// fixed base; the nav / numpad cluster comes from `NAMED_KEYS`. Anything
+/// else is rejected so only sensibly-bindable keys reach RegisterHotKey.
+fn key_to_vk(key: &str) -> Option<u32> {
+    let bytes = key.as_bytes();
+    if bytes.len() == 1 {
+        let b = bytes[0];
+        if b.is_ascii_alphabetic() {
+            return Some(b.to_ascii_uppercase() as u32); // VK_A..VK_Z == 'A'..'Z'
+        }
+        if b.is_ascii_digit() {
+            return Some(b as u32); // VK_0..VK_9 == '0'..'9'
+        }
+        return None;
+    }
+    if bytes[0].eq_ignore_ascii_case(&b'F') {
+        if let Ok(n) = key[1..].parse::<u32>() {
+            if (1..=24).contains(&n) {
+                return Some(0x70 + (n - 1)); // VK_F1 == 0x70
+            }
+        }
+    }
+    NAMED_KEYS
+        .iter()
+        .find(|(name, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, vk)| *vk)
+}
+
+/// Inverse of `key_to_vk` for canonical display. Only the ranges
+/// `key_to_vk` can produce are handled; anything else is None.
+fn vk_to_key(vk: u32) -> Option<String> {
+    match vk {
+        0x30..=0x39 | 0x41..=0x5A => char::from_u32(vk).map(|c| c.to_string()),
+        0x70..=0x87 => Some(format!("F{}", vk - 0x70 + 1)),
+        _ => NAMED_KEYS
+            .iter()
+            .find(|(_, code)| *code == vk)
+            .map(|(name, _)| (*name).to_string()),
+    }
 }
 
 /// One streaming destination - Twitch, YouTube, a private server, etc.
@@ -376,6 +666,11 @@ impl Settings {
             // dashboard does it on first load, then flips this true.
             overlays_seeded: false,
             docks: BTreeMap::new(),
+            // No hotkeys bound out of the box: they are opt-in so a fresh
+            // install never steals a key combo a game or another app uses.
+            hotkeys: Hotkeys::default(),
+            // Likewise no MIDI bindings until the user maps a controller.
+            midi: MidiBindings::default(),
         }
     }
 
@@ -627,6 +922,20 @@ impl Settings {
         for (id, layout) in &self.docks {
             writeln!(f, "dock.{}={}", one_line(id), one_line(layout))?;
         }
+        // Hotkey bindings. Only bound actions are written, so a fresh
+        // install's config stays lean and a downgrade drops the unknown
+        // keys via apply_field's catch-all arm.
+        for (action, combo) in self.hotkeys.entries() {
+            if !combo.is_empty() {
+                writeln!(f, "hotkey.{}={}", action, combo)?;
+            }
+        }
+        // MIDI bindings, same only-when-bound rule.
+        for (action, sig) in self.midi.entries() {
+            if !sig.is_empty() {
+                writeln!(f, "midi.{}={}", action, sig)?;
+            }
+        }
         for (i, p) in self.profiles.iter().enumerate() {
             writeln!(f, "profile.{}.name={}", i, one_line(&p.name))?;
             writeln!(f, "profile.{}.delay_ms={}", i, p.delay_ms)?;
@@ -743,6 +1052,17 @@ impl Settings {
                 if !id.is_empty() && id.len() <= 40 && self.docks.len() < MAX_DOCKS {
                     self.docks.insert(id.to_string(), value.to_string());
                 }
+            }
+            // hotkey.<action>=<combo>. `set` canonicalizes and drops any
+            // malformed or unknown-action value, so a hand-edited config
+            // can never load a combo the tray would fail to register.
+            k if k.starts_with("hotkey.") => {
+                self.hotkeys.set(&k["hotkey.".len()..], value);
+            }
+            // midi.<action>=<signature>. `set` validates and drops anything
+            // malformed, so a hand-edited config can't load a bad signature.
+            k if k.starts_with("midi.") => {
+                self.midi.set(&k["midi.".len()..], value);
             }
             k if k.starts_with("profile.") => {
                 let rest = &k[8..];
@@ -955,6 +1275,24 @@ impl Settings {
             ));
         }
         dests.push(']');
+        // Hotkey bindings. Not secrets, so always emitted; the dashboard
+        // only surfaces the editor on Windows (where they take effect).
+        let hotkeys = format!(
+            r#"{{"toggle":{t},"arm":{a},"activate":{ac},"cut":{c},"cut_after":{ca}}}"#,
+            t = json_str(&self.hotkeys.toggle),
+            a = json_str(&self.hotkeys.arm),
+            ac = json_str(&self.hotkeys.activate),
+            c = json_str(&self.hotkeys.cut),
+            ca = json_str(&self.hotkeys.cut_after),
+        );
+        let midi = format!(
+            r#"{{"toggle":{t},"arm":{a},"activate":{ac},"cut":{c},"cut_after":{ca}}}"#,
+            t = json_str(&self.midi.toggle),
+            a = json_str(&self.midi.arm),
+            ac = json_str(&self.midi.activate),
+            c = json_str(&self.midi.cut),
+            ca = json_str(&self.midi.cut_after),
+        );
         // The two raw credentials are emitted only for a full session; a
         // dock-token caller gets them blanked (see the doc comment above).
         let ik_shown = if include_secrets {
@@ -968,7 +1306,7 @@ impl Settings {
             ""
         };
         format!(
-            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"ingest_key":{ik},"auth_enabled":{ae},"dock_token":{dt},"os":{osname},"version":{ver},"destinations":{dests}}}"#,
+            r#"{{"configured":{c},"ingest_port":{ip},"ingest_bind_all":{iba},"web_port":{wp},"web_bind_all":{wba},"buffer_mb":{bm},"buffer_path":{bp},"target_delay_ms":{td},"obs_url":{ou},"discord_webhook_url":{dw},"webhook_set":{ws},"overlays_dir":{ov},"tracing_enabled":{te},"auto_arm_on_connect":{aaoc},"auto_activate_when_ready":{aawr},"auto_arm_delay_ms":{aadm},"overlays_seeded":{os},"start_with_windows":{sww},"update_check_enabled":{uce},"open_dashboard_on_launch":{odol},"ingest_key":{ik},"auth_enabled":{ae},"dock_token":{dt},"os":{osname},"version":{ver},"hotkeys":{hotkeys},"midi":{midi},"destinations":{dests}}}"#,
             c = self.configured,
             sww = start_with_windows,
             ik = json_str(ik_shown),
@@ -994,6 +1332,8 @@ impl Settings {
             os = self.overlays_seeded,
             uce = self.update_check_enabled,
             odol = self.open_dashboard_on_launch,
+            hotkeys = hotkeys,
+            midi = midi,
             dests = dests,
         )
     }
@@ -2294,6 +2634,149 @@ mod tests {
         assert_eq!(s.ingest_port, 1935);
         assert_eq!(s.web_port, 7799);
         assert!(!s.configured);
+    }
+
+    #[test]
+    fn parse_hotkey_accepts_modifier_plus_key_and_canonicalizes() {
+        // Order-independent, case-insensitive, alias-aware; canonical form
+        // is a fixed modifier order so the same combo always renders alike.
+        assert_eq!(
+            canonicalize_hotkey("alt+ctrl+d").as_deref(),
+            Some("Ctrl+Alt+D")
+        );
+        assert_eq!(
+            canonicalize_hotkey("CONTROL + SHIFT + f8").as_deref(),
+            Some("Ctrl+Shift+F8")
+        );
+        assert_eq!(canonicalize_hotkey("super+1").as_deref(), Some("Win+1"));
+        let (mods, vk) = parse_hotkey("Ctrl+Alt+D").expect("valid");
+        assert_eq!(mods, HK_MOD_CONTROL | HK_MOD_ALT);
+        assert_eq!(vk, b'D' as u32);
+        // Named keys (nav / numpad cluster) round-trip case-insensitively.
+        assert_eq!(
+            canonicalize_hotkey("ctrl+numpad5").as_deref(),
+            Some("Ctrl+Numpad5")
+        );
+        assert_eq!(canonicalize_hotkey("alt+LEFT").as_deref(), Some("Alt+Left"));
+        assert_eq!(
+            canonicalize_hotkey("ctrl+pageup").as_deref(),
+            Some("Ctrl+PageUp")
+        );
+        assert_eq!(
+            canonicalize_hotkey("shift+numadd").as_deref(),
+            Some("Shift+NumAdd")
+        );
+        assert_eq!(parse_hotkey("Ctrl+Home").expect("valid").1, 0x24);
+    }
+
+    #[test]
+    fn parse_hotkey_rejects_bare_keys_and_multi_key_chords() {
+        // A bare key (no modifier) is the misclick risk we refuse, and a
+        // two-letter chord is not expressible via RegisterHotKey.
+        assert!(parse_hotkey("D").is_none(), "bare key must be rejected");
+        assert!(
+            parse_hotkey("F8").is_none(),
+            "bare function key must be rejected"
+        );
+        assert!(
+            parse_hotkey("Ctrl+D+L").is_none(),
+            "multi-key chord must be rejected"
+        );
+        assert!(
+            parse_hotkey("Ctrl+Alt").is_none(),
+            "modifiers with no main key"
+        );
+        assert!(parse_hotkey("Ctrl+Q1").is_none(), "unknown key token");
+        assert!(parse_hotkey("Ctrl+F25").is_none(), "F-key out of range");
+        assert!(parse_hotkey("").is_none());
+    }
+
+    #[test]
+    fn hotkeys_round_trip_through_save_and_load() {
+        let path = std::env::temp_dir().join(format!(
+            "ic-test-hotkeys-roundtrip-{}-{}.ini",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let mut s = Settings::defaults();
+        // A lowercase, out-of-order input must be stored canonicalized.
+        s.hotkeys.set("toggle", "alt+ctrl+d");
+        s.hotkeys.set("cut", "ctrl+shift+f8");
+        // A malformed binding must be dropped, not persisted.
+        s.hotkeys.set("arm", "just-nonsense");
+        s.destinations.push(Destination {
+            id: "test".into(),
+            name: "Test".into(),
+            enabled: true,
+            platform: "twitch".into(),
+            stream_key: "test".into(),
+            custom_egress_url: String::new(),
+            twitch_ingest: String::new(),
+            youtube_ingest: String::new(),
+            vod_audio: false,
+            vod_audio_inject_eb: false,
+            stream_format: "horizontal".into(),
+            audio_track: "auto".into(),
+        });
+        s.save(&path).expect("save");
+
+        let loaded = Settings::load(&path).expect("load");
+        assert_eq!(loaded.hotkeys.toggle, "Ctrl+Alt+D");
+        assert_eq!(loaded.hotkeys.cut, "Ctrl+Shift+F8");
+        assert!(
+            loaded.hotkeys.arm.is_empty(),
+            "malformed binding must not persist"
+        );
+        assert!(loaded.hotkeys.activate.is_empty(), "unbound stays unbound");
+
+        // A defaults() config must not write any hotkey line.
+        let bare =
+            std::env::temp_dir().join(format!("ic-test-hotkeys-bare-{}.ini", std::process::id()));
+        let _ = std::fs::remove_file(&bare);
+        let mut d = Settings::defaults();
+        d.destinations = loaded.destinations.clone();
+        d.save(&bare).expect("save bare");
+        let text = std::fs::read_to_string(&bare).expect("read bare");
+        assert!(
+            !text.contains("hotkey."),
+            "unbound hotkeys must stay out of the config file"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&bare);
+    }
+
+    #[test]
+    fn midi_signatures_validate_and_route() {
+        assert_eq!(canonicalize_midi("NOTE:1:36").as_deref(), Some("note:1:36"));
+        assert_eq!(
+            canonicalize_midi(" cc : 10 : 20 ").as_deref(),
+            Some("cc:10:20")
+        );
+        assert!(canonicalize_midi("note:0:36").is_none(), "channel below 1");
+        assert!(
+            canonicalize_midi("note:17:36").is_none(),
+            "channel above 16"
+        );
+        assert!(canonicalize_midi("cc:1:128").is_none(), "data above 127");
+        assert!(canonicalize_midi("pitch:1:1").is_none(), "unknown kind");
+        assert!(canonicalize_midi("note:1").is_none(), "missing data");
+        assert!(canonicalize_midi("note:1:1:1").is_none(), "trailing junk");
+
+        let mut m = MidiBindings::default();
+        m.set("toggle", "note:1:36");
+        m.set("cut", "bad-signature");
+        assert_eq!(m.toggle, "note:1:36");
+        assert!(m.cut.is_empty(), "malformed signature must not persist");
+        assert_eq!(m.action_for("note:1:36"), Some("toggle"));
+        assert_eq!(m.action_for("note:1:99"), None);
+        // An empty signature must never match an unbound action.
+        assert_eq!(m.action_for(""), None);
     }
 }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -589,6 +589,12 @@ pub struct Controller {
 
     // In-process log ring (most recent N lines).
     pub logs: crate::sync::Mutex<std::collections::VecDeque<String>>,
+
+    // Shared MIDI state (bindings mirror + learn mode + device list),
+    // driven by the Windows winmm listener thread and read/written by the
+    // web layer. Present on every platform; inert where there is no MIDI
+    // backend (`available` stays false).
+    midi: Arc<crate::midi::MidiState>,
 }
 
 impl Controller {
@@ -645,7 +651,13 @@ impl Controller {
             shutdown_kind: AtomicU8::new(0),
             started: std::time::Instant::now(),
             logs: crate::sync::Mutex::new(std::collections::VecDeque::with_capacity(512)),
+            midi: Arc::new(crate::midi::MidiState::new()),
         }
+    }
+
+    /// Shared MIDI state, for the listener thread and the web endpoints.
+    pub fn midi(&self) -> &Arc<crate::midi::MidiState> {
+        &self.midi
     }
 
     /// Seconds since the process started, for the dashboard uptime readout.
@@ -1060,6 +1072,70 @@ impl Controller {
     /// Drop a pending scheduled cut. No-op if none is pending.
     pub fn cancel_safe_cut(&self) {
         self.safe_cut_input_ts.store(0, Ordering::Relaxed);
+    }
+
+    /// Run a named delay action. Shared by the keyboard hotkeys and MIDI
+    /// bindings so both trigger identical behaviour. `default_ms` is the
+    /// delay armed when starting from nothing; `source` tags the log line
+    /// ("hotkey" / "midi"). Unknown action names are ignored. Every call
+    /// here is atomic-only, so it is safe to invoke straight from an OS
+    /// callback thread with no runtime.
+    ///
+    /// Windows-only today: both callers (the tray hotkeys and the winmm MIDI
+    /// listener) are Windows-only. On other platforms the delay is driven
+    /// through the HTTP endpoints instead.
+    #[cfg(windows)]
+    pub fn run_named_action(&self, action: &str, default_ms: u32, source: &str) {
+        match action {
+            // Toggle: cut to live when a delay is live (or a safe-cut is
+            // pending), otherwise arm at the default delay and go delayed.
+            "toggle" => {
+                if self.target_delay_ms() > 0 || self.safe_cut_pending() {
+                    self.stop_delay();
+                    self.log(format!("[{source}] delay off - cut to live"));
+                } else {
+                    let ms = if self.armed_delay_ms() > 0 {
+                        self.armed_delay_ms()
+                    } else {
+                        default_ms
+                    };
+                    self.arm_delay(ms);
+                    match self.activate_delay() {
+                        Ok(d) => self.log(format!("[{source}] delay on - {} s", d / 1000)),
+                        Err(_) => self.log(format!(
+                            "[{source}] delay arming {} s - goes live once the buffer fills",
+                            ms / 1000
+                        )),
+                    }
+                }
+            }
+            "arm" => {
+                self.arm_delay(default_ms);
+                self.log(format!("[{source}] armed {} s", default_ms / 1000));
+            }
+            "activate" => match self.activate_delay() {
+                Ok(d) => self.log(format!("[{source}] activated - {} s delay", d / 1000)),
+                Err(e) => self.log(format!("[{source}] activate: {}", e.message())),
+            },
+            "cut" => {
+                self.stop_delay();
+                self.log(format!("[{source}] cut to live"));
+            }
+            // Toggle: first press schedules the safe cut, a second cancels
+            // the pending one, so a mistaken press stays reversible.
+            "cut_after" => {
+                if self.safe_cut_pending() {
+                    self.cancel_safe_cut();
+                    self.log(format!("[{source}] cut after this airs - cancelled"));
+                } else {
+                    match self.schedule_safe_cut() {
+                        Ok(_) => self.log(format!("[{source}] cut after this airs - scheduled")),
+                        Err(e) => self.log(format!("[{source}] cut after: {e}")),
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     pub fn safe_cut_pending(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod controller;
 mod crypto;
 mod h264;
 mod https;
+mod midi;
 mod obs_register;
 mod portcheck;
 mod rtmp;
@@ -224,6 +225,9 @@ fn main() -> std::io::Result<()> {
         // startup can never slip in with any key while the mirror is still
         // pending. supervise_egress keeps it in sync on later edits.
         ctrl.update_ingest_key(settings.ingest_key.clone());
+        // Seed the MIDI listener's live view (bindings + default delay)
+        // before it starts, so a mapped controller works from the first tick.
+        ctrl.midi().update_from_settings(&settings);
 
         let (tx, rx) = watch::channel(settings.clone());
         let tx = Arc::new(tx);
@@ -285,6 +289,28 @@ fn main() -> std::io::Result<()> {
         // RTMP URL clipboard action.
         #[cfg(windows)]
         tray::spawn(rx.clone(), ctrl.clone());
+
+        // MIDI listener: a background thread that maps a controller's pads /
+        // knobs to the delay actions. No-op on platforms with no MIDI
+        // backend (the dashboard hides the section there).
+        midi::spawn(ctrl.clone(), ctrl.midi().clone(), rx.clone());
+
+        // Live-apply global hotkey + MIDI edits: every settings change nudges
+        // the tray to re-register its hotkeys and refreshes the MIDI
+        // listener's bindings view, so a combo or mapping set in the
+        // dashboard takes effect without a restart. Cheap and Windows-only,
+        // matching the tray. `changed()` ends only when the sender drops.
+        #[cfg(windows)]
+        {
+            let mut hk_rx = rx.clone();
+            let hk_ctrl = ctrl.clone();
+            tokio::spawn(async move {
+                while hk_rx.changed().await.is_ok() {
+                    hk_ctrl.midi().update_from_settings(&hk_rx.borrow());
+                    tray::request_hotkey_reload();
+                }
+            });
+        }
 
         // Shared dashboard-auth state (sessions + login rate limiter). Created
         // here, not inside the web supervisor, so a web restart (port change)

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -1,0 +1,481 @@
+//! MIDI controller bindings for the delay actions.
+//!
+//! A background thread (Windows, via winmm) listens to every MIDI input
+//! device and turns note-on / control-change "press" edges into signature
+//! strings (`note:ch:n` / `cc:ch:n`). Each signature is matched against the
+//! user's bindings and routed through `Controller::run_named_action`, the
+//! same path the keyboard hotkeys use, so both trigger identical behaviour.
+//!
+//! `MidiState` is cross-platform: it holds the live bindings mirror, the
+//! device list, and the "learn mode" slot the dashboard drives over HTTP.
+//! On a build with no MIDI backend the listener never starts, so
+//! `available` stays false and the dashboard hides the section - exactly
+//! like the keyboard hotkeys on Linux.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::config::{MidiBindings, Settings};
+#[cfg(windows)]
+use crate::controller::Controller;
+
+/// Shared MIDI state between the listener thread and the web layer.
+#[derive(Default)]
+pub struct MidiState {
+    available: AtomicBool,
+    bindings: Mutex<MidiBindings>,
+    devices: Mutex<Vec<String>>,
+    /// The action currently being learned, if any. While set, the next
+    /// incoming message is captured for it instead of being dispatched.
+    learn: Mutex<Option<String>>,
+    /// A just-captured (action, signature) awaiting commit by the web layer.
+    captured: Mutex<Option<(String, String)>>,
+}
+
+impl MidiState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mirror the current bindings into the listener's live match view.
+    pub fn update_from_settings(&self, s: &Settings) {
+        *self.bindings.lock().unwrap() = s.midi.clone();
+    }
+
+    pub fn available(&self) -> bool {
+        self.available.load(Ordering::Relaxed)
+    }
+    #[cfg(windows)]
+    pub fn set_available(&self, v: bool) {
+        self.available.store(v, Ordering::Relaxed);
+    }
+    #[cfg(windows)]
+    pub fn set_devices(&self, names: Vec<String>) {
+        *self.devices.lock().unwrap() = names;
+    }
+    pub fn devices(&self) -> Vec<String> {
+        self.devices.lock().unwrap().clone()
+    }
+
+    pub fn start_learn(&self, action: &str) {
+        *self.learn.lock().unwrap() = Some(action.to_string());
+        *self.captured.lock().unwrap() = None;
+    }
+    pub fn cancel_learn(&self) {
+        *self.learn.lock().unwrap() = None;
+    }
+    pub fn learning(&self) -> Option<String> {
+        self.learn.lock().unwrap().clone()
+    }
+    /// Take a captured (action, signature) if one is waiting. The web layer
+    /// persists it to config, so it is consumed exactly once.
+    pub fn take_captured(&self) -> Option<(String, String)> {
+        self.captured.lock().unwrap().take()
+    }
+
+    /// Called by the listener on each press-edge message. In learn mode it
+    /// records the signature for the pending action; otherwise it routes to
+    /// the bound action via the shared controller path. `default_ms` is the
+    /// delay to arm with, read live by the caller from settings.
+    #[cfg(windows)]
+    pub fn on_signature(&self, ctrl: &Controller, default_ms: u32, signature: &str) {
+        // Learn mode wins: capture and stop, do not also fire an action.
+        {
+            let mut learn = self.learn.lock().unwrap();
+            if let Some(action) = learn.take() {
+                *self.captured.lock().unwrap() = Some((action, signature.to_string()));
+                return;
+            }
+        }
+        let action = self.bindings.lock().unwrap().action_for(signature);
+        if let Some(action) = action {
+            ctrl.run_named_action(action, default_ms, "midi");
+        }
+    }
+
+    /// Runtime snapshot for the dashboard's MIDI poll: whether a device is
+    /// listening, the device names, which action (if any) is learning, and
+    /// the current bindings (so a just-committed one shows without a full
+    /// config refetch).
+    pub fn to_json(&self) -> String {
+        let learning = match self.learning() {
+            Some(a) => json_string(&a),
+            None => "null".to_string(),
+        };
+        let devices: Vec<String> = self.devices().iter().map(|d| json_string(d)).collect();
+        let bindings = {
+            let b = self.bindings.lock().unwrap();
+            format!(
+                r#"{{"toggle":{t},"arm":{a},"activate":{ac},"cut":{c},"cut_after":{ca}}}"#,
+                t = json_string(&b.toggle),
+                a = json_string(&b.arm),
+                ac = json_string(&b.activate),
+                c = json_string(&b.cut),
+                ca = json_string(&b.cut_after),
+            )
+        };
+        format!(
+            r#"{{"available":{a},"learning":{l},"devices":[{d}],"bindings":{b}}}"#,
+            a = self.available(),
+            l = learning,
+            d = devices.join(","),
+            b = bindings,
+        )
+    }
+}
+
+/// Minimal JSON string escaper. Device names come from the driver and can
+/// carry any character, so quotes / backslashes / control chars are escaped.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Turn a raw MIDI message (status, data1, data2) into a binding signature,
+/// or None when it is not a "press" edge we act on. Note-on with velocity 0
+/// is a note-off in disguise and is ignored; a control-change only counts as
+/// a press at value >= 64, so a button's release (0) never double-fires.
+#[cfg(any(windows, test))]
+fn signature_for(status: u8, data1: u8, data2: u8) -> Option<String> {
+    let channel = (status & 0x0F) as u32 + 1;
+    match status & 0xF0 {
+        0x90 if data2 > 0 => Some(format!("note:{channel}:{data1}")),
+        0xB0 if data2 >= 64 => Some(format!("cc:{channel}:{data1}")),
+        _ => None,
+    }
+}
+
+/// Spawn the MIDI listener. Windows opens every input device via winmm;
+/// other platforms have no backend yet, so this is a no-op and `available`
+/// stays false (the dashboard then hides the MIDI section). The settings
+/// receiver lets the listener read the current default delay when a mapped
+/// action fires.
+#[cfg(windows)]
+pub fn spawn(
+    ctrl: Arc<Controller>,
+    state: Arc<MidiState>,
+    settings: tokio::sync::watch::Receiver<Settings>,
+) {
+    std::thread::Builder::new()
+        .name("instantclone-midi".into())
+        .spawn(move || win::run(ctrl, state, settings))
+        .ok();
+}
+
+#[cfg(not(windows))]
+pub fn spawn(
+    _ctrl: Arc<crate::controller::Controller>,
+    _state: Arc<MidiState>,
+    _settings: tokio::sync::watch::Receiver<Settings>,
+) {
+}
+
+#[cfg(windows)]
+mod win {
+    use super::{signature_for, MidiState};
+    use crate::config::Settings;
+    use crate::controller::Controller;
+    use std::sync::Arc;
+    use tokio::sync::watch;
+    use windows_sys::Win32::Media::Audio::{
+        midiInClose, midiInGetDevCapsW, midiInGetNumDevs, midiInOpen, midiInReset, midiInStart,
+        midiInStop, CALLBACK_FUNCTION, HMIDIIN, MIDIINCAPSW,
+    };
+
+    // Stable winmm constants that windows-sys does not re-export.
+    const MMSYSERR_NOERROR: u32 = 0;
+    const MIM_DATA: u32 = 0x3C3;
+
+    /// Passed to every open device as the callback instance. Leaked for the
+    /// process lifetime (the listener thread never exits in normal running),
+    /// so the pointer handed to winmm always stays valid.
+    struct CallbackCtx {
+        ctrl: Arc<Controller>,
+        state: Arc<MidiState>,
+        settings: watch::Receiver<Settings>,
+    }
+
+    pub fn run(ctrl: Arc<Controller>, state: Arc<MidiState>, settings: watch::Receiver<Settings>) {
+        let ctx: &'static CallbackCtx = Box::leak(Box::new(CallbackCtx {
+            ctrl,
+            state,
+            settings,
+        }));
+        let instance = ctx as *const CallbackCtx as usize;
+
+        let mut handles: Vec<HMIDIIN> = Vec::new();
+        let mut last_count = u32::MAX;
+        loop {
+            let count = unsafe { midiInGetNumDevs() };
+            // Reconcile only when the device count changes: winmm gives no
+            // hot-plug event, so a periodic count check is the cheap way to
+            // pick up a controller plugged in (or pulled out) mid-session.
+            if count != last_count {
+                close_all(&mut handles);
+                let names = open_all(count, instance, &mut handles);
+                ctx.state.set_devices(names);
+                ctx.state.set_available(!handles.is_empty());
+                last_count = count;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
+    }
+
+    /// Open and start every input device, returning their names. Devices
+    /// that fail to open are skipped (another app may hold them exclusively).
+    fn open_all(count: u32, instance: usize, handles: &mut Vec<HMIDIIN>) -> Vec<String> {
+        let mut names = Vec::new();
+        for dev in 0..count {
+            let mut h: HMIDIIN = std::ptr::null_mut();
+            let r = unsafe {
+                midiInOpen(
+                    &mut h,
+                    dev,
+                    midi_in_proc as *const () as usize,
+                    instance,
+                    CALLBACK_FUNCTION,
+                )
+            };
+            if r != MMSYSERR_NOERROR || h.is_null() {
+                continue;
+            }
+            if unsafe { midiInStart(h) } != MMSYSERR_NOERROR {
+                unsafe { midiInClose(h) };
+                continue;
+            }
+            names.push(device_name(dev));
+            handles.push(h);
+        }
+        names
+    }
+
+    fn close_all(handles: &mut Vec<HMIDIIN>) {
+        for h in handles.drain(..) {
+            unsafe {
+                midiInStop(h);
+                midiInReset(h);
+                midiInClose(h);
+            }
+        }
+    }
+
+    /// Read a device's display name from its caps, trimmed at the NUL.
+    fn device_name(dev: u32) -> String {
+        let mut caps: MIDIINCAPSW = unsafe { std::mem::zeroed() };
+        let r = unsafe {
+            midiInGetDevCapsW(
+                dev as usize,
+                &mut caps,
+                std::mem::size_of::<MIDIINCAPSW>() as u32,
+            )
+        };
+        if r != MMSYSERR_NOERROR {
+            return format!("MIDI device {dev}");
+        }
+        // MIDIINCAPSW is #[repr(packed)], so the name field can't be
+        // borrowed directly; copy it out unaligned into an owned array first.
+        let name: [u16; 32] = unsafe { std::ptr::read_unaligned(std::ptr::addr_of!(caps.szPname)) };
+        let end = name.iter().position(|&c| c == 0).unwrap_or(name.len());
+        String::from_utf16_lossy(&name[..end])
+    }
+
+    /// winmm callback. Runs on a system thread; keeps work minimal (parse +
+    /// a couple of short mutex holds). Only MIM_DATA carries a channel-voice
+    /// message; dwParam1 packs status / data1 / data2 in its low three bytes.
+    unsafe extern "system" fn midi_in_proc(
+        _hmi: HMIDIIN,
+        msg: u32,
+        instance: usize,
+        param1: usize,
+        _param2: usize,
+    ) {
+        if msg != MIM_DATA || instance == 0 {
+            return;
+        }
+        let status = (param1 & 0xFF) as u8;
+        let data1 = ((param1 >> 8) & 0x7F) as u8;
+        let data2 = ((param1 >> 16) & 0x7F) as u8;
+        let Some(sig) = signature_for(status, data1, data2) else {
+            return;
+        };
+        let ctx = &*(instance as *const CallbackCtx);
+        // Read the default delay live so a mid-session change in the
+        // dashboard is reflected without restarting the listener.
+        let default_ms = ctx.settings.borrow().auto_arm_delay_ms;
+        ctx.state.on_signature(&ctx.ctrl, default_ms, &sig);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::signature_for;
+    #[cfg(windows)]
+    use super::MidiState;
+
+    #[test]
+    fn note_on_and_cc_press_edges_map_to_signatures() {
+        // Note-on ch1 (0x90), note 36, velocity 100.
+        assert_eq!(signature_for(0x90, 36, 100).as_deref(), Some("note:1:36"));
+        // Channel is encoded in the low nibble: 0x9F = channel 16.
+        assert_eq!(signature_for(0x9F, 60, 1).as_deref(), Some("note:16:60"));
+        // Control change ch1, controller 20, value 127 (pressed).
+        assert_eq!(signature_for(0xB0, 20, 127).as_deref(), Some("cc:1:20"));
+    }
+
+    #[test]
+    fn releases_and_other_messages_are_ignored() {
+        assert!(
+            signature_for(0x90, 36, 0).is_none(),
+            "note-on vel 0 = release"
+        );
+        assert!(signature_for(0x80, 36, 100).is_none(), "note-off ignored");
+        assert!(signature_for(0xB0, 20, 0).is_none(), "cc release ignored");
+        assert!(signature_for(0xB0, 20, 63).is_none(), "cc below threshold");
+        assert!(signature_for(0xE0, 0, 0).is_none(), "pitch bend ignored");
+    }
+
+    // Build a real Controller backed by a temp ring, so the dispatch below
+    // exercises the same code the live app runs.
+    #[cfg(windows)]
+    fn test_controller() -> (
+        std::sync::Arc<crate::controller::Controller>,
+        std::path::PathBuf,
+    ) {
+        let path = std::env::temp_dir().join(format!(
+            "ic-test-midi-ctrl-{}-{}.buf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let ring = std::sync::Arc::new(
+            crate::buffer::DiskRing::create(&path, 4 * 1024 * 1024).expect("ring create"),
+        );
+        (
+            std::sync::Arc::new(crate::controller::Controller::new(ring, 0)),
+            path,
+        )
+    }
+
+    /// Full simulated MIDI note: the exact bytes winmm delivers for a pad
+    /// press, fed through signature_for -> on_signature -> the controller,
+    /// asserting the bound action actually fires. This is everything past
+    /// the OS driver, i.e. the whole app-owned MIDI path.
+    #[cfg(windows)]
+    #[test]
+    fn simulated_note_fires_the_bound_action() {
+        let (ctrl, path) = test_controller();
+        let state = MidiState::new();
+
+        // Map "arm" to note 36 on channel 1, the way the learn UI would.
+        let mut s = crate::config::Settings::defaults();
+        s.midi.set("arm", "note:1:36");
+        state.update_from_settings(&s);
+
+        assert_eq!(ctrl.armed_delay_ms(), 0, "nothing armed before the note");
+
+        // Simulate the winmm callback: note-on ch1 note36 velocity100.
+        let sig = signature_for(0x90, 36, 100).expect("a press edge");
+        assert_eq!(sig, "note:1:36");
+        state.on_signature(&ctrl, 15_000, &sig);
+
+        assert_eq!(
+            ctrl.armed_delay_ms(),
+            15_000,
+            "a mapped MIDI note must arm the delay at the default"
+        );
+
+        // A note that is NOT mapped must do nothing.
+        let other = signature_for(0x90, 40, 100).expect("a press edge");
+        ctrl.stop_delay();
+        state.on_signature(&ctrl, 15_000, &other);
+        // (arm stays as-is; the unmapped note fired no action.)
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Full on/off/schedule sequence driven entirely by simulated MIDI
+    /// messages against a buffer-filled controller, proving the mapped
+    /// actions produce the right delay-state transitions.
+    #[cfg(windows)]
+    #[test]
+    fn simulated_notes_drive_toggle_and_scheduled_cut() {
+        let (ctrl, path) = test_controller();
+        let state = MidiState::new();
+        let mut s = crate::config::Settings::defaults();
+        s.midi.set("toggle", "note:1:36");
+        s.midi.set("cut_after", "cc:2:20");
+        state.update_from_settings(&s);
+
+        // Pre-fill the ring with ~3 s of fake video (IDR at each second) so a
+        // 1 s toggle can actually activate, mirroring a live OBS feed.
+        for sec in 0..3u32 {
+            for f in 0..30u32 {
+                let ts = sec * 1000 + f * 33;
+                let is_idr = f == 0;
+                let payload = [if is_idr { 0x17u8 } else { 0x27u8 }; 50];
+                ctrl.on_tag(9, ts, &payload, is_idr, false);
+            }
+        }
+        let note = signature_for(0x90, 36, 100).unwrap(); // pad, ch1 note36
+        let knob = signature_for(0xB1, 20, 127).unwrap(); // knob, ch2 cc20
+
+        // Toggle -> delay on.
+        state.on_signature(&ctrl, 1_000, &note);
+        assert_eq!(ctrl.target_delay_ms(), 1_000, "toggle turned the delay on");
+
+        // Cut-after -> scheduled; press again -> cancelled.
+        state.on_signature(&ctrl, 1_000, &knob);
+        assert!(ctrl.safe_cut_pending(), "knob scheduled the safe cut");
+        state.on_signature(&ctrl, 1_000, &knob);
+        assert!(!ctrl.safe_cut_pending(), "knob again cancelled it");
+
+        // Toggle -> delay off.
+        state.on_signature(&ctrl, 1_000, &note);
+        assert_eq!(ctrl.target_delay_ms(), 0, "toggle turned the delay off");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// In learn mode the same simulated note is captured for the pending
+    /// action and does NOT fire anything.
+    #[cfg(windows)]
+    #[test]
+    fn learn_captures_the_note_without_firing() {
+        let (ctrl, path) = test_controller();
+        let state = MidiState::new();
+
+        state.start_learn("toggle");
+        let sig = signature_for(0xB0, 20, 127).expect("cc press");
+        state.on_signature(&ctrl, 15_000, &sig);
+
+        assert_eq!(
+            state.take_captured(),
+            Some(("toggle".to_string(), "cc:1:20".to_string())),
+            "learn must capture the pressed control"
+        );
+        assert_eq!(state.learning(), None, "learn clears after one capture");
+        assert_eq!(
+            ctrl.target_delay_ms(),
+            0,
+            "capturing must not also fire the action"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -20,11 +20,12 @@
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr;
+use std::sync::atomic::{AtomicIsize, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use crate::config::Settings;
+use crate::config::{self, Settings};
 use crate::controller::Controller;
 
 use windows_sys::Win32::Foundation::{GlobalFree, HANDLE, HWND, LPARAM, LRESULT, POINT, WPARAM};
@@ -34,6 +35,9 @@ use windows_sys::Win32::System::DataExchange::{
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows_sys::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
 use windows_sys::Win32::System::Ole::CF_UNICODETEXT;
+use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+    RegisterHotKey, UnregisterHotKey, MOD_NOREPEAT,
+};
 use windows_sys::Win32::UI::Shell::{
     Shell_NotifyIconW, NIF_ICON, NIF_MESSAGE, NIF_TIP, NIM_ADD, NIM_DELETE, NOTIFYICONDATAW,
 };
@@ -45,10 +49,32 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     TranslateMessage, GWLP_USERDATA, HMENU, IDI_APPLICATION, IDYES, LR_DEFAULTCOLOR,
     MB_ICONWARNING, MB_YESNO, MF_DISABLED, MF_GRAYED, MF_SEPARATOR, MF_STRING, MSG, SM_CXSMICON,
     SM_CYSMICON, TPM_BOTTOMALIGN, TPM_LEFTALIGN, TPM_RIGHTBUTTON, WM_APP, WM_COMMAND, WM_DESTROY,
-    WM_LBUTTONUP, WM_RBUTTONUP, WNDCLASSW,
+    WM_HOTKEY, WM_LBUTTONUP, WM_RBUTTONUP, WNDCLASSW,
 };
 
 const TRAY_MSG: u32 = WM_APP + 1;
+// Posted (from any thread) to ask the message loop to re-read hotkey
+// bindings from settings and re-register them - the live-apply path when
+// the user edits a binding in the dashboard.
+const HOTKEY_RELOAD_MSG: u32 = WM_APP + 2;
+
+// Global-hotkey action table: (RegisterHotKey id, config action name).
+// The id is echoed back in WM_HOTKEY's wParam; the action name is the one
+// `Hotkeys::entries` uses, so the two stay in lockstep. Ids start at 1
+// (RegisterHotKey rejects 0 for an application hotkey).
+const HOTKEY_ACTIONS: [(i32, &str); 5] = [
+    (1, "toggle"),
+    (2, "arm"),
+    (3, "activate"),
+    (4, "cut"),
+    (5, "cut_after"),
+];
+
+/// The tray window handle, published once the message-only window exists so
+/// the tokio side can post `HOTKEY_RELOAD_MSG` to it. 0 means "not up yet",
+/// in which case a reload request is a safe no-op.
+static TRAY_HWND: AtomicIsize = AtomicIsize::new(0);
+
 // Menu item IDs. Kept above 0x100 so they can't collide with system IDs.
 const ID_OPEN_DASH: usize = 0x101;
 const ID_OPEN_DOCK: usize = 0x102;
@@ -162,6 +188,11 @@ fn run(
             return Err("Shell_NotifyIconW(NIM_ADD) failed".into());
         }
 
+        // Publish the handle so `request_hotkey_reload` can post to us, then
+        // bind whatever hotkeys the user already has configured.
+        TRAY_HWND.store(hwnd as isize, Ordering::Release);
+        register_hotkeys(hwnd);
+
         // Message loop until WM_QUIT (PostQuitMessage from the Quit handler
         // or DefWindowProc on WM_DESTROY).
         let mut msg: MSG = std::mem::zeroed();
@@ -170,6 +201,10 @@ fn run(
             DispatchMessageW(&msg);
         }
 
+        // Tear down in reverse: stop the OS from routing hotkeys to a window
+        // we're about to destroy, then drop the tray icon and state.
+        TRAY_HWND.store(0, Ordering::Release);
+        unregister_hotkeys(hwnd);
         Shell_NotifyIconW(NIM_DELETE, &nid);
 
         // Reclaim and drop the TrayState.
@@ -220,6 +255,22 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
             if ev == WM_LBUTTONUP || ev == WM_RBUTTONUP {
                 show_menu(hwnd);
             }
+            0
+        }
+        // Global hotkey fired. wParam is the RegisterHotKey id from the
+        // action table; run the matching delay action straight on the
+        // controller (atomic stores, no runtime needed).
+        WM_HOTKEY => {
+            let state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut TrayState;
+            if !state_ptr.is_null() {
+                dispatch_hotkey(&*state_ptr, wp as i32);
+            }
+            0
+        }
+        // Live re-apply: the user edited a binding in the dashboard.
+        HOTKEY_RELOAD_MSG => {
+            unregister_hotkeys(hwnd);
+            register_hotkeys(hwnd);
             0
         }
         // Menu selection.
@@ -288,6 +339,71 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LPARAM)
         }
         _ => DefWindowProcW(hwnd, msg, wp, lp),
     }
+}
+
+/// Ask the tray's message loop to re-read hotkey bindings and re-register
+/// them. Called from the tokio side after a settings change. Safe no-op
+/// until the tray window exists (TRAY_HWND still 0) - the initial bind
+/// happens in `run` regardless.
+pub fn request_hotkey_reload() {
+    let hwnd = TRAY_HWND.load(Ordering::Acquire);
+    if hwnd != 0 {
+        // SAFETY: PostMessageW is thread-safe; a stale handle (window torn
+        // down between the load and the post) is handled by the OS, which
+        // just fails the post. TRAY_HWND is set back to 0 before teardown.
+        unsafe {
+            PostMessageW(hwnd as HWND, HOTKEY_RELOAD_MSG, 0, 0);
+        }
+    }
+}
+
+/// (Re)register every configured hotkey against the tray window. Unbound
+/// or malformed entries are skipped; a combo another app already owns logs
+/// a friendly line rather than failing silently, so the user knows why a
+/// key does nothing.
+unsafe fn register_hotkeys(hwnd: HWND) {
+    let state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut TrayState;
+    if state_ptr.is_null() {
+        return;
+    }
+    let state = &*state_ptr;
+    // Clone so we don't hold the watch borrow across the log calls below.
+    let hotkeys = state.settings.borrow().hotkeys.clone();
+    for (i, (action, combo)) in hotkeys.entries().into_iter().enumerate() {
+        if combo.is_empty() {
+            continue;
+        }
+        let Some((mods, vk)) = config::parse_hotkey(combo) else {
+            continue;
+        };
+        let id = (i + 1) as i32;
+        // MOD_NOREPEAT so holding the combo fires once, not on autorepeat.
+        if RegisterHotKey(hwnd, id, mods | MOD_NOREPEAT, vk) == 0 {
+            state.ctrl.log(format!(
+                "[hotkey] {combo} is already in use by another app - {action} not bound"
+            ));
+        }
+    }
+}
+
+/// Drop every hotkey registration. Unregistering an id that was never
+/// registered is harmless, so this can run unconditionally on reload and
+/// teardown.
+unsafe fn unregister_hotkeys(hwnd: HWND) {
+    for (id, _) in HOTKEY_ACTIONS {
+        UnregisterHotKey(hwnd, id);
+    }
+}
+
+/// Run the delay action bound to a fired hotkey. The RegisterHotKey id maps
+/// back to an action name via `HOTKEY_ACTIONS`; the shared controller method
+/// carries the semantics (identical to the MIDI path).
+fn dispatch_hotkey(state: &TrayState, id: i32) {
+    let Some((_, action)) = HOTKEY_ACTIONS.iter().find(|(hid, _)| *hid == id) else {
+        return;
+    };
+    let default_ms = state.settings.borrow().auto_arm_delay_ms;
+    state.ctrl.run_named_action(action, default_ms, "hotkey");
 }
 
 /// Modal Yes/No shown when the user hits Quit while OBS is publishing.

--- a/src/web.rs
+++ b/src/web.rs
@@ -1036,6 +1036,11 @@ async fn route(
         ("POST", "/go-live") => post_stop(ctrl, settings, cfg_path, sysstat).await,
         ("POST", "/cut-after") => post_cut_after(ctrl, settings, sysstat).await,
         ("POST", "/cut-after/cancel") => post_cut_after_cancel(ctrl, settings, sysstat).await,
+        // MIDI mapping (Windows). Learn mode is server-side because the MIDI
+        // events arrive at the backend, not the browser; the dashboard polls.
+        ("POST", "/midi/learn") => post_midi_learn(body, ctrl).await,
+        ("POST", "/midi/learn/cancel") => post_midi_learn_cancel(ctrl).await,
+        ("POST", "/midi/poll") => post_midi_poll(ctrl, settings, cfg_path).await,
         ("POST", "/test-egress") => test_egress(settings).await,
         ("POST", "/test-webhook") => post_test_webhook(ctrl).await,
         ("POST", "/logs/clear") => {
@@ -2114,7 +2119,8 @@ async fn post_config(
                 | "auto_arm_delay_ms"
                 | "update_check_enabled"
                 | "open_dashboard_on_launch"
-        ) {
+        ) || k.starts_with("hotkey.")
+        {
             apply_field_str(&mut new_settings, k, v);
         }
     }
@@ -2484,6 +2490,65 @@ async fn post_cut_after_cancel(
         "application/json",
         state_json(ctrl, settings, sysstat),
     )
+}
+
+// ---- MIDI mapping ----
+//
+// The listener thread (see crate::midi) receives controller messages and,
+// in learn mode, captures the next one for a chosen action. Because those
+// events land at the backend, the whole learn flow is server-side and the
+// dashboard drives it over these routes.
+
+/// Arm learn mode for one action: the next MIDI press is captured for it.
+async fn post_midi_learn(
+    body: &str,
+    ctrl: &Arc<Controller>,
+) -> (&'static str, &'static str, String) {
+    let form = config::parse_form(body);
+    let action = form.get("action").map(String::as_str).unwrap_or("");
+    if !matches!(action, "toggle" | "arm" | "activate" | "cut" | "cut_after") {
+        return (
+            "400 Bad Request",
+            "application/json",
+            r#"{"ok":false,"error":"unknown action"}"#.into(),
+        );
+    }
+    if !ctrl.midi().available() {
+        return (
+            "409 Conflict",
+            "application/json",
+            r#"{"ok":false,"error":"No MIDI device detected. Connect a controller and try again."}"#
+                .into(),
+        );
+    }
+    ctrl.midi().start_learn(action);
+    ("200 OK", "application/json", r#"{"ok":true}"#.into())
+}
+
+/// Drop a pending learn without binding anything.
+async fn post_midi_learn_cancel(ctrl: &Arc<Controller>) -> (&'static str, &'static str, String) {
+    ctrl.midi().cancel_learn();
+    ("200 OK", "application/json", r#"{"ok":true}"#.into())
+}
+
+/// Poll during learn: commit a freshly-captured binding (through the same
+/// guarded save path the settings form uses) and return the runtime state
+/// the dashboard renders (device availability, names, and what is learning).
+async fn post_midi_poll(
+    ctrl: &Arc<Controller>,
+    settings: &Arc<watch::Sender<Settings>>,
+    cfg_path: &Path,
+) -> (&'static str, &'static str, String) {
+    if let Some((action, signature)) = ctrl.midi().take_captured() {
+        let _wl = settings_write_guard();
+        let mut new_settings = settings.borrow().clone();
+        new_settings.midi.set(&action, &signature);
+        if new_settings.save(cfg_path).is_ok() {
+            ctrl.midi().update_from_settings(&new_settings);
+            let _ = settings.send(new_settings);
+        }
+    }
+    ("200 OK", "application/json", ctrl.midi().to_json())
 }
 
 fn persist_delay_state(
@@ -3569,6 +3634,11 @@ fn apply_field_str(s: &mut Settings, key: &str, value: &str) {
         }
         "open_dashboard_on_launch" => {
             s.open_dashboard_on_launch = !matches!(value, "" | "false" | "0" | "off");
+        }
+        // hotkey.<action>=<combo>. `set` canonicalizes and drops anything
+        // malformed, so an empty or bad value simply clears the binding.
+        k if k.starts_with("hotkey.") => {
+            s.hotkeys.set(&k["hotkey.".len()..], value);
         }
         _ => {}
     }

--- a/web/index.html
+++ b/web/index.html
@@ -1718,6 +1718,61 @@ details.sys-collapse>summary .ic-label{margin:0}
 @media (prefers-contrast: more){
   :root{--line:rgba(255,255,255,.24);--line-2:rgba(255,255,255,.40);--fg-4:oklch(0.63 0.018 230)}
 }
+/* ── Global hotkeys editor ─────────────────────────────────────────────
+   A capture field per action: click to record, press a modifier+key combo,
+   it commits and saves. Chips render the bound combo; the recording and
+   invalid states carry the whole affordance so no copy is needed. */
+.hk-list{margin-top:14px;display:flex;flex-direction:column;gap:10px}
+.hk-row{display:flex;align-items:center;gap:16px}
+.hk-row-main{flex:1;min-width:0}
+.hk-row-title{font-weight:600}
+.hk-row-sub{margin-top:2px}
+.hk-capture{
+  flex:0 0 auto;min-width:168px;min-height:38px;display:inline-flex;
+  align-items:center;justify-content:center;gap:7px;padding:7px 12px;
+  border:1px solid var(--line-2);border-radius:var(--radius-sm);
+  background:var(--surface-3,rgba(255,255,255,.04));color:var(--fg-2);
+  font:inherit;cursor:pointer;user-select:none;
+  transition:border-color .18s var(--ease-out),background .18s var(--ease-out),
+    box-shadow .18s var(--ease-out),transform .12s var(--ease-spring);
+}
+.hk-capture:hover{border-color:var(--accent);color:var(--fg)}
+.hk-capture:focus-visible{outline:none;border-color:var(--accent);
+  box-shadow:0 0 0 3px var(--accent-glow)}
+.hk-capture.recording{border-color:var(--accent);color:var(--fg);
+  background:color-mix(in oklch,var(--accent) 10%,transparent);
+  box-shadow:0 0 0 3px var(--accent-glow);animation:hk-pulse 1.4s var(--ease-out) infinite}
+.hk-capture.invalid{border-color:var(--danger);animation:hk-shake .32s var(--ease-out)}
+.hk-capture.empty{color:var(--fg-4);font-size:13px}
+.hk-chip{display:inline-flex;align-items:center;justify-content:center;
+  min-width:22px;height:24px;padding:0 7px;border-radius:6px;
+  border:1px solid var(--line-2);border-bottom-width:2px;
+  background:color-mix(in oklch,#fff 7%,var(--surface-3,transparent));
+  color:var(--fg);font-family:ui-monospace,'SF Mono',Menlo,monospace;
+  font-size:12px;font-weight:600;line-height:1}
+.hk-sep{color:var(--fg-4);font-size:11px;font-weight:600}
+.hk-cue{color:var(--fg-3);font-size:12.5px;letter-spacing:.2px}
+.hk-clear{flex:0 0 auto;width:30px;height:30px;display:inline-flex;
+  align-items:center;justify-content:center;border:none;border-radius:8px;
+  background:transparent;color:var(--fg-4);cursor:pointer;font-size:17px;line-height:1;
+  transition:background .15s var(--ease-out),color .15s var(--ease-out),opacity .15s}
+.hk-clear:hover{background:color-mix(in oklch,var(--danger) 16%,transparent);color:var(--danger)}
+.hk-clear[hidden]{display:none}
+.hk-warn{margin-top:10px;color:var(--warn);font-size:12.5px;min-height:1.1em}
+.hk-note{margin-top:10px;color:var(--fg-3);font-size:12.5px}
+@keyframes hk-pulse{0%,100%{box-shadow:0 0 0 3px var(--accent-glow)}
+  50%{box-shadow:0 0 0 5px var(--accent-glow)}}
+@keyframes hk-shake{0%,100%{transform:translateX(0)}
+  20%{transform:translateX(-5px)}40%{transform:translateX(5px)}
+  60%{transform:translateX(-3px)}80%{transform:translateX(3px)}}
+@media (prefers-reduced-motion: reduce){
+  .hk-capture.recording{animation:none}
+  .hk-capture.invalid{animation:none}
+}
+@media (max-width:560px){
+  .hk-row{flex-wrap:wrap;gap:8px}
+  .hk-capture{min-width:0;flex:1}
+}
 </style>
 </head>
 <body>
@@ -2592,6 +2647,25 @@ details.sys-collapse>summary .ic-label{margin:0}
       </div>
     </section>
 
+    <!-- Global hotkeys. Windows-only (RegisterHotKey from the tray); the
+         whole section stays hidden until loadConfig confirms the platform. -->
+    <section class="sys-section" id="s-hotkeys-section" hidden>
+      <div class="ic-label">Global hotkeys</div>
+      <div class="tab-sub">Drive the delay from anywhere, even mid-game with OBS in the background. Click a field and press your combo. Each needs a modifier (Ctrl, Alt, Shift or Win) so it can never fire by accident.</div>
+      <div class="hk-list" id="hk-list"></div>
+      <div class="hk-warn" id="hk-warn" role="status" aria-live="polite"></div>
+    </section>
+
+    <!-- MIDI controller mapping. Windows-only; learn mode is server-side
+         (the MIDI events arrive at the backend) so the dashboard polls. -->
+    <section class="sys-section" id="s-midi-section" hidden>
+      <div class="ic-label">MIDI controller</div>
+      <div class="tab-sub">Map a pad or knob to each action. Click Learn, then press the control you want. Works while gaming, just like the hotkeys.</div>
+      <div class="hk-note" id="midi-note" hidden></div>
+      <div class="hk-list" id="midi-list"></div>
+      <div class="hk-warn" id="midi-warn" role="status" aria-live="polite"></div>
+    </section>
+
     <!-- Twitch VOD audio via the optional unlocker script. Surfaced here so
          a streamer can grab it without opening a destination's settings. -->
     <section class="sys-section">
@@ -2964,6 +3038,10 @@ details.sys-collapse>summary .ic-label{margin:0}
 'use strict';
 const $ = id => document.getElementById(id);
 const $$ = sel => Array.from(document.querySelectorAll(sel));
+// Escape text bound for innerHTML. Used by the hotkeys editor; values there
+// are already constrained, so this is belt-and-braces against future callers.
+const escAttr = s => String(s == null ? '' : s).replace(/[&<>"']/g,
+  c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
 // - State ------------------------------─
 let lastState = null;
@@ -4450,6 +4528,31 @@ async function loadConfig(){
     $('s-auto-arm').checked = !!c.auto_arm_on_connect;
     $('s-auto-act').checked = !!c.auto_activate_when_ready;
     $('s-auto-arm-secs').value = Math.round((c.auto_arm_delay_ms || 15000) / 1000);
+    // Global hotkeys: Windows-only, so the whole section stays hidden
+    // elsewhere. A pending recording is cancelled before a re-render so
+    // stale listeners never outlive the DOM they were bound to.
+    if ($('s-hotkeys-section')){
+      if (c.os === 'windows'){
+        if (hkRec) hkCancelRecording();
+        hkBindings = Object.assign({toggle:'',arm:'',activate:'',cut:'',cut_after:''}, c.hotkeys || {});
+        $('s-hotkeys-section').hidden = false;
+        hkRenderList();
+      } else {
+        $('s-hotkeys-section').hidden = true;
+      }
+    }
+    // MIDI mapping: Windows-only, same gating as the hotkeys. A one-off
+    // poll fills in device availability; learn mode is driven separately.
+    if ($('s-midi-section')){
+      if (c.os === 'windows'){
+        if (midiLearnAction) midiCancelLearn();
+        midiBindings = Object.assign({toggle:'',arm:'',activate:'',cut:'',cut_after:''}, c.midi || {});
+        $('s-midi-section').hidden = false;
+        midiInit();
+      } else {
+        $('s-midi-section').hidden = true;
+      }
+    }
     // OBS panel
     $('obs-srv').textContent = c.obs_url;
     if ($('wiz-obs-srv')) $('wiz-obs-srv').textContent = c.obs_url;
@@ -5390,6 +5493,347 @@ async function testWebhook(){
   const r = await(await fetch('/test-webhook',{method:'POST'})).json();
   if (r.ok) toast('Webhook test fired - check Discord','ok');
   else toast(`Webhook test failed: ${r.error || 'no response from Discord'}`, 'err');
+}
+
+// ── Global hotkeys editor (Windows only) ───────────────────────────────
+// Click a capture field, press a modifier+key combo, and it commits and
+// saves instantly. Chips render the current binding; recording and invalid
+// states carry the whole affordance. Order here is display-only (most-used
+// first) and independent of the server-side action ids.
+const HOTKEY_ACTIONS = [
+  ['toggle',    'Toggle delay',        'Go delayed when live, cut to live when delayed. One key, on and off.'],
+  ['activate',  'Activate delay',      'Switch the armed delay on.'],
+  ['cut',       'Cut to live',         'Drop back to live, keeping the buffer armed for an instant re-activate.'],
+  ['arm',       'Arm buffer',          'Start filling the buffer at your default delay.'],
+  ['cut_after', 'Cut after this airs', 'Press once to schedule a cut the instant the live edge reaches every viewer; press again to cancel it.'],
+];
+let hkBindings = {toggle:'',arm:'',activate:'',cut:'',cut_after:''};
+let hkRec = null; // {action, el} while recording, else null
+let hkWarnTimer = null;
+
+const hkTitleOf = a => (HOTKEY_ACTIONS.find(x => x[0] === a) || [,''])[1];
+
+// Named keys beyond letters/digits/F-keys, keyed by KeyboardEvent.code and
+// mapped to the exact tokens the server's NAMED_KEYS table expects.
+const HK_CODE_MAP = {
+  Space:'Space', Tab:'Tab', Escape:'Esc', Enter:'Enter', NumpadEnter:'Enter', Backspace:'Backspace',
+  ArrowLeft:'Left', ArrowRight:'Right', ArrowUp:'Up', ArrowDown:'Down',
+  PageUp:'PageUp', PageDown:'PageDown', End:'End', Home:'Home', Insert:'Insert', Delete:'Delete',
+  NumpadMultiply:'NumMultiply', NumpadAdd:'NumAdd', NumpadSubtract:'NumSubtract',
+  NumpadDecimal:'NumDecimal', NumpadDivide:'NumDivide',
+};
+// Physical-key name from a KeyboardEvent.code, mirroring the server's
+// key_to_vk: letters, digits, F1-F24, numpad and the nav cluster.
+// Modifiers and everything else -> null.
+function hkMainKey(code){
+  let m;
+  if ((m = /^Key([A-Z])$/.exec(code))) return m[1];
+  if ((m = /^Digit([0-9])$/.exec(code))) return m[1];
+  if ((m = /^Numpad([0-9])$/.exec(code))) return 'Numpad' + m[1];
+  if ((m = /^F([1-9]|1[0-9]|2[0-4])$/.exec(code))) return 'F' + m[1];
+  return HK_CODE_MAP[code] || null;
+}
+// Fixed modifier order matches the server's canonical form.
+function hkMods(e){
+  const m = [];
+  if (e.ctrlKey) m.push('Ctrl');
+  if (e.altKey) m.push('Alt');
+  if (e.shiftKey) m.push('Shift');
+  if (e.metaKey) m.push('Win');
+  return m;
+}
+
+function hkSetWarn(msg){
+  const w = $('hk-warn'); if (!w) return;
+  w.textContent = msg || '';
+  clearTimeout(hkWarnTimer);
+  if (msg) hkWarnTimer = setTimeout(() => { if ($('hk-warn')) $('hk-warn').textContent = ''; }, 4000);
+}
+
+// Paint a capture field: chips for a bound combo, a cue when unbound.
+function hkRenderCapture(el, action){
+  const combo = hkBindings[action] || '';
+  el.classList.remove('recording','invalid');
+  if (!combo){
+    el.classList.add('empty');
+    el.innerHTML = '<span class="hk-cue">Click to set</span>';
+    el.setAttribute('aria-label', hkTitleOf(action) + ': no hotkey set, click to set one');
+    return;
+  }
+  el.classList.remove('empty');
+  const parts = combo.split('+');
+  el.innerHTML = parts.map(p =>
+    `<span class="hk-chip">${escAttr(p)}</span>`).join('<span class="hk-sep">+</span>');
+  el.setAttribute('aria-label', hkTitleOf(action) + ': ' + parts.join(' ') + ', click to change');
+}
+
+function hkRenderList(){
+  const list = $('hk-list'); if (!list) return;
+  list.innerHTML = '';
+  for (const [action, title, sub] of HOTKEY_ACTIONS){
+    const row = document.createElement('div');
+    row.className = 'hk-row';
+    const main = document.createElement('div');
+    main.className = 'hk-row-main';
+    main.innerHTML = `<div class="hk-row-title">${escAttr(title)}</div>`
+      + `<div class="tab-sub hk-row-sub">${escAttr(sub)}</div>`;
+    const cap = document.createElement('div');
+    cap.className = 'hk-capture';
+    cap.setAttribute('role','button');
+    cap.setAttribute('tabindex','0');
+    cap.addEventListener('click', () => hkStartRecording(action, cap));
+    cap.addEventListener('keydown', ev => {
+      // Enter/Space starts recording; once recording, the capture-phase
+      // handler owns every key, so this only fires when idle.
+      if (!hkRec && (ev.key === 'Enter' || ev.key === ' ')){ ev.preventDefault(); hkStartRecording(action, cap); }
+    });
+    const clear = document.createElement('button');
+    clear.className = 'hk-clear';
+    clear.type = 'button';
+    clear.innerHTML = '&times;';
+    clear.title = 'Clear ' + title + ' hotkey';
+    clear.setAttribute('aria-label', 'Clear ' + title + ' hotkey');
+    clear.hidden = !hkBindings[action];
+    clear.addEventListener('click', e => { e.stopPropagation(); hkSaveBinding(action, '', cap); });
+    row.append(main, cap, clear);
+    list.appendChild(row);
+    hkRenderCapture(cap, action);
+  }
+}
+
+function hkStartRecording(action, el){
+  if (hkRec) hkCancelRecording();
+  hkRec = {action, el};
+  el.classList.remove('empty');
+  el.classList.add('recording');
+  el.innerHTML = '<span class="hk-cue">Press keys&hellip;</span>';
+  el.focus();
+  hkSetWarn('');
+  document.addEventListener('keydown', hkOnKeydown, true);
+  el.addEventListener('blur', hkOnBlur);
+}
+
+function hkStopRecording(){
+  document.removeEventListener('keydown', hkOnKeydown, true);
+  if (hkRec) hkRec.el.removeEventListener('blur', hkOnBlur);
+  hkRec = null;
+}
+
+function hkCancelRecording(){
+  if (!hkRec) return;
+  const {action, el} = hkRec;
+  hkStopRecording();
+  hkRenderCapture(el, action);
+}
+
+function hkOnBlur(){ if (hkRec) hkCancelRecording(); }
+
+function hkFlashInvalid(msg){
+  if (!hkRec) return;
+  const el = hkRec.el;
+  el.classList.add('invalid');
+  setTimeout(() => el && el.classList.remove('invalid'), 340);
+  hkSetWarn(msg);
+}
+
+function hkOnKeydown(e){
+  if (!hkRec) return;
+  e.preventDefault(); e.stopPropagation();
+  if (e.key === 'Escape'){ hkCancelRecording(); return; }
+  if (e.key === 'Backspace' || e.key === 'Delete'){
+    const {action, el} = hkRec; hkStopRecording(); hkSaveBinding(action, '', el); return;
+  }
+  const mods = hkMods(e);
+  const key = hkMainKey(e.code);
+  if (!key){
+    // Modifiers only so far: live preview of what's held.
+    const cue = mods.length ? mods.join(' + ') + ' + &hellip;' : 'Press keys&hellip;';
+    hkRec.el.innerHTML = `<span class="hk-cue">${cue}</span>`;
+    return;
+  }
+  if (mods.length === 0){ hkFlashInvalid('Add Ctrl, Alt, Shift or Win - a bare key would fire by accident'); return; }
+  const combo = mods.concat(key).join('+');
+  const dup = Object.keys(hkBindings).find(a => a !== hkRec.action && hkBindings[a] === combo);
+  if (dup){ hkFlashInvalid(combo + ' is already bound to ' + hkTitleOf(dup)); return; }
+  const {action, el} = hkRec;
+  hkStopRecording();
+  hkSaveBinding(action, combo, el);
+}
+
+// Persist one binding. Optimistic: paint it, then POST. On failure, resync
+// from the server so the UI never lies about what is actually bound.
+async function hkSaveBinding(action, combo, el){
+  hkBindings[action] = combo;
+  hkRenderCapture(el, action);
+  const clearBtn = el.parentElement && el.parentElement.querySelector('.hk-clear');
+  if (clearBtn) clearBtn.hidden = !combo;
+  try {
+    const body = new URLSearchParams(); body.set('hotkey.' + action, combo);
+    const j = await (await fetch('/config', {method:'POST', body})).json();
+    if (j.ok){
+      toast(combo ? `${hkTitleOf(action)}: ${combo}` : `${hkTitleOf(action)} hotkey cleared`, 'ok');
+    } else {
+      toast(`Couldn't save hotkey: ${j.error}`, 'err');
+      await loadConfig();
+    }
+  } catch(e){
+    toast('Save failed - the app may have stopped responding', 'err');
+    await loadConfig();
+  }
+}
+
+// ── MIDI controller mapping (Windows only) ─────────────────────────────
+// Same five actions as the hotkeys, but "learn" is server-side: the MIDI
+// message arrives at the backend, so we POST /midi/learn then poll
+// /midi/poll until it is captured (or cancelled). Reuses the hk-* styles.
+let midiBindings = {toggle:'',arm:'',activate:'',cut:'',cut_after:''};
+let midiAvailable = false;
+let midiDevices = [];
+let midiLearnAction = null;
+let midiPollTimer = null;
+
+// "note:1:36" -> "Note 36 · ch 1"; "cc:1:20" -> "CC 20 · ch 1".
+function midiLabel(sig){
+  const p = (sig || '').split(':');
+  if (p.length !== 3) return sig || '';
+  const [kind, ch, n] = p;
+  if (kind === 'note') return 'Note ' + n + ' · ch ' + ch;
+  if (kind === 'cc') return 'CC ' + n + ' · ch ' + ch;
+  return sig;
+}
+
+function midiSetWarn(msg){ const w = $('midi-warn'); if (w) w.textContent = msg || ''; }
+
+function midiRenderCapture(el, action){
+  const sig = midiBindings[action] || '';
+  el.classList.remove('recording','invalid','empty');
+  if (midiLearnAction === action){
+    el.classList.add('recording');
+    el.innerHTML = '<span class="hk-cue">Press a pad or knob&hellip;</span>';
+    el.setAttribute('aria-label', hkTitleOf(action) + ': learning, press a control or click to cancel');
+    return;
+  }
+  if (!sig){
+    el.classList.add('empty');
+    el.innerHTML = '<span class="hk-cue">Click to learn</span>';
+    el.setAttribute('aria-label', hkTitleOf(action) + ': no MIDI control mapped, click to learn');
+    return;
+  }
+  el.innerHTML = '<span class="hk-chip">' + escAttr(midiLabel(sig)) + '</span>';
+  el.setAttribute('aria-label', hkTitleOf(action) + ': ' + midiLabel(sig) + ', click to remap');
+}
+
+function midiRenderList(){
+  const list = $('midi-list'); if (!list) return;
+  list.innerHTML = '';
+  for (const [action, title, sub] of HOTKEY_ACTIONS){
+    const row = document.createElement('div');
+    row.className = 'hk-row';
+    const main = document.createElement('div');
+    main.className = 'hk-row-main';
+    main.innerHTML = `<div class="hk-row-title">${escAttr(title)}</div>`
+      + `<div class="tab-sub hk-row-sub">${escAttr(sub)}</div>`;
+    const cap = document.createElement('div');
+    cap.className = 'hk-capture';
+    cap.setAttribute('role','button');
+    cap.setAttribute('tabindex','0');
+    cap.addEventListener('click', () => midiToggleLearn(action));
+    cap.addEventListener('keydown', ev => {
+      if (ev.key === 'Enter' || ev.key === ' '){ ev.preventDefault(); midiToggleLearn(action); }
+      if (ev.key === 'Escape' && midiLearnAction === action) midiCancelLearn();
+    });
+    const clear = document.createElement('button');
+    clear.className = 'hk-clear';
+    clear.type = 'button';
+    clear.innerHTML = '&times;';
+    clear.title = 'Clear ' + title + ' mapping';
+    clear.setAttribute('aria-label', 'Clear ' + title + ' MIDI mapping');
+    clear.hidden = !midiBindings[action];
+    clear.addEventListener('click', e => { e.stopPropagation(); midiClear(action); });
+    row.append(main, cap, clear);
+    list.appendChild(row);
+    midiRenderCapture(cap, action);
+  }
+  const note = $('midi-note');
+  if (note){
+    if (!midiAvailable){
+      note.hidden = false;
+      note.textContent = 'No MIDI controller detected. Connect one and it shows up here.';
+    } else if (midiDevices.length){
+      note.hidden = false;
+      note.textContent = 'Listening to: ' + midiDevices.join(', ');
+    } else {
+      note.hidden = true;
+    }
+  }
+}
+
+async function midiToggleLearn(action){
+  if (midiLearnAction === action){ await midiCancelLearn(); return; }
+  if (midiLearnAction) await midiCancelLearn();
+  if (!midiAvailable){ midiSetWarn('Connect a MIDI controller first.'); return; }
+  try {
+    const j = await (await fetch('/midi/learn', {method:'POST', body:new URLSearchParams({action})})).json();
+    if (!j.ok){ midiSetWarn(j.error || 'Could not start learn'); return; }
+    midiLearnAction = action;
+    midiSetWarn('');
+    midiRenderList();
+    midiStartPoll();
+  } catch(e){ midiSetWarn('Learn failed - the app may have stopped responding'); }
+}
+
+async function midiCancelLearn(){
+  const was = midiLearnAction;
+  midiLearnAction = null;
+  midiStopPoll();
+  try { await fetch('/midi/learn/cancel', {method:'POST'}); } catch(e){}
+  if (was) midiRenderList();
+}
+
+function midiStartPoll(){ midiStopPoll(); midiPollTimer = setInterval(midiPollOnce, 300); }
+function midiStopPoll(){ if (midiPollTimer){ clearInterval(midiPollTimer); midiPollTimer = null; } }
+
+// One poll: refresh availability/devices/bindings and, while learning,
+// detect when the server has captured (learning back to null).
+async function midiPollOnce(){
+  let j;
+  try { j = await (await fetch('/midi/poll', {method:'POST'})).json(); }
+  catch(e){ return; }
+  midiAvailable = !!j.available;
+  midiDevices = j.devices || [];
+  if (j.bindings) midiBindings = Object.assign(midiBindings, j.bindings);
+  if (j.learning == null){
+    const was = midiLearnAction;
+    const got = was && midiBindings[was];
+    midiLearnAction = null;
+    midiStopPoll();
+    midiRenderList();
+    if (was && got) toast(`${hkTitleOf(was)}: ${midiLabel(midiBindings[was])}`, 'ok');
+  } else {
+    midiRenderList();
+  }
+}
+
+async function midiClear(action){
+  midiBindings[action] = '';
+  midiRenderList();
+  try {
+    const body = new URLSearchParams(); body.set('midi.' + action, '');
+    const j = await (await fetch('/config', {method:'POST', body})).json();
+    if (j.ok) toast(`${hkTitleOf(action)} mapping cleared`, 'ok');
+    else { toast(`Couldn't clear mapping: ${j.error}`, 'err'); await loadConfig(); }
+  } catch(e){ toast('Save failed - the app may have stopped responding', 'err'); await loadConfig(); }
+}
+
+// One-off poll on load to learn availability + device names.
+async function midiInit(){
+  try {
+    const j = await (await fetch('/midi/poll', {method:'POST'})).json();
+    midiAvailable = !!j.available;
+    midiDevices = j.devices || [];
+    if (j.bindings) midiBindings = Object.assign(midiBindings, j.bindings);
+  } catch(e){}
+  midiRenderList();
 }
 
 // - OBS service registration --------------------─


### PR DESCRIPTION
Adds two ways to drive the delay from outside the dashboard, so a streamer can arm, activate, or cut without alt-tabbing out of a game.

## Hotkeys

Uses Win32 `RegisterHotKey`, so bindings fire while OBS or a game has focus.

Bindings are modifier-plus-key only. Full chords would need a low-level keyboard hook, which reads as a keylogger to AV vendors and is not a trade worth making for five actions.

## MIDI

Uses the winmm input API, with a learn mode so a deck or pad can be bound by pressing it rather than by looking up a note number.

## Both

Five actions are bindable, configured in Settings, and reloaded on save through the tray message loop, so no restart is needed.

Windows only for now. The config fields parse and round-trip on every platform, so a config file shared with a Linux build stays valid.

## Testing

- `cargo test`: full suite passes, including new coverage for hotkey parsing and canonicalisation, rejection of bare keys and multi-key chords, MIDI signature validation and routing, and a save/load round-trip
- `cargo clippy --all-targets`: clean
