### PR TITLE
README: offer the Linux download too

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -10,6 +10,7 @@
 <br/>
 
 <a href="https://github.com/Soulhackzlol/InstantClone/releases/latest"><img alt="Descargar para Windows" src="https://img.shields.io/badge/Descargar%20para%20Windows-5ac8fa?style=for-the-badge&labelColor=11141a&logo=windows&logoColor=white"/></a>
+<a href="https://github.com/Soulhackzlol/InstantClone/releases/latest"><img alt="Descargar para Linux" src="https://img.shields.io/badge/Descargar%20para%20Linux-1c2129?style=for-the-badge&labelColor=11141a&logo=linux&logoColor=white"/></a>
 
 
 <a href="#inicio-rápido"><img src="https://img.shields.io/badge/-Inicio%20r%C3%A1pido-1c2129?style=for-the-badge&labelColor=11141a"/></a>
@@ -64,11 +65,12 @@ Una señal entra. Un delay con buffer que **armas**, **activas** y **cortas** al
 **1 · Ejecútalo**
 
 ```text
-Descarga instantclone.exe → doble clic.
+Windows:  descarga instantclone.exe → doble clic.
+Linux:    chmod +x instantclone-*-linux-x64 → ejecútalo.
 El panel abre en http://127.0.0.1:7799
 ```
 
-Esa es toda la instalación. Un icono queda en la bandeja mientras corre; clic derecho para el panel, el dock, un **Corte** de un clic, o **Salir**. Cerrar la pestaña no mata el proxy, solo Salir lo hace.
+Esa es toda la instalación. En Windows un icono queda en la bandeja mientras corre; clic derecho para el panel, el dock, un **Corte** de un clic, o **Salir**. Cerrar la pestaña no mata el proxy, solo Salir lo hace. En Linux no hay bandeja, así que el panel es toda la superficie de control y Salir y Reiniciar viven en su pestaña Sistema.
 
 <sub>Al primer arranque, Windows SmartScreen puede decir "editor desconocido" porque la build aún no está firmada. Pulsa **Más información → Ejecutar de todas formas**, o compárala con el `SHA256SUMS.txt` de la release.</sub>
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <br/>
 
 <a href="https://github.com/Soulhackzlol/InstantClone/releases/latest"><img alt="Download for Windows" src="https://img.shields.io/badge/Download%20for%20Windows-5ac8fa?style=for-the-badge&labelColor=11141a&logo=windows&logoColor=white"/></a>
+<a href="https://github.com/Soulhackzlol/InstantClone/releases/latest"><img alt="Download for Linux" src="https://img.shields.io/badge/Download%20for%20Linux-1c2129?style=for-the-badge&labelColor=11141a&logo=linux&logoColor=white"/></a>
 
 
 <a href="#quickstart"><img src="https://img.shields.io/badge/-Quickstart-1c2129?style=for-the-badge&labelColor=11141a"/></a>
@@ -64,11 +65,12 @@ One feed in. A buffered delay you **arm**, **activate**, and **cut** on the fly,
 **1 · Run it**
 
 ```text
-Download instantclone.exe → double-click.
+Windows:  download instantclone.exe → double-click.
+Linux:    chmod +x instantclone-*-linux-x64 → run it.
 Dashboard opens at http://127.0.0.1:7799
 ```
 
-That's the whole install. A tray icon sits in the systray while it runs; right-click for the dashboard, dock, one-click **Cut**, or **Quit**. Closing the tab doesn't kill the proxy, only Quit does.
+That's the whole install. On Windows a tray icon sits in the systray while it runs; right-click for the dashboard, dock, one-click **Cut**, or **Quit**. Closing the tab doesn't kill the proxy, only Quit does. Linux has no tray, so the dashboard is the whole control surface and Quit and Restart live in its System tab.
 
 <sub>First launch, Windows SmartScreen may say "unknown publisher" because the build isn't code-signed yet. Click **More info → Run anyway**, or check it against the `SHA256SUMS.txt` on the release.</sub>
 


### PR DESCRIPTION
The badge row and the "Run it" block both predate Linux support, so the first thing a visitor saw was a Windows-only download button and an `instantclone.exe` double-click.

Both READMEs now offer either platform, and the tray sentence notes that Linux has no tray and drives everything from the dashboard.

The rest of both files already covered Linux (the platform note, the FAQ), so this was only the top of the page still describing the old release.

Docs only, no code change.