### PR TITLE
fix(ingest): support OBS set to IP Family = IPv6

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1453,6 +1453,15 @@ fn hex_nibble(b: u8) -> Option<u8> {
 
 #[cfg(test)]
 mod tests {
+
+    // Mirrors obs_register: what we tell the user to paste into OBS has to
+    // resolve under either IP Family, so it stays a hostname.
+    #[test]
+    fn obs_url_uses_a_hostname_not_an_ipv4_literal() {
+        let mut s = Settings::defaults();
+        s.ingest_port = 1935;
+        assert_eq!(s.obs_url(), "rtmp://localhost:1935/live");
+    }
     use super::*;
     use std::path::PathBuf;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -841,13 +841,31 @@ impl Settings {
 
     // ---- Derived values ----
 
-    pub fn ingest_addr(&self) -> String {
-        let host = if self.ingest_bind_all {
-            "0.0.0.0"
+    /// Every address the ingest listener binds, IPv4 first.
+    ///
+    /// The IPv6 leg exists because OBS's Settings -> Advanced -> Network ->
+    /// IP Family is a resolver setting, not a transport preference. Set it
+    /// to IPv6 and OBS resolves with `AF_INET6`, under which an IPv4
+    /// literal cannot resolve at all: `getaddrinfo("127.0.0.1", AF_INET6)`
+    /// returns host-not-found and OBS reports "Error reaching host" before
+    /// it ever opens a socket. Pairing this with the `localhost` and
+    /// `[::1]` server entries in `obs_register` gives that configuration
+    /// something it can actually reach.
+    ///
+    /// IPv4 stays first because it is the default server entry and the one
+    /// almost everyone dials. The IPv6 leg is best-effort: a machine with
+    /// IPv6 disabled cannot bind it, and `supervise_ingest` drops it rather
+    /// than retrying forever.
+    pub fn ingest_addrs(&self) -> Vec<String> {
+        let (v4, v6) = if self.ingest_bind_all {
+            ("0.0.0.0", "[::]")
         } else {
-            "127.0.0.1"
+            ("127.0.0.1", "[::1]")
         };
-        format!("{}:{}", host, self.ingest_port)
+        vec![
+            format!("{}:{}", v4, self.ingest_port),
+            format!("{}:{}", v6, self.ingest_port),
+        ]
     }
 
     pub fn web_addr(&self) -> String {
@@ -1430,6 +1448,31 @@ fn hex_nibble(b: u8) -> Option<u8> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// Both legs, IPv4 first, in both bind modes. Order is contractual:
+    /// `spawn_ingest_legs` treats only the first address as required, so a
+    /// reordering here would silently make the IPv4 listener give up after
+    /// one failed bind and the IPv6 one retry forever.
+    #[test]
+    fn ingest_addrs_lists_ipv4_first_then_ipv6() {
+        let mut s = Settings::defaults();
+        s.ingest_port = 1935;
+
+        s.ingest_bind_all = false;
+        assert_eq!(s.ingest_addrs(), vec!["127.0.0.1:1935", "[::1]:1935"]);
+
+        s.ingest_bind_all = true;
+        assert_eq!(s.ingest_addrs(), vec!["0.0.0.0:1935", "[::]:1935"]);
+
+        // Every entry has to parse as a SocketAddr, since the IPv6 leg
+        // parses its address by hand before binding.
+        for addr in s.ingest_addrs() {
+            assert!(
+                addr.parse::<std::net::SocketAddr>().is_ok(),
+                "{addr} must parse"
+            );
+        }
+    }
 
     /// `start_with_windows` is not a `Settings` field - it comes from the
     /// registry via the caller. This guards the wire contract the dashboard

--- a/src/config.rs
+++ b/src/config.rs
@@ -878,9 +878,16 @@ impl Settings {
     }
 
     pub fn obs_url(&self) -> String {
-        // What OBS should be pointed at. Always 127.0.0.1 from the user's
+        // What OBS should be pointed at. Always loopback from the user's
         // perspective even if we bind on 0.0.0.0.
-        format!("rtmp://127.0.0.1:{}/live", self.ingest_port)
+        //
+        // `localhost` rather than a literal, for the same reason
+        // `obs_register::server_url` uses it: OBS's IP Family setting picks
+        // the address family passed to `getaddrinfo`, and an IPv4 literal
+        // cannot resolve under AF_INET6. Someone pasting this into a Custom
+        // service hits that wall exactly like someone picking our
+        // registered service would.
+        format!("rtmp://localhost:{}/live", self.ingest_port)
     }
 
     /// First destination's resolved URL - used by the legacy single-dest

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,17 +405,13 @@ fn spawn_ingest_legs(
 
 /// Bind and serve one ingest address, retrying on failure.
 ///
-/// A bind failure on an optional leg is treated as permanent and the task
-/// exits. On a machine with IPv6 disabled that bind can never succeed, and
-/// retrying it every second would spend the rest of the session writing the
-/// same line to the log. A required leg keeps retrying, because there a
-/// bind failure means something transient like a port still closing behind
-/// a restart.
-async fn supervise_ingest_leg(
-    addr: String,
-    ctrl: Arc<controller::Controller>,
-    required: bool,
-) {
+/// A required leg always retries. An optional leg retries only while the
+/// address is in use, which happens when a port is still closing behind a
+/// restart. Any other error means the family is unusable on this machine:
+/// with IPv6 disabled that bind can never succeed, and retrying it every
+/// second would spend the rest of the session writing the same log line, so
+/// the task logs once and exits.
+async fn supervise_ingest_leg(addr: String, ctrl: Arc<controller::Controller>, required: bool) {
     loop {
         match rtmp::server::bind(&addr).await {
             Ok(listener) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,7 +423,12 @@ async fn supervise_ingest_leg(
                     eprintln!("[ingest] {} stopped serving: {}", addr, e);
                 }
             }
-            Err(e) if !required => {
+            // AddrInUse is transient: on a restart or self-update the outgoing
+            // instance can still hold [::1] after it has released 127.0.0.1, and
+            // the port pre-flight only probes the IPv4 address. Keep retrying
+            // those. Any other error means the family is unusable on this
+            // machine, so an optional leg gives up instead of spinning.
+            Err(e) if !required && e.kind() != std::io::ErrorKind::AddrInUse => {
                 eprintln!("[ingest] optional listener {} unavailable: {}", addr, e);
                 ctrl.log(format!(
                     "ingest: IPv6 listener {addr} unavailable ({e}). IPv4 ingest is \

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,28 +357,83 @@ fn main() -> std::io::Result<()> {
 }
 
 async fn supervise_ingest(mut rx: watch::Receiver<Settings>, ctrl: Arc<controller::Controller>) {
-    let mut current_addr = rx.borrow().ingest_addr();
-    let mut handle = tokio::spawn(rtmp::server::run(current_addr.clone(), ctrl.clone()));
+    let mut current = rx.borrow().ingest_addrs();
+    let mut legs = spawn_ingest_legs(&current, &ctrl);
     loop {
-        tokio::select! {
-            r = &mut handle => {
-                eprintln!("[ingest] task ended: {:?}", r);
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                handle = tokio::spawn(rtmp::server::run(current_addr.clone(), ctrl.clone()));
-            }
-            ch = rx.changed() => {
-                if ch.is_err() { return; }
-                let new_addr = rx.borrow().ingest_addr();
-                if new_addr != current_addr {
-                    eprintln!("[ingest] hot-restart {} → {}", current_addr, new_addr);
-                    ctrl.log(format!("ingest: rebinding {} → {}", current_addr, new_addr));
-                    handle.abort();
-                    let _ = (&mut handle).await;
-                    current_addr = new_addr;
-                    handle = tokio::spawn(rtmp::server::run(current_addr.clone(), ctrl.clone()));
+        if rx.changed().await.is_err() {
+            return;
+        }
+        let next = rx.borrow().ingest_addrs();
+        if next == current {
+            continue;
+        }
+        eprintln!("[ingest] hot-restart {:?} -> {:?}", current, next);
+        ctrl.log(format!(
+            "ingest: rebinding {} -> {}",
+            current.join(", "),
+            next.join(", ")
+        ));
+        // Abort AND await every leg before rebinding. A listener that has
+        // been aborted but not yet dropped still holds the port, so binding
+        // the replacement first would fail and fall into the retry loop.
+        for mut leg in legs.drain(..) {
+            leg.abort();
+            let _ = (&mut leg).await;
+        }
+        current = next;
+        legs = spawn_ingest_legs(&current, &ctrl);
+    }
+}
+
+/// One supervisor task per address. `ingest_addrs` documents IPv4 first,
+/// and only that first leg is required: the IPv6 leg is a bonus that lets
+/// an OBS configured for IP Family = IPv6 reach us at all, and a machine
+/// with IPv6 disabled is expected to fail it.
+fn spawn_ingest_legs(
+    addrs: &[String],
+    ctrl: &Arc<controller::Controller>,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    addrs
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let required = i == 0;
+            tokio::spawn(supervise_ingest_leg(addr.clone(), ctrl.clone(), required))
+        })
+        .collect()
+}
+
+/// Bind and serve one ingest address, retrying on failure.
+///
+/// A bind failure on an optional leg is treated as permanent and the task
+/// exits. On a machine with IPv6 disabled that bind can never succeed, and
+/// retrying it every second would spend the rest of the session writing the
+/// same line to the log. A required leg keeps retrying, because there a
+/// bind failure means something transient like a port still closing behind
+/// a restart.
+async fn supervise_ingest_leg(
+    addr: String,
+    ctrl: Arc<controller::Controller>,
+    required: bool,
+) {
+    loop {
+        match rtmp::server::bind(&addr).await {
+            Ok(listener) => {
+                if let Err(e) = rtmp::server::serve(listener, ctrl.clone()).await {
+                    eprintln!("[ingest] {} stopped serving: {}", addr, e);
                 }
             }
+            Err(e) if !required => {
+                eprintln!("[ingest] optional listener {} unavailable: {}", addr, e);
+                ctrl.log(format!(
+                    "ingest: IPv6 listener {addr} unavailable ({e}). IPv4 ingest is \
+                     unaffected; only an OBS set to IP Family = IPv6 needs this one."
+                ));
+                return;
+            }
+            Err(e) => eprintln!("[ingest] bind {} failed: {}", addr, e),
         }
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -1236,6 +1236,17 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32 as TestUniq, Ordering as TestOrd};
 
+    // OBS resolves the server URL with the address family picked in
+    // Settings -> Advanced -> IP Family. An IPv4 literal is not resolvable
+    // under IPv6, so the single entry we register has to carry a hostname.
+    #[test]
+    fn the_registered_server_url_is_resolvable_under_either_ip_family() {
+        assert_eq!(server_url(1935), "rtmp://localhost:1935/live");
+        let entry = entry_json(7799, 1935);
+        assert!(entry.contains("rtmp://localhost:1935/live"), "{entry}");
+        assert!(!entry.contains("rtmp://127.0.0.1"), "{entry}");
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn linux_obs_config_dirs_cover_native_flatpak_snap() {
@@ -1804,6 +1815,3 @@ mod tests {
 
     static UNIQ_OBS: TestUniq = TestUniq::new(0);
 }
-
-
-

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -104,20 +104,28 @@ pub fn is_registered(web_port: u16, ingest_port: u16) -> bool {
 /// server and the multi-track config endpoint. Both carry a port, so a
 /// retuned port shows up here too.
 ///
-/// The literals must also be gone. A plain "contains our URL" test would
-/// pass a file that has our current entry *plus* leftover literal servers
-/// from an older build, leaving dead options in the dropdown that fail
-/// under one IP Family setting each. No other service in OBS's
-/// services.json points at loopback on our port, so finding one means it
-/// is ours and out of date.
+/// Leftover literal servers inside OUR entry also count as stale: they
+/// would sit in the dropdown as options that fail under one IP Family
+/// setting each.
+///
+/// Every check runs against `entry_span` and not the whole file. Scanning
+/// the file would let anything InstantClone-shaped elsewhere in
+/// services.json hold the answer at "stale" permanently, and since
+/// re-registering only rewrites our own entry, the user would be stuck
+/// with a Register button that never turns into Unregister no matter how
+/// many times they press it.
 fn registration_is_current(file: &str, web_port: u16, ingest_port: u16) -> bool {
+    let Some(span) = entry_span(file) else {
+        return false;
+    };
+    let entry = &file[span];
     let stale_literals = [
         format!("rtmp://127.0.0.1:{ingest_port}/live"),
         format!("rtmp://[::1]:{ingest_port}/live"),
     ];
-    file.contains(&server_url(ingest_port))
-        && file.contains(&multitrack_url(web_port))
-        && !stale_literals.iter().any(|u| file.contains(u.as_str()))
+    entry.contains(&server_url(ingest_port))
+        && entry.contains(&multitrack_url(web_port))
+        && !stale_literals.iter().any(|u| entry.contains(u.as_str()))
 }
 
 /// The RTMP URL we advertise to OBS.
@@ -322,14 +330,17 @@ fn insert_entry(file: &str, entry: &str) -> Option<String> {
     Some(format!("{head}\n{entry},{tail}"))
 }
 
-/// Walk the file from the InstantClone name marker outward to find the
-/// `{ … }` span that encloses our entry, then delete that span plus
-/// any preceding/trailing comma so the surrounding array stays valid.
-fn remove_entry(file: &str) -> Option<String> {
+/// Byte range of our service object in `file`, braces included.
+///
+/// Scoping matters: the rest of the file belongs to OBS and to other
+/// services, and a stray `InstantClone`-flavoured string elsewhere (a
+/// leftover server object inside another service's `servers` array, say)
+/// must not be read as ours. Anything that inspects "our entry" has to go
+/// through here rather than searching the whole file.
+fn entry_span(file: &str) -> Option<std::ops::Range<usize>> {
     // Locate the marker (handles both indented and non-indented
-    // formats - the exact-substring check `entry_exists` already
-    // confirmed at least one is present, so the unwraps below are
-    // safe in practice but we still use `?` for paranoia).
+    // formats). The trailing quote is what keeps this from matching a
+    // nested `"name": "InstantClone (local proxy)"` server object.
     let marker = if file.contains(r#""name": "InstantClone""#) {
         r#""name": "InstantClone""#
     } else {
@@ -373,6 +384,15 @@ fn remove_entry(file: &str) -> Option<String> {
     if end == start {
         return None;
     }
+    Some(start..end)
+}
+
+/// Delete our entry plus any preceding/trailing comma so the surrounding
+/// array stays valid.
+fn remove_entry(file: &str) -> Option<String> {
+    let span = entry_span(file)?;
+    let (start, end) = (span.start, span.end);
+    let bytes = file.as_bytes();
     // Also strip the trailing comma + whitespace if our entry isn't
     // the last item, or the leading comma if it is.
     let mut left = start;
@@ -1340,6 +1360,61 @@ mod tests {
         );
     }
 
+    /// Found on a real install: a leftover `InstantClone (local proxy)`
+    /// server object sitting inside Twitch's `servers` array, unrelated to
+    /// our own entry. A whole-file staleness scan sees that literal and
+    /// reports stale forever, and because re-registering only rewrites our
+    /// entry, the Register button can never turn into Unregister no matter
+    /// how many times it is pressed. The check has to look at our entry
+    /// only.
+    #[test]
+    fn a_stray_instantclone_server_in_another_service_does_not_block_registration() {
+        let polluted = format!(
+            r#"{{"format_version":4,"services":[
+{},
+{{"name":"Twitch","common":true,"servers":[
+                {{ "name": "InstantClone (local proxy)", "url": "rtmp://127.0.0.1:1935/live" }},
+                {{"name":"Asia: Hong Kong","url":"rtmp://hk.contribute.live-video.net/app"}}]}}
+]}}"#,
+            entry_json(7799, 1935)
+        );
+        assert!(
+            polluted.contains("rtmp://127.0.0.1:1935/live"),
+            "the stray must be present for this test to mean anything"
+        );
+        assert!(
+            registration_is_current(&polluted, 7799, 1935),
+            "a stray in someone else's entry must not make ours look stale"
+        );
+        assert!(is_entry_current_for_test(&polluted));
+    }
+
+    /// Removing our entry must leave the unrelated stray alone: it is not
+    /// ours to delete, and clobbering another service's servers array
+    /// would be far worse than the dead dropdown option it causes.
+    #[test]
+    fn remove_entry_leaves_a_stray_in_another_service_untouched() {
+        let polluted = format!(
+            r#"{{"format_version":4,"services":[
+{},
+{{"name":"Twitch","common":true,"servers":[
+                {{ "name": "InstantClone (local proxy)", "url": "rtmp://127.0.0.1:1935/live" }}]}}
+]}}"#,
+            entry_json(7799, 1935)
+        );
+        let stripped = remove_entry(&polluted).expect("remove");
+        assert!(!entry_exists(&stripped), "our entry is gone");
+        assert!(
+            stripped.contains(r#"{ "name": "InstantClone (local proxy)", "url": "rtmp://127.0.0.1:1935/live" }"#),
+            "Twitch's array must be untouched"
+        );
+        assert!(stripped.contains("Twitch"));
+    }
+
+    fn is_entry_current_for_test(file: &str) -> bool {
+        entry_exists(file) && registration_is_current(file, 7799, 1935)
+    }
+
     #[test]
     fn insert_is_idempotent_for_caller() {
         // Caller (`register`) checks `entry_exists` before splicing,
@@ -1729,3 +1804,6 @@ mod tests {
 
     static UNIQ_OBS: TestUniq = TestUniq::new(0);
 }
+
+
+

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -1327,7 +1327,10 @@ mod tests {
         let entry = entry_json(7799, 1935);
         assert!(entry.contains(r#""url": "rtmp://localhost:1935/live""#));
         // A literal would strand one IP Family setting apiece.
-        assert!(!entry.contains("rtmp://127.0.0.1:1935/live"), "no v4 literal");
+        assert!(
+            !entry.contains("rtmp://127.0.0.1:1935/live"),
+            "no v4 literal"
+        );
         assert!(!entry.contains("rtmp://[::1]:1935/live"), "no v6 literal");
         // One server, so the user never has to pick.
         assert_eq!(entry.matches(r#""url": "rtmp://"#).count(), 1);
@@ -1343,10 +1346,7 @@ mod tests {
         assert!(registration_is_current(&current, 7799, 1935));
 
         // Pre-IPv6 builds wrote the v4 literal.
-        let legacy = current.replace(
-            "rtmp://localhost:1935/live",
-            "rtmp://127.0.0.1:1935/live",
-        );
+        let legacy = current.replace("rtmp://localhost:1935/live", "rtmp://127.0.0.1:1935/live");
         assert!(entry_exists(&legacy), "still ours by name");
         assert!(
             !registration_is_current(&legacy, 7799, 1935),
@@ -1416,7 +1416,9 @@ mod tests {
         let stripped = remove_entry(&polluted).expect("remove");
         assert!(!entry_exists(&stripped), "our entry is gone");
         assert!(
-            stripped.contains(r#"{ "name": "InstantClone (local proxy)", "url": "rtmp://127.0.0.1:1935/live" }"#),
+            stripped.contains(
+                r#"{ "name": "InstantClone (local proxy)", "url": "rtmp://127.0.0.1:1935/live" }"#
+            ),
             "Twitch's array must be untouched"
         );
         assert!(stripped.contains("Twitch"));

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -78,14 +78,70 @@ pub fn services_json_path() -> Option<PathBuf> {
         .find(|p| p.exists())
 }
 
-/// True when the user's services.json already contains an entry whose
-/// `name` matches our `SERVICE_NAME`. Used by the System tab to render
+/// True when services.json holds an InstantClone entry that matches the
+/// ports and URLs we would write today. Used by the System tab to render
 /// the button as "Unregister" instead of "Register".
-pub fn is_registered() -> bool {
+///
+/// Deliberately stricter than "an entry with our name exists". An entry
+/// written by an older build, or before the user retuned a port, still
+/// carries our name while pointing OBS somewhere useless, and reporting
+/// that as registered leaves the user with no way to notice or fix it.
+/// Reporting it as unregistered puts the Register button back, and
+/// `register` is remove-and-replace, so one click repairs it.
+pub fn is_registered(web_port: u16, ingest_port: u16) -> bool {
     let Some(p) = services_json_path() else {
         return false;
     };
-    matches!(fs::read_to_string(&p), Ok(s) if entry_exists(&s))
+    let Ok(file) = fs::read_to_string(&p) else {
+        return false;
+    };
+    entry_exists(&file) && registration_is_current(&file, web_port, ingest_port)
+}
+
+/// Whether the entry in `file` still matches what `entry_json` produces.
+///
+/// Checks the two URLs that decide whether OBS can reach us, the RTMP
+/// server and the multi-track config endpoint. Both carry a port, so a
+/// retuned port shows up here too.
+///
+/// The literals must also be gone. A plain "contains our URL" test would
+/// pass a file that has our current entry *plus* leftover literal servers
+/// from an older build, leaving dead options in the dropdown that fail
+/// under one IP Family setting each. No other service in OBS's
+/// services.json points at loopback on our port, so finding one means it
+/// is ours and out of date.
+fn registration_is_current(file: &str, web_port: u16, ingest_port: u16) -> bool {
+    let stale_literals = [
+        format!("rtmp://127.0.0.1:{ingest_port}/live"),
+        format!("rtmp://[::1]:{ingest_port}/live"),
+    ];
+    file.contains(&server_url(ingest_port))
+        && file.contains(&multitrack_url(web_port))
+        && !stale_literals.iter().any(|u| file.contains(u.as_str()))
+}
+
+/// The RTMP URL we advertise to OBS.
+///
+/// `localhost`, not a literal, and that is the whole point. OBS's
+/// Settings -> Advanced -> Network -> IP Family is a resolver setting: it
+/// picks the address family passed to `getaddrinfo`. Under IP Family =
+/// IPv6 an IPv4 literal cannot resolve (`getaddrinfo("127.0.0.1",
+/// AF_INET6)` returns host-not-found), and under IPv4 an IPv6 literal
+/// cannot either. `localhost` is the one spelling that resolves under all
+/// three settings, so a single entry covers every configuration and the
+/// user never has to know the setting exists.
+///
+/// This is safe only because the ingest binds both families (see
+/// `Settings::ingest_addrs`). Under IPv4+IPv6 OBS resolves both `::1` and
+/// `127.0.0.1` and races them; happy-eyeballs reports failure only when
+/// every candidate fails, so even if our IPv6 leg could not bind, the
+/// IPv4 leg still wins the race.
+fn server_url(ingest_port: u16) -> String {
+    format!("rtmp://localhost:{ingest_port}/live")
+}
+
+fn multitrack_url(web_port: u16) -> String {
+    format!("http://127.0.0.1:{web_port}/obs/multitrack-config")
 }
 
 /// Build the services.json entry for InstantClone. The
@@ -96,15 +152,9 @@ pub fn is_registered() -> bool {
 /// the name marker to the nearest `{` without tracking strings, so it only
 /// finds our object's opening brace while nothing precedes the name.
 ///
-/// Three server entries, IPv4 first because it is what almost everyone
-/// dials and what existing profiles already have saved. The other two
-/// exist for OBS's Settings -> Advanced -> Network -> IP Family, which is
-/// a resolver setting: under IP Family = IPv6 OBS asks for `AF_INET6`, an
-/// IPv4 literal cannot resolve under it, and the stream fails with
-/// "Error reaching host" before a socket is ever opened. `localhost`
-/// resolves under every family setting, so it is the one to pick when in
-/// doubt; the explicit `[::1]` entry is there for anyone who wants to be
-/// unambiguous.
+/// One server entry, on `localhost`. See `server_url` for why that
+/// spelling is the only one that works under every OBS IP Family setting,
+/// and why a single entry beats offering the user a choice.
 fn entry_json(web_port: u16, ingest_port: u16) -> String {
     format!(
         r#"{{
@@ -112,21 +162,13 @@ fn entry_json(web_port: u16, ingest_port: u16) -> String {
             "common": true,
             "more_info_link": "https://github.com/Soulhackzlol/InstantClone",
             "stream_key_link": "http://127.0.0.1:{web}/",
-            "multitrack_video_configuration_url": "http://127.0.0.1:{web}/obs/multitrack-config",
+            "multitrack_video_configuration_url": "{mtv}",
             "multitrack_video_name": "Multi-track via InstantClone",
             "multitrack_video_learn_more_link": "https://github.com/Soulhackzlol/InstantClone",
             "servers": [
                 {{
                     "name": "InstantClone (local proxy)",
-                    "url": "rtmp://127.0.0.1:{rtmp}/live"
-                }},
-                {{
-                    "name": "InstantClone (localhost, any IP family)",
-                    "url": "rtmp://localhost:{rtmp}/live"
-                }},
-                {{
-                    "name": "InstantClone (IPv6 loopback)",
-                    "url": "rtmp://[::1]:{rtmp}/live"
+                    "url": "{server}"
                 }}
             ],
             "recommended": {{
@@ -138,7 +180,8 @@ fn entry_json(web_port: u16, ingest_port: u16) -> String {
             "supported video codecs": ["h264"]
         }}"#,
         web = web_port,
-        rtmp = ingest_port,
+        mtv = multitrack_url(web_port),
+        server = server_url(ingest_port),
     )
 }
 
@@ -1242,29 +1285,59 @@ mod tests {
         assert!(stripped.contains("YouTube"));
     }
 
-    /// The IPv6 entries only help if OBS can still find and remove our
-    /// object, and `remove_entry` walks braces by hand. Three nested server
-    /// objects instead of one is exactly the shape that would break a
-    /// depth-blind walk, so pin the round-trip on the real entry.
+    /// The single server entry must be the `localhost` spelling. An IP
+    /// literal of either family is unreachable under one of OBS's three IP
+    /// Family settings, because that setting picks the address family
+    /// handed to `getaddrinfo`. Measured on Windows 11:
+    /// `getaddrinfo("127.0.0.1", AF_INET6)` returns 11001 host-not-found,
+    /// while `localhost` resolves under AF_INET, AF_INET6 and AF_UNSPEC.
     #[test]
-    fn entry_with_ipv6_servers_still_round_trips_through_remove() {
+    fn entry_advertises_localhost_so_every_ip_family_setting_resolves() {
         let entry = entry_json(7799, 1935);
-        assert!(entry.contains("rtmp://127.0.0.1:1935/live"), "IPv4 entry");
-        assert!(entry.contains("rtmp://localhost:1935/live"), "any-family");
-        assert!(entry.contains("rtmp://[::1]:1935/live"), "IPv6 literal");
-        // IPv4 must stay the first server: OBS preselects it, and every
-        // existing profile already has that URL saved.
-        let v4 = entry.find("rtmp://127.0.0.1:1935/live").unwrap();
-        let localhost = entry.find("rtmp://localhost:1935/live").unwrap();
-        let v6 = entry.find("rtmp://[::1]:1935/live").unwrap();
-        assert!(v4 < localhost && localhost < v6, "IPv4 first");
+        assert!(entry.contains(r#""url": "rtmp://localhost:1935/live""#));
+        // A literal would strand one IP Family setting apiece.
+        assert!(!entry.contains("rtmp://127.0.0.1:1935/live"), "no v4 literal");
+        assert!(!entry.contains("rtmp://[::1]:1935/live"), "no v6 literal");
+        // One server, so the user never has to pick.
+        assert_eq!(entry.matches(r#""url": "rtmp://"#).count(), 1);
+    }
 
-        let patched = insert_entry(&fake_services_json(), &entry).expect("insert");
-        assert!(entry_exists(&patched));
-        let stripped = remove_entry(&patched).expect("remove");
-        assert!(!entry_exists(&stripped));
-        assert!(!stripped.contains("::1"), "no orphaned server object");
-        assert!(stripped.contains("Twitch") && stripped.contains("YouTube"));
+    /// An entry from an older build still carries our name while pointing
+    /// OBS at an address it may not be able to resolve. Reporting that as
+    /// registered would leave the user no way to notice, so staleness has
+    /// to read as unregistered and put the Register button back.
+    #[test]
+    fn a_stale_entry_does_not_count_as_registered() {
+        let current = entry_json(7799, 1935);
+        assert!(registration_is_current(&current, 7799, 1935));
+
+        // Pre-IPv6 builds wrote the v4 literal.
+        let legacy = current.replace(
+            "rtmp://localhost:1935/live",
+            "rtmp://127.0.0.1:1935/live",
+        );
+        assert!(entry_exists(&legacy), "still ours by name");
+        assert!(
+            !registration_is_current(&legacy, 7799, 1935),
+            "a v4-literal entry is stale and must prompt a re-register"
+        );
+
+        // A retuned port is stale for the same reason.
+        assert!(!registration_is_current(&current, 7799, 1936));
+        assert!(!registration_is_current(&current, 7800, 1935));
+
+        // Our current URL present but literal servers left over beside it:
+        // the dropdown would still offer options that fail under one IP
+        // Family setting each, so this has to read as stale too.
+        let with_leftovers = current.replace(
+            r#""url": "rtmp://localhost:1935/live""#,
+            r#""url": "rtmp://localhost:1935/live"}, {"name": "old", "url": "rtmp://[::1]:1935/live""#,
+        );
+        assert!(with_leftovers.contains("rtmp://localhost:1935/live"));
+        assert!(
+            !registration_is_current(&with_leftovers, 7799, 1935),
+            "a superset of our entry is still out of date"
+        );
     }
 
     #[test]

--- a/src/obs_register.rs
+++ b/src/obs_register.rs
@@ -91,6 +91,20 @@ pub fn is_registered() -> bool {
 /// Build the services.json entry for InstantClone. The
 /// `multitrack_video_configuration_url` is what OBS hits when the user
 /// enables multi-track video - we serve it from our own web port.
+///
+/// `"name"` MUST stay the first key: `remove_entry` walks backwards from
+/// the name marker to the nearest `{` without tracking strings, so it only
+/// finds our object's opening brace while nothing precedes the name.
+///
+/// Three server entries, IPv4 first because it is what almost everyone
+/// dials and what existing profiles already have saved. The other two
+/// exist for OBS's Settings -> Advanced -> Network -> IP Family, which is
+/// a resolver setting: under IP Family = IPv6 OBS asks for `AF_INET6`, an
+/// IPv4 literal cannot resolve under it, and the stream fails with
+/// "Error reaching host" before a socket is ever opened. `localhost`
+/// resolves under every family setting, so it is the one to pick when in
+/// doubt; the explicit `[::1]` entry is there for anyone who wants to be
+/// unambiguous.
 fn entry_json(web_port: u16, ingest_port: u16) -> String {
     format!(
         r#"{{
@@ -105,6 +119,14 @@ fn entry_json(web_port: u16, ingest_port: u16) -> String {
                 {{
                     "name": "InstantClone (local proxy)",
                     "url": "rtmp://127.0.0.1:{rtmp}/live"
+                }},
+                {{
+                    "name": "InstantClone (localhost, any IP family)",
+                    "url": "rtmp://localhost:{rtmp}/live"
+                }},
+                {{
+                    "name": "InstantClone (IPv6 loopback)",
+                    "url": "rtmp://[::1]:{rtmp}/live"
                 }}
             ],
             "recommended": {{
@@ -1218,6 +1240,31 @@ mod tests {
         // services array should still contain both original entries.
         assert!(stripped.contains("Twitch"));
         assert!(stripped.contains("YouTube"));
+    }
+
+    /// The IPv6 entries only help if OBS can still find and remove our
+    /// object, and `remove_entry` walks braces by hand. Three nested server
+    /// objects instead of one is exactly the shape that would break a
+    /// depth-blind walk, so pin the round-trip on the real entry.
+    #[test]
+    fn entry_with_ipv6_servers_still_round_trips_through_remove() {
+        let entry = entry_json(7799, 1935);
+        assert!(entry.contains("rtmp://127.0.0.1:1935/live"), "IPv4 entry");
+        assert!(entry.contains("rtmp://localhost:1935/live"), "any-family");
+        assert!(entry.contains("rtmp://[::1]:1935/live"), "IPv6 literal");
+        // IPv4 must stay the first server: OBS preselects it, and every
+        // existing profile already has that URL saved.
+        let v4 = entry.find("rtmp://127.0.0.1:1935/live").unwrap();
+        let localhost = entry.find("rtmp://localhost:1935/live").unwrap();
+        let v6 = entry.find("rtmp://[::1]:1935/live").unwrap();
+        assert!(v4 < localhost && localhost < v6, "IPv4 first");
+
+        let patched = insert_entry(&fake_services_json(), &entry).expect("insert");
+        assert!(entry_exists(&patched));
+        let stripped = remove_entry(&patched).expect("remove");
+        assert!(!entry_exists(&stripped));
+        assert!(!stripped.contains("::1"), "no orphaned server object");
+        assert!(stripped.contains("Twitch") && stripped.contains("YouTube"));
     }
 
     #[test]

--- a/src/rtmp/server.rs
+++ b/src/rtmp/server.rs
@@ -3,7 +3,10 @@
 //!
 //! Only one active publisher is meaningful at a time (one streamer). We
 //! still accept many TCP connections but the controller will reject a
-//! second `publish` until the first goes away.
+//! second `publish` until the first goes away. That guard is what makes
+//! the IPv4 and IPv6 listeners safe to run side by side: whichever one
+//! the encoder happens to arrive on takes the slot, and the other is
+//! refused exactly as a second OBS on the same listener would be.
 
 use crate::controller::Controller;
 use crate::h264;
@@ -17,12 +20,50 @@ use std::sync::Arc;
 use tokio::io::split;
 use tokio::net::TcpListener;
 
-pub async fn run(addr: String, ctrl: Arc<Controller>) -> io::Result<()> {
-    let listener = TcpListener::bind(&addr).await?;
+/// Bind one ingest address. Kept separate from `serve` so the supervisor
+/// can tell a bind failure (permanent for the IPv6 leg on a machine with
+/// IPv6 disabled) from a serve failure (worth retrying), instead of
+/// respawning a hopeless listener once a second forever.
+///
+/// IPv6 addresses go through `TcpSocket` rather than `TcpListener::bind`
+/// so `IPV6_V6ONLY` can be set before the bind - see `tcp::set_v6_only`
+/// for why the two sockets must not overlap.
+pub async fn bind(addr: &str) -> io::Result<TcpListener> {
+    let listener = if addr.starts_with('[') {
+        bind_v6_only(addr)?
+    } else {
+        TcpListener::bind(addr).await?
+    };
     // Keep this listener out of a restart/self-update child (else the ingest
     // port stays bound after we exit and the new instance can't reclaim it).
     crate::self_update::dont_inherit(&listener);
     eprintln!("[ingest] listening on {}", addr);
+    Ok(listener)
+}
+
+/// Bind a `[::1]` / `[::]` address with `IPV6_V6ONLY` forced on.
+///
+/// `SO_REUSEADDR` mirrors what `TcpListener::bind` does per platform (std
+/// sets it on unix, not on Windows), so a hot-rebind behaves the same on
+/// both legs. Anything else would let the IPv6 leg fail to reclaim the
+/// port on a restart where IPv4 succeeded.
+fn bind_v6_only(addr: &str) -> io::Result<TcpListener> {
+    let parsed: std::net::SocketAddr = addr.parse().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("not a socket address: {addr}"),
+        )
+    })?;
+    let sock = tokio::net::TcpSocket::new_v6()?;
+    crate::rtmp::tcp::set_v6_only(&sock)?;
+    #[cfg(unix)]
+    sock.set_reuseaddr(true)?;
+    sock.bind(parsed)?;
+    // Matches the backlog tokio uses inside `TcpListener::bind`.
+    sock.listen(1024)
+}
+
+pub async fn serve(listener: TcpListener, ctrl: Arc<Controller>) -> io::Result<()> {
     loop {
         let (sock, peer) = listener.accept().await?;
         sock.set_nodelay(true)?;
@@ -320,4 +361,69 @@ async fn send_set_peer_bandwidth<W: tokio::io::AsyncWrite + Unpin>(
     buf[..4].copy_from_slice(&size.to_be_bytes());
     buf[4] = limit_type;
     writer.write_message(2, 0, 6, 0, &buf).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A machine or container with IPv6 switched off cannot run these.
+    /// The product degrades to IPv4 there by design (`supervise_ingest_leg`
+    /// drops the optional leg), so skipping is the honest outcome rather
+    /// than a red suite on a Docker image without IPv6.
+    async fn bind_v6_or_skip(addr: &str) -> Option<TcpListener> {
+        match bind(addr).await {
+            Ok(l) => Some(l),
+            Err(e) => {
+                eprintln!("skipping IPv6 test, {addr} is unbindable here: {e}");
+                None
+            }
+        }
+    }
+
+    /// The wildcard legs have to hold one port simultaneously. Without
+    /// `IPV6_V6ONLY` this passes on Windows (the option defaults on) and
+    /// fails on Linux with EADDRINUSE, because `net.ipv6.bindv6only`
+    /// defaults off there and `[::]` swallows v4-mapped addresses. This is
+    /// the test that keeps the two-socket layout portable.
+    #[tokio::test]
+    async fn wildcard_v4_and_v6_listeners_share_one_port() {
+        let v4 = bind("0.0.0.0:0").await.expect("IPv4 wildcard bind");
+        let port = v4.local_addr().unwrap().port();
+        let Some(v6) = bind_v6_or_skip(&format!("[::]:{port}")).await else {
+            return;
+        };
+        assert!(v6.local_addr().unwrap().is_ipv6());
+    }
+
+    /// The default layout, plus the property `Controller::begin_publish`
+    /// depends on: a v6-only socket reports a local peer as `::1`, which
+    /// `is_loopback` accepts. A dual-stack socket would hand us
+    /// `::ffff:127.0.0.1` instead, where `is_loopback` is false and a
+    /// publisher sitting at the machine would be rate-limited as remote.
+    #[tokio::test]
+    async fn ipv6_loopback_listener_accepts_and_reports_a_loopback_peer() {
+        let Some(v6) = bind_v6_or_skip("[::1]:0").await else {
+            return;
+        };
+        let addr = v6.local_addr().unwrap();
+        assert!(addr.is_ipv6());
+
+        let client = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("connect over IPv6");
+        let (accepted, peer) = v6.accept().await.expect("accept");
+        assert!(
+            peer.ip().is_loopback(),
+            "peer must classify as loopback, got {peer}"
+        );
+        drop((client, accepted));
+    }
+
+    /// A bad address must surface as an error the supervisor can act on,
+    /// not a panic inside the bind path.
+    #[tokio::test]
+    async fn malformed_ipv6_address_is_an_error_not_a_panic() {
+        assert!(bind("[not-an-address]:1935").await.is_err());
+    }
 }

--- a/src/rtmp/tcp.rs
+++ b/src/rtmp/tcp.rs
@@ -8,9 +8,12 @@
 //!   * EGRESS: Twitch / NAT / firewall idle-paths sometimes silently drop
 //!     long connections. Without probes, we'd only discover a dead socket
 //!     on the next send - by then the viewer has been frozen for a while.
+//!   * INGEST (IPv6): `set_v6_only` keeps our two listen sockets from
+//!     overlapping, and keeps v4 peers from arriving v4-mapped.
 //!
-//! Implementation: raw `WSAIoctl(SIO_KEEPALIVE_VALS)` on Windows (no
-//! `socket2` dependency), no-op stub on other platforms.
+//! Implementation: raw `WSAIoctl(SIO_KEEPALIVE_VALS)` / `setsockopt` on
+//! Windows and `libc::setsockopt` on unix (no `socket2` dependency),
+//! no-op stubs elsewhere.
 
 use std::io;
 use tokio::net::TcpStream;
@@ -110,5 +113,70 @@ pub fn set_send_buffer(sock: &TcpStream, bytes: u32) -> io::Result<()> {
 
 #[cfg(not(target_os = "windows"))]
 pub fn set_send_buffer(_sock: &TcpStream, _bytes: u32) -> io::Result<()> {
+    Ok(())
+}
+
+/// Pin an unbound IPv6 socket to IPv6 only, so it never claims v4-mapped
+/// addresses. Must be called BEFORE `bind`: the option is fixed once the
+/// socket is bound.
+///
+/// Not optional, for two reasons.
+///
+/// Platforms disagree on the default. Windows starts with the option on,
+/// Linux with it off (`net.ipv6.bindv6only=0`), so a dual-stack `[::]`
+/// socket would swallow v4-mapped addresses on Linux and collide with our
+/// separate `0.0.0.0` bind, while behaving fine on Windows. Setting it
+/// makes both platforms run the same two-socket layout.
+///
+/// It also keeps peer addresses honest. A dual-stack socket reports v4
+/// peers as `::ffff:127.0.0.1`, and `Ipv6Addr::is_loopback` is false for
+/// v4-mapped addresses, so `Controller::begin_publish` would classify a
+/// local OBS as remote and apply the wrong-key rate limiter to someone
+/// sitting at the machine.
+#[cfg(target_os = "windows")]
+pub fn set_v6_only(sock: &tokio::net::TcpSocket) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::{setsockopt, IPPROTO_IPV6, IPV6_V6ONLY};
+
+    let on: i32 = 1;
+    let rc = unsafe {
+        setsockopt(
+            sock.as_raw_socket() as usize,
+            IPPROTO_IPV6,
+            IPV6_V6ONLY,
+            &on as *const i32 as *const u8,
+            std::mem::size_of::<i32>() as i32,
+        )
+    };
+    if rc != 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+pub fn set_v6_only(sock: &tokio::net::TcpSocket) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let on: libc::c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_V6ONLY,
+            &on as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if rc != 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(target_os = "windows", unix)))]
+pub fn set_v6_only(_sock: &tokio::net::TcpSocket) -> io::Result<()> {
     Ok(())
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -759,7 +759,7 @@ async fn route(
                 "application/json",
                 format!(
                     r#"{{"registered":{},"obs_running":{},"vod_audio_flag":{},"vod_eb_injected":{},"obs_version":{},"active_profile":{},"path":{}}}"#,
-                    crate::obs_register::is_registered(),
+                    crate::obs_register::is_registered(s.web_port, s.ingest_port),
                     crate::obs_register::is_obs_running(),
                     crate::obs_register::vod_audio_flag_set(),
                     crate::obs_register::vod_eb_injection_present(s.web_port),
@@ -1561,7 +1561,7 @@ async fn obs_multitrack_config_proxy(
     // begin_publish accepts it (see Controller::remember_eb_key).
     let rewritten = rewrite_url_templates(
         &twitch_json,
-        &format!("rtmp://127.0.0.1:{}/live/{{stream_key}}", ingest_port),
+        &format!("rtmp://localhost:{}/live/{{stream_key}}", ingest_port),
     );
     // Extract the *original* IVS ingest URL from Twitch's response
     // BEFORE rewriting it to localhost, substitute the streamer's real
@@ -2015,7 +2015,7 @@ fn obs_multitrack_config_static(query: &str, settings: &Arc<watch::Sender<Settin
     }
 
     format!(
-        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://127.0.0.1:{port}/live/{{stream_key}}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
+        r#"{{"meta":{{"service":"InstantClone","schema_version":"2024-06-04","config_id":"{cid}"}},"ingest_endpoints":[{{"protocol":"RTMP","url_template":"rtmp://localhost:{port}/live/{{stream_key}}"}}],"encoder_configurations":[{encs}],"audio_configurations":{{"live":[{{"codec":"aac","track_id":0,"channels":2,"settings":{{"bitrate":160}}}}]}}}}"#,
         cid = config_id,
         port = ingest_port,
         encs = enc_configs,

--- a/web/index.html
+++ b/web/index.html
@@ -1835,7 +1835,7 @@ details.sys-collapse>summary .ic-label{margin:0}
                 <p class="wizard-obs-body">Prefer pasting a URL? Set <b>Service: Custom</b> in OBS. It applies live, nothing to close.</p>
                 <div class="wizard-obs-copy-row">
                   <span class="muted">Server</span>
-                  <code class="mono" id="wiz-obs-srv">rtmp://127.0.0.1:1935/live</code>
+                  <code class="mono" id="wiz-obs-srv">rtmp://localhost:1935/live</code>
                   <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'wiz-obs-srv','Server URL')">Copy</button>
                 </div>
                 <div class="wizard-obs-copy-row">
@@ -2295,7 +2295,7 @@ details.sys-collapse>summary .ic-label{margin:0}
         <div class="obs-manual-field">
           <div class="ic-label">Server URL</div>
           <div class="copy-block">
-            <code class="mono" id="obs-srv">rtmp://127.0.0.1:1935/live</code>
+            <code class="mono" id="obs-srv">rtmp://localhost:1935/live</code>
             <button class="ic-btn ic-btn-ghost" onclick="copyEl(this,'obs-srv','Server URL')">Copy</button>
           </div>
         </div>
@@ -3678,7 +3678,7 @@ function renderHeader(s){
   $('hdr-obs-v').textContent = s.ingest_alive ? 'Live' : 'Offline';
   obs.title = s.ingest_alive
     ? 'Your encoder is connected and publishing to InstantClone.'
-    : 'Waiting for your encoder. Point OBS (or any RTMP encoder) at rtmp://127.0.0.1:1935/live and start streaming.';
+    : 'Waiting for your encoder. Point OBS (or any RTMP encoder) at rtmp://localhost:1935/live and start streaming.';
   // Egress pill - how many destinations are actually connected.
   const eg = $('hdr-egress');
   const total = s.destinations_total || 0;
@@ -5157,8 +5157,8 @@ async function nudgeObsWiringIfNeeded(){
     const r = await (await fetch('/obs/register-status')).json();
     if (r.registered) return;
     const how = (r.path === null)
-      ? 'In OBS → Settings → Stream: Service = Custom, Server = rtmp://127.0.0.1:1935/live, then restart OBS.'
-      : 'In OBS → Settings → Stream, pick InstantClone (or Custom: rtmp://127.0.0.1:1935/live), then restart OBS.';
+      ? 'In OBS → Settings → Stream: Service = Custom, Server = rtmp://localhost:1935/live, then restart OBS.'
+      : 'In OBS → Settings → Stream, pick InstantClone (or Custom: rtmp://localhost:1935/live), then restart OBS.';
     toast('One more step to go live: point OBS at InstantClone. ' + how, 'info', 11000);
   } catch(_){ /* status endpoint unreachable; the first-run tour still covers OBS wiring */ }
 }


### PR DESCRIPTION
## Problem

A user could not connect, with OBS reporting:

```
Invalid socket settings: Host desconocido. (11001)
Error reaching host. Make sure that the interface you have bound can access
the internet and that the streaming service supports the address family you
selected (see Settings -> Advanced).
```

They had Settings -> Advanced -> Network -> IP Family set to IPv6.

That setting is passed straight to `getaddrinfo` as the address family hint, and `127.0.0.1` does not resolve under `AF_INET6`. Verified on the reporter's machine:

```
127.0.0.1 family=INET6  -> rc=11001 (WSAHOST_NOT_FOUND)
127.0.0.1 family=INET   -> ok
localhost family=INET6  -> ok, 1 result (::1)
localhost family=INET   -> ok
```

librtmp relabels the lookup failure as "error reaching host" because a bind IP is set, which is what made the dialog point at the wrong thing. On top of that we only ever listened on IPv4, so even a resolvable name would have had nothing to connect to.

## Fix

**Listen on both families.** `Settings::ingest_addrs()` returns the IPv4 address followed by the IPv6 one, and `supervise_ingest` runs one supervisor task per address. IPv4 is the required leg; IPv6 is best effort, so a machine with IPv6 disabled logs one line and carries on. Hot-restart aborts and awaits every leg before rebinding, since an aborted-but-not-dropped listener still holds the port.

The IPv6 listener sets `IPV6_V6ONLY` before bind, for two reasons. Windows defaults it on and Linux defaults it off, so without it the two legs collide on `[::]` vs `0.0.0.0` on Linux only. And a dual-stack socket reports IPv4 peers as `::ffff:127.0.0.1`, which `Ipv6Addr::is_loopback` rejects, so `begin_publish` would rate-limit a local publisher.

**Advertise one hostname.** The OBS server entry, the dashboard, and `Settings::obs_url()` now use `rtmp://localhost:1935/live`. `localhost` resolves under either family, and happy eyeballs races every resolved address and only fails when all of them do, so one entry covers both cases without asking the user to pick.

**Scope the registration check to our own entry.** `is_registered` compared against the whole of `services.json`. A stray object named like ours living inside another service's `servers` array pinned the button to "registered" with no way out from the UI. All checks now run against the byte span of our own entry.

**Keep retrying the IPv6 leg on AddrInUse.** The optional leg treated every bind error as permanent. On a restart or self-update the outgoing instance can still hold `[::1]` after it has released `127.0.0.1`, and the port pre-flight only probes the IPv4 address, so the leg died on its first attempt and never came back.

## Verification

Through real OBS 32.2.2, with the IP Family toggle flipped between runs:

```
18:09:15  Connection to rtmp://localhost:1935/live (::1) successful
18:11:04  Connection to rtmp://localhost:1935/live (127.0.0.1) successful
```

The `::1` run published 16,216 frames. The multitrack config fetch over plain HTTP is unaffected, since IP Family is an rtmp-output option only.

## Test

`cargo test` (322 pass), `cargo clippy --all-targets` clean. New coverage: two wildcard listeners sharing one port, an IPv6 loopback listener reporting a loopback peer, a malformed address returning an error rather than panicking, and the advertised URL staying a hostname. The IPv6 tests skip themselves on a host without IPv6.